### PR TITLE
Document local data directories for research artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,36 @@ python tradingbot_ibkr/binance_to_gcs.py --bucket <bucket-name> \
 ```
 
 Replace the bucket name and time range as needed.
+
+## Local research data layout
+
+The repository expects large market data and derived features to live outside of
+version control. Organize any downloaded datasets under the `data/` directory
+using the following convention:
+
+```
+data/
+  raw/binance/
+    spot/BTCUSDT/2022/*.csv.gz
+    spot/ETHUSDT/2022/*.csv.gz
+  parquet/ohlcv_1m/symbol=BTCUSDT/date=2022-01-01/*.parquet
+  parquet/features_1m/symbol=BTCUSDT/date=2022-01-01/*.parquet
+```
+
+- `data/raw/` holds the original exchange files (e.g., minute-level Binance
+  klines compressed as CSVs).
+- `data/parquet/ohlcv_1m/` stores cleaned one-minute OHLCV bars that are ready
+  for model training and backtesting.
+- `data/parquet/features_1m/` contains engineered features aligned with the
+  OHLCV data.
+
+Model checkpoints or other bulky artifacts should be placed beneath the
+`artifacts/` directory, which is also ignored by Git:
+
+```
+artifacts/
+  models/
+```
+
+Only keep lightweight samples in the repository itself; all high-volume data
+remains in these local folders to keep clones fast and commits reviewable.


### PR DESCRIPTION
## Summary
- describe the expected on-disk layout for raw, parquet, and feature datasets under `data/`
- clarify that bulky models should live in `artifacts/models/` outside version control
- note that these folders remain local so the repository stays lightweight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd79a23290832cbe4064dab3f265bb