### PR TITLE
feat: support multiple asset classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ install.bat
 
 This creates a `venv` directory and installs packages from `tradingbot_ibkr/requirements.txt`.
 
+## Asset classes
+
+The bot supports multiple asset classes including forex, options, futures,
+crypto, and stocks via a unified `AssetClass` enum. Trading scripts and the
+engine can adjust risk settings based on the selected class.
+
 ## Binance to GCS ingestion
 
 Fetch minute and five-minute klines for BTCUSDT and ETHUSDT across spot and

--- a/tradingbot_ibkr/README.md
+++ b/tradingbot_ibkr/README.md
@@ -12,6 +12,8 @@ The bot now follows a modular pipeline:
 - **Decision Layer** (`decision_layer.py`) – reinforcement learning agents (PPO/DDQN placeholders).
 - **Risk Management** (`risk_management.py`) – CVaR, drawdown limits and volatility filters.
 - **Trading Engine** (`trading_engine.py`) – orchestrates the stages above.
+- **Asset Classes** (`asset_classes.py`) – enumerates forex, options, futures,
+  crypto and stocks with default risk settings.
 
 These modules provide a foundation for enhancing performance by expanding each component.
 
@@ -36,6 +38,9 @@ python live_trade_ccxt.py           # live crypto
 python ibkr_live_stock_bracket.py   # live stocks (PDT if margin < $25k)
 python ibkr_live_forex_bracket.py   # live FX (no PDT)
 ```
+
+Specify the asset class via environment variable when running the live CCXT
+script, e.g. `ASSET_CLASS=forex python live_trade_ccxt.py`.
 
 Notes:
 - These scripts are minimal examples for demonstration. Review and test in paper mode before enabling live trading.

--- a/tradingbot_ibkr/__init__.py
+++ b/tradingbot_ibkr/__init__.py
@@ -6,4 +6,5 @@ from . import (
     decision_layer,
     risk_management,
     trading_engine,
+    asset_classes,
 )

--- a/tradingbot_ibkr/asset_classes.py
+++ b/tradingbot_ibkr/asset_classes.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+"""Enumeration of supported asset classes for the trading bot."""
+from enum import Enum
+
+class AssetClass(Enum):
+    """Supported asset classes for trading operations."""
+    FOREX = "forex"
+    OPTIONS = "options"
+    FUTURES = "futures"
+    CRYPTO = "crypto"
+    STOCKS = "stocks"
+
+# Default volatility thresholds used by the trading engine for each asset class.
+VOLATILITY_THRESHOLDS = {
+    AssetClass.FOREX: 0.02,
+    AssetClass.OPTIONS: 0.10,
+    AssetClass.FUTURES: 0.04,
+    AssetClass.CRYPTO: 0.05,
+    AssetClass.STOCKS: 0.03,
+}
+
+
+def get_volatility_threshold(asset_class: AssetClass) -> float:
+    """Return the default volatility threshold for the given asset class."""
+    return VOLATILITY_THRESHOLDS.get(asset_class, 0.05)

--- a/tradingbot_ibkr/live_trade_ccxt.py
+++ b/tradingbot_ibkr/live_trade_ccxt.py
@@ -10,6 +10,7 @@ import ccxt
 from money_engine import choose_position_size, round_qty
 from data.store import append_trade_record
 from datetime import datetime, timezone
+from asset_classes import AssetClass
 
 load_dotenv()
 EXCHANGE = os.getenv('EXCHANGE', 'binance')
@@ -17,6 +18,15 @@ API_KEY = os.getenv('API_KEY')
 API_SECRET = os.getenv('API_SECRET')
 PAPER = os.getenv('PAPER', 'true').lower() == 'true'
 ALLOW_LIVE_RISK = os.getenv('ALLOW_LIVE_RISK', 'false').lower() == 'true'
+ASSET_CLASS = AssetClass(os.getenv('ASSET_CLASS', 'crypto'))
+
+RISK_PER_TRADE = {
+    AssetClass.CRYPTO: 0.02,
+    AssetClass.FOREX: 0.01,
+    AssetClass.STOCKS: 0.02,
+    AssetClass.FUTURES: 0.03,
+    AssetClass.OPTIONS: 0.05,
+}
 
 
 def build_exchange():
@@ -41,9 +51,10 @@ def main():
     balance = 1000.0
     entry_price = 30000.0
     stop_loss_price = 29700.0
-    qty, notional = choose_position_size(balance, 0.02, entry_price, stop_loss_price)
+    risk_pct = RISK_PER_TRADE.get(ASSET_CLASS, 0.02)
+    qty, notional = choose_position_size(balance, risk_pct, entry_price, stop_loss_price)
     qty = round_qty(qty, step=0.0001, min_qty=0.0001)
-    print('Exchange:', EXCHANGE, 'PAPER:', PAPER, 'ALLOW_LIVE_RISK:', ALLOW_LIVE_RISK)
+    print('Exchange:', EXCHANGE, 'PAPER:', PAPER, 'ALLOW_LIVE_RISK:', ALLOW_LIVE_RISK, 'ASSET_CLASS:', ASSET_CLASS.value)
     print(f'Would place {side} {qty} {symbol} (notional {notional})')
     res = place_market_order(ex, symbol, side, qty)
     print('Result:', res)

--- a/tradingbot_ibkr/trading_engine.py
+++ b/tradingbot_ibkr/trading_engine.py
@@ -5,14 +5,20 @@ from .feature_extraction import technical_indicators
 from .signal_prediction import SignalPredictor
 from .decision_layer import PPOAgent
 from .risk_management import volatility_filter
+from .asset_classes import AssetClass, get_volatility_threshold
 
 
 class TradingEngine:
-    """Simple orchestration of feature extraction, prediction, and decision making."""
+    """Simple orchestration of feature extraction, prediction, and decision making.
 
-    def __init__(self) -> None:
+    Supports multiple asset classes via :class:`~tradingbot_ibkr.asset_classes.AssetClass`.
+    """
+
+    def __init__(self, asset_class: AssetClass = AssetClass.CRYPTO) -> None:
         self.predictor = SignalPredictor()
         self.agent = PPOAgent()
+        self.asset_class = asset_class
+        self.volatility_threshold = get_volatility_threshold(asset_class)
 
     def prepare_features(self, data: pd.DataFrame) -> pd.DataFrame:
         return technical_indicators(data)
@@ -22,8 +28,12 @@ class TradingEngine:
         self.predictor.fit(features.values, target)
 
     def generate_signal(self, data: pd.DataFrame) -> int:
+        """Generate a trading signal for the latest data point.
+
+        The volatility filter threshold is determined by the configured asset class.
+        """
         features = self.prepare_features(data).iloc[-1:]
         prob = float(self.predictor.predict(features.values)[0])
-        if not volatility_filter(data["close"], threshold=0.05):
+        if not volatility_filter(data["close"], threshold=self.volatility_threshold):
             return 0
         return self.agent.choose_action(prob)


### PR DESCRIPTION
## Summary
- add `AssetClass` enum covering forex, options, futures, crypto and stocks
- allow trading engine and CCXT live trader to configure asset class with risk presets
- document new asset class support in READMEs

## Testing
- `pytest` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68bcacec1550832c8ad08e14352bbc2f