### PR TITLE
Add FastAPI monitoring server

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI, WebSocket
+from datetime import datetime, timezone
+import asyncio, json
+
+app = FastAPI()
+
+STATE = {
+    "running": False,
+    "metrics": {
+        "equity": 100000,
+        "daily_pnl": 0,
+        "win_rate": 0.55,
+        "sharpe": 1.2,
+        "drawdown": 0.05,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    },
+    "positions": [],
+    "orders": []
+}
+
+@app.get("/status")
+def status():
+    return {"running": STATE["running"]}
+
+@app.post("/control/start")
+def start():
+    STATE["running"] = True
+    return {"ok": True}
+
+@app.post("/control/stop")
+def stop():
+    STATE["running"] = False
+    return {"ok": True}
+
+clients = []
+
+@app.websocket("/ws")
+async def ws(ws: WebSocket):
+    await ws.accept()
+    clients.append(ws)
+    try:
+        while True:
+            await asyncio.sleep(2)
+            STATE["metrics"]["timestamp"] = datetime.now(timezone.utc).isoformat()
+            await ws.send_text(json.dumps({"metrics": STATE["metrics"]}))
+    except Exception:
+        clients.remove(ws)


### PR DESCRIPTION
## Summary
- add FastAPI server with status, start/stop controls, and WebSocket metrics streaming

## Testing
- `python -m py_compile server.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1a4808e8832cb5b91691037c2757