### PR TITLE
Add adaptive learning to trading engine

### DIFF
--- a/tests/test_trading_engine_adaptive.py
+++ b/tests/test_trading_engine_adaptive.py
@@ -1,0 +1,57 @@
+import pandas as pd
+
+from tradingbot_ibkr.asset_classes import AssetClass, get_volatility_threshold
+from tradingbot_ibkr.trading_engine import TradeOutcome, TradingEngine
+
+
+def _build_sample_data(rows: int = 60) -> pd.DataFrame:
+    index = pd.date_range("2024-01-01", periods=rows, freq="T")
+    close = pd.Series(range(rows), dtype=float) + 100.0
+    high = close + 0.5
+    low = close - 0.5
+    volume = pd.Series(1000.0, index=index)
+    return pd.DataFrame({"close": close.values, "high": high.values, "low": low.values, "volume": volume.values}, index=index)
+
+
+def test_online_learning_updates_probability() -> None:
+    engine = TradingEngine(asset_classes=[AssetClass.CRYPTO], online_blend=1.0)
+    data = _build_sample_data()
+    feature_dict = engine.extract_feature_dict(data)
+    baseline = engine._online_trainer.predict_proba(feature_dict)
+
+    for _ in range(50):
+        engine.update_from_trade(data, TradeOutcome(realised_return=0.02))
+
+    updated = engine._online_trainer.predict_proba(engine.extract_feature_dict(data))
+    assert updated > baseline
+
+
+def test_online_learning_reacts_to_losses() -> None:
+    engine = TradingEngine(asset_classes=[AssetClass.CRYPTO], online_blend=1.0)
+    data = _build_sample_data()
+
+    for _ in range(50):
+        engine.update_from_trade(data, 0.02)
+    feature_dict = engine.extract_feature_dict(data)
+    positive_prob = engine._online_trainer.predict_proba(feature_dict)
+
+    for _ in range(100):
+        engine.update_from_trade(data, -0.05)
+    lowered_prob = engine._online_trainer.predict_proba(engine.extract_feature_dict(data))
+
+    assert lowered_prob < positive_prob
+
+
+def test_asset_rotation_between_crypto_and_forex() -> None:
+    engine = TradingEngine()
+    assert engine.asset_classes == [AssetClass.CRYPTO, AssetClass.FOREX]
+    assert engine.asset_class == AssetClass.CRYPTO
+    assert engine.volatility_threshold == get_volatility_threshold(AssetClass.CRYPTO)
+
+    engine.focus_on(AssetClass.FOREX)
+    assert engine.asset_class == AssetClass.FOREX
+    assert engine.volatility_threshold == get_volatility_threshold(AssetClass.FOREX)
+
+    rotated = engine.rotate_asset_focus()
+    assert rotated == AssetClass.CRYPTO
+    assert engine.asset_class == AssetClass.CRYPTO

--- a/tradingbot_ibkr/trading_engine.py
+++ b/tradingbot_ibkr/trading_engine.py
@@ -1,39 +1,170 @@
 """High-level trading engine connecting the pipeline components."""
 from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
 import pandas as pd
-from .feature_extraction import technical_indicators
-from .signal_prediction import SignalPredictor
-from .decision_layer import PPOAgent
-from .risk_management import volatility_filter
+
 from .asset_classes import AssetClass, get_volatility_threshold
+from .decision_layer import PPOAgent
+from .feature_extraction import technical_indicators
+from .models.online_trainer import OnlineTrainer
+from .risk_management import volatility_filter
+from .signal_prediction import SignalPredictor
+
+
+def _normalise_asset_classes(asset_classes: Sequence[AssetClass]) -> List[AssetClass]:
+    """Return a unique list of asset classes preserving order."""
+
+    seen = set()
+    normalised = []
+    for asset_class in asset_classes:
+        if asset_class not in seen:
+            normalised.append(asset_class)
+            seen.add(asset_class)
+    return normalised
+
+
+@dataclass
+class TradeOutcome:
+    """Container describing the realised outcome of a trade used for online learning."""
+
+    realised_return: float
 
 
 class TradingEngine:
     """Simple orchestration of feature extraction, prediction, and decision making.
 
-    Supports multiple asset classes via :class:`~tradingbot_ibkr.asset_classes.AssetClass`.
+    The engine now maintains an incremental model that can continually learn from
+    realised trade outcomes via :class:`~tradingbot_ibkr.models.online_trainer.OnlineTrainer`.
+    It defaults to operating across crypto and forex markets and can rotate focus
+    between the configured asset classes.
     """
 
-    def __init__(self, asset_class: AssetClass = AssetClass.CRYPTO) -> None:
+    def __init__(
+        self,
+        asset_class: AssetClass | None = None,
+        *,
+        asset_classes: Sequence[AssetClass] | None = None,
+        online_blend: float = 0.5,
+        min_positive_return: float = 0.0,
+    ) -> None:
+        if asset_classes is None:
+            if asset_class is None:
+                asset_classes = (AssetClass.CRYPTO, AssetClass.FOREX)
+            else:
+                asset_classes = (asset_class,)
+
+        if not asset_classes:
+            raise ValueError("TradingEngine requires at least one asset class")
+
+        self.asset_universe = _normalise_asset_classes(tuple(asset_classes))
+        self._asset_index = 0
+
+        if asset_class is not None and asset_class in self.asset_universe:
+            self._asset_index = self.asset_universe.index(asset_class)
+
         self.predictor = SignalPredictor()
         self.agent = PPOAgent()
-        self.asset_class = asset_class
-        self.volatility_threshold = get_volatility_threshold(asset_class)
+        self._online_trainer = OnlineTrainer()
+        self._online_weight = float(max(0.0, min(1.0, online_blend)))
+        self._min_positive_return = min_positive_return
+
+        try:
+            self._online_trainer.load()
+        except Exception:
+            # Loading is best-effort; failures should not prevent usage.
+            pass
+
+        self._update_asset_focus(self.asset_universe[self._asset_index])
+
+    @property
+    def asset_class(self) -> AssetClass:
+        """Current asset class focus."""
+
+        return self.asset_universe[self._asset_index]
+
+    @property
+    def asset_classes(self) -> List[AssetClass]:
+        """Ordered list of asset classes managed by the engine."""
+
+        return list(self.asset_universe)
+
+    def _update_asset_focus(self, asset_class: AssetClass) -> None:
+        self._volatility_threshold = get_volatility_threshold(asset_class)
+
+    @property
+    def volatility_threshold(self) -> float:
+        return self._volatility_threshold
+
+    def focus_on(self, asset_class: AssetClass) -> None:
+        """Switch the engine focus to ``asset_class`` within the configured universe."""
+
+        if asset_class not in self.asset_universe:
+            raise ValueError(f"Asset class {asset_class.value} not in configured universe")
+        self._asset_index = self.asset_universe.index(asset_class)
+        self._update_asset_focus(asset_class)
+
+    def rotate_asset_focus(self) -> AssetClass:
+        """Rotate to the next asset class and return it."""
+
+        self._asset_index = (self._asset_index + 1) % len(self.asset_universe)
+        asset_class = self.asset_universe[self._asset_index]
+        self._update_asset_focus(asset_class)
+        return asset_class
 
     def prepare_features(self, data: pd.DataFrame) -> pd.DataFrame:
         return technical_indicators(data)
 
+    def _latest_feature_row(self, data: pd.DataFrame) -> pd.Series:
+        features = self.prepare_features(data).fillna(0.0)
+        return features.iloc[-1]
+
+    def _features_to_dict(self, row: pd.Series) -> dict[str, float]:
+        return {col: float(row[col]) for col in row.index}
+
     def train(self, data: pd.DataFrame, target) -> None:
         features = self.prepare_features(data).dropna()
         self.predictor.fit(features.values, target)
+
+    def extract_feature_dict(self, data: pd.DataFrame) -> dict[str, float]:
+        """Public helper used by tests and downstream components to reuse features."""
+
+        return self._features_to_dict(self._latest_feature_row(data))
+
+    def _blend_probabilities(self, model_prob: float, online_prob: float) -> float:
+        return (1 - self._online_weight) * model_prob + self._online_weight * online_prob
 
     def generate_signal(self, data: pd.DataFrame) -> int:
         """Generate a trading signal for the latest data point.
 
         The volatility filter threshold is determined by the configured asset class.
         """
-        features = self.prepare_features(data).iloc[-1:]
-        prob = float(self.predictor.predict(features.values)[0])
+
+        latest_row = self._latest_feature_row(data)
+        latest_frame = latest_row.to_frame().T
+        prob = float(self.predictor.predict(latest_frame.values)[0])
+        online_prob = self._online_trainer.predict_proba(self._features_to_dict(latest_row))
+        prob = self._blend_probabilities(prob, online_prob)
+
         if not volatility_filter(data["close"], threshold=self.volatility_threshold):
             return 0
         return self.agent.choose_action(prob)
+
+    def update_from_trade(self, data: pd.DataFrame, outcome: TradeOutcome | float) -> None:
+        """Update the online trainer using the realised outcome of a trade."""
+
+        if isinstance(outcome, TradeOutcome):
+            realised_return = outcome.realised_return
+        else:
+            realised_return = float(outcome)
+
+        label = 1 if realised_return > self._min_positive_return else 0
+        feature_dict = self._features_to_dict(self._latest_feature_row(data))
+        self._online_trainer.learn_one(feature_dict, label)
+
+    def save_online_model(self) -> None:
+        """Persist the incremental model to disk."""
+
+        self._online_trainer.save()


### PR DESCRIPTION
## Summary
- extend the trading engine with an incremental online trainer that blends with the existing signal model and records trade outcomes
- default the engine focus to crypto and forex while providing rotation and focus helpers
- add tests that cover online learning behaviour and asset focus controls

## Testing
- pytest *(fails: pandas not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0cfeafee0832c98a9069040555279