### PR TITLE
feat: add TraderDash desktop interface

### DIFF
--- a/tradingbot_ibkr/dashboard.py
+++ b/tradingbot_ibkr/dashboard.py
@@ -21,6 +21,11 @@ def index():
             info[f.name] = str(f.stat().st_mtime)
     return render_template('index.html', models=info)
 
+
+@app.route('/traderdash')
+def traderdash():
+    return render_template('traderdash.html')
+
 @app.route('/api/train', methods=['POST'])
 def api_train():
     # trigger demo training (runs synchronously)

--- a/tradingbot_ibkr/templates/traderdash.html
+++ b/tradingbot_ibkr/templates/traderdash.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>TraderDash</title></head>
+  <body>
+    <h1>TraderDash Desktop</h1>
+    <button onclick="start()">Start Bot</button>
+    <button onclick="stop()">Stop Bot</button>
+    <pre id="metrics"></pre>
+    <script>
+      const API = window.env.API_BASE;
+      async function start(){ await fetch(API+'/control/start',{method:'POST'}); }
+      async function stop(){ await fetch(API+'/control/stop',{method:'POST'}); }
+      const ws = new WebSocket('ws://localhost:8000/ws');
+      ws.onmessage = e => { document.getElementById('metrics').textContent = e.data; };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add TraderDash HTML page with start/stop controls and metrics stream
- expose new `/traderdash` route to serve the interface

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1af2cb80832c85dcb82e3775d7e7