### PR TITLE
Add helper for reading zipped CSV data

### DIFF
--- a/tradingbot_ibkr/data/load_zip_csv.py
+++ b/tradingbot_ibkr/data/load_zip_csv.py
@@ -1,0 +1,42 @@
+import zipfile
+from pathlib import Path
+from typing import Optional
+import tempfile
+
+import pandas as pd
+
+
+def load_zipped_csv(zip_path: str | Path, csv_filename: Optional[str] = None) -> pd.DataFrame:
+    """Load the first CSV from a ZIP archive into a DataFrame.
+
+    Works with the lightweight pandas stub used in tests by writing the CSV to a
+    temporary file when file-like objects are unsupported.
+    """
+    with zipfile.ZipFile(zip_path, "r") as z:
+        if csv_filename is None:
+            csv_filename = z.namelist()[0]
+        with z.open(csv_filename) as csv_file:
+            try:
+                df = pd.read_csv(csv_file)
+            except TypeError:
+                data = csv_file.read()
+                with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
+                    tmp.write(data)
+                    tmp_path = tmp.name
+                try:
+                    df = pd.read_csv(tmp_path)
+                finally:
+                    Path(tmp_path).unlink(missing_ok=True)
+    return df
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Load a zipped CSV into pandas")
+    parser.add_argument("zip_path", help="Path to ZIP file containing a CSV")
+    parser.add_argument("csv_filename", nargs="?", help="CSV filename inside the ZIP")
+    args = parser.parse_args()
+
+    dataframe = load_zipped_csv(args.zip_path, args.csv_filename)
+    print(dataframe.head())

--- a/tradingbot_ibkr/tests/test_load_zip_csv.py
+++ b/tradingbot_ibkr/tests/test_load_zip_csv.py
@@ -1,0 +1,33 @@
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+
+from tradingbot_ibkr.data.load_zip_csv import load_zipped_csv
+
+
+def test_load_zipped_csv(tmp_path):
+    data = {
+        "Open time (ms)": [1, 2],
+        "Open": [10.0, 11.0],
+        "High": [12.0, 13.0],
+        "Low": [8.0, 9.0],
+        "Close": [11.0, 12.0],
+        "Volume": [100, 200],
+        "Close time (ms)": [3, 4],
+        "Quote asset volume": [1000, 2000],
+        "Number of trades": [1, 2],
+        "Taker buy base asset volume": [50, 60],
+        "Taker buy quote asset volume": [500, 600],
+        "Ignore": [0, 0],
+    }
+    df = pd.DataFrame(data)
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+    zip_path = tmp_path / "data.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(csv_path, arcname="data.csv")
+
+    loaded = load_zipped_csv(zip_path)
+    assert list(loaded.columns) == list(df.columns)
+    assert len(loaded) == len(df)


### PR DESCRIPTION
## Summary
- add `load_zipped_csv` utility to read CSV files directly from ZIP archives
- include CLI helper and unit test verifying extraction of Binance-style data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbce0a477c832caad6e59a8f4f8823