### PR TITLE
Add ML ensemble with fundamental gating

### DIFF
--- a/tradingbot_ibkr/backtest_ccxt.py
+++ b/tradingbot_ibkr/backtest_ccxt.py
@@ -30,20 +30,15 @@ logger = logging.getLogger(__name__)
 
 # Use package-relative imports with error handling
 try:
-    from .money_engine import choose_position_size, fixed_fractional, round_qty, round_price
+    from .money_engine import choose_position_size, round_qty
 except ImportError:
     logger.warning("Money engine not available, using simplified position sizing")
+
     def choose_position_size(balance, risk_pct, entry_price, stop_price, leverage=1.0, min_qty=0.0):
         return balance * risk_pct / abs(entry_price - stop_price), balance * risk_pct
 
-try:
-    from .models.online_trainer import OnlineTrainer
-except ImportError:
-    logger.warning("Online trainer not available, adaptive learning disabled")
-    class OnlineTrainer:
-        def load(self): pass
-        def predict_proba(self, features): return 0.5
-        def learn_one(self, features, outcome): pass
+from .feature_extraction import fundamental_indicators, orderflow_features
+from .signal_prediction import FundamentalFilter, SignalEnsemble, SignalPredictor
 
 load_dotenv()
 EXCHANGE = os.getenv('EXCHANGE', 'binance')
@@ -334,14 +329,14 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
     
     # Volatility and ATR indicators
     df['vol20'] = df['ret1'].rolling(20).std().fillna(0.0)
-    
+
     # True Range and ATR calculation (vectorized)
     high_low = df['high'] - df['low']
     high_close_prev = (df['high'] - df['close'].shift(1)).abs()
     low_close_prev = (df['low'] - df['close'].shift(1)).abs()
     tr = pd.concat([high_low, high_close_prev, low_close_prev], axis=1).max(axis=1)
     df['atr14'] = tr.rolling(14, min_periods=1).mean()
-    
+
     # RSI calculation (vectorized)
     delta = df['close'].diff()
     up = delta.clip(lower=0)
@@ -350,6 +345,15 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
     roll_down = down.rolling(14, min_periods=1).mean()
     rs = roll_up / roll_down.replace(0, 1e-8)
     df['rsi14'] = 100.0 - (100.0 / (1.0 + rs))
+
+    # Fundamental and order-flow features used by ensemble/fundamental filter
+    fundamentals_df = fundamental_indicators(df)
+    for column in fundamentals_df.columns:
+        df[column] = fundamentals_df[column]
+
+    orderflow_df = orderflow_features(df)
+    for column in orderflow_df.columns:
+        df[column] = orderflow_df[column]
     
     # Initialize trading variables
     trades = []
@@ -364,9 +368,31 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
     if risk_per_trade is None:
         risk_per_trade = 0.01
         
-    # Adaptive learning setup
-    trainer = OnlineTrainer()
-    trainer.load()
+    # Machine learning ensemble with supervised models
+    ensemble = SignalEnsemble(
+        predictors={
+            'gbm': SignalPredictor(
+                model_type='gbm',
+                input_keys=[
+                    'close', 'high', 'low', 'volume', 'ret1', 'ma3', 'mom5', 'mom10',
+                    'vol20', 'vol_ratio', 'atr14', 'rsi14',
+                    'pe_ratio', 'earnings_growth', 'earnings_surprise', 'fundamental_score'
+                ]
+            ),
+            'lstm': SignalPredictor(
+                model_type='lstm',
+                sequence_length=16,
+                input_keys=['close', 'ma3', 'mom5', 'mom10', 'atr14', 'rsi14', 'vol20']
+            ),
+            'transformer': SignalPredictor(
+                model_type='transformer_orderflow',
+                sequence_length=16,
+                input_keys=['order_imbalance', 'flow_velocity', 'liquidity_ratio', 'order_flow_trend', 'vol_ratio']
+            ),
+        },
+        fundamental_filter=FundamentalFilter(),
+        min_confidence=0.6,
+    )
     
     # Trading statistics
     stats = {
@@ -375,6 +401,7 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
         'entries_filtered_trend': 0,
         'entries_filtered_vol': 0,
         'entries_filtered_ml': 0,
+        'entries_filtered_fundamental': 0,
         'exits_tp': 0,
         'exits_sl': 0,
         'exits_trailing': 0,
@@ -384,6 +411,7 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
     holding = 0
     last_features = None
     last_outcome = None
+    last_fundamentals = None
     peak_price = 0
     trailing_stop_price = None
     
@@ -397,27 +425,59 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
             'high': float(row['high']),
             'low': float(row['low']),
             'volume': float(row.get('volume', 1)),
-            'ret1': float(row['ret1']),
-            'ma3': float(row['ma3']),
-            'mom5': float(row['mom5']),
-            'mom10': float(row['mom10']),
-            'vol20': float(row['vol20']),
-            'vol_ratio': float(row['vol_ratio']),
-            'atr14': float(row['atr14']),
-            'rsi14': float(row['rsi14'])
+            'ret1': float(row.get('ret1', 0.0)),
+            'ma3': float(row.get('ma3', row['close'])),
+            'mom5': float(row.get('mom5', 0.0)),
+            'mom10': float(row.get('mom10', 0.0)),
+            'vol20': float(row.get('vol20', 0.0)),
+            'vol_ratio': float(row.get('vol_ratio', 0.0)),
+            'atr14': float(row.get('atr14', 0.0)),
+            'rsi14': float(row.get('rsi14', 50.0)),
+            'pe_ratio': float(row.get('pe_ratio', 0.0)),
+            'earnings_growth': float(row.get('earnings_growth', 0.0)),
+            'earnings_surprise': float(row.get('earnings_surprise', 0.0)),
+            'fundamental_score': float(row.get('fundamental_score', 0.0)),
+            'order_imbalance': float(row.get('order_imbalance', 0.0)),
+            'flow_velocity': float(row.get('flow_velocity', 0.0)),
+            'liquidity_ratio': float(row.get('liquidity_ratio', 0.0)),
+            'order_flow_trend': float(row.get('order_flow_trend', 0.0)),
         }
+
+        fundamentals = {
+            'pe_ratio': float(row.get('pe_ratio', np.nan)),
+            'earnings_growth': float(row.get('earnings_growth', 0.0)),
+            'earnings_surprise': float(row.get('earnings_surprise', 0.0)),
+            'fundamental_score': float(row.get('fundamental_score', 0.0)),
+            'earnings_yield': float(row.get('earnings_yield', 0.0)),
+        }
+
+        ensemble.observe(features, fundamentals)
         
         if position is None:
             # Check for entry signal
             if not pd.isna(row['rolling_high']) and row['close'] > row['rolling_high']:
                 stats['entries_attempted'] += 1
                 
-                # ML-based filtering
-                prob = trainer.predict_proba(features)
-                if prob < 0.6:
+                # ML-based filtering with ensemble agreement
+                decision = ensemble.evaluate(features, fundamentals)
+                if not decision.ml_agreement:
                     stats['entries_filtered_ml'] += 1
                     if enable_logging and i % 100 == 0:
-                        logger.debug(f"Entry filtered by ML at {timestamp}: prob={prob:.3f}")
+                        logger.debug(
+                            "Entry filtered by ML ensemble at %s: probs=%s",
+                            timestamp,
+                            decision.probabilities,
+                        )
+                    continue
+
+                if not decision.fundamentals_pass:
+                    stats['entries_filtered_fundamental'] += 1
+                    if enable_logging and i % 100 == 0:
+                        logger.debug(
+                            "Entry blocked by fundamental filter at %s: fundamentals=%s",
+                            timestamp,
+                            fundamentals,
+                        )
                     continue
                 
                 # Trend filter
@@ -468,14 +528,17 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
                     'entry_time': timestamp,
                     'entry_price': entry_price,
                     'qty': qty,
-                    'ml_prob': prob,
-                    'features': features.copy()
+                    'ml_probabilities': decision.probabilities,
+                    'consensus_prob': decision.consensus,
+                    'features': features.copy(),
+                    'fundamentals': fundamentals.copy(),
                 })
                 
                 holding = 0
                 peak_price = entry_price
                 trailing_stop_price = None
                 last_features = features
+                last_fundamentals = fundamentals
                 stats['entries_executed'] += 1
                 
                 if enable_logging and len(trades) <= 5:  # Log first few trades in detail
@@ -575,8 +638,8 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
                     })
                 
                 # ML learning
-                if last_features is not None and last_outcome is not None:
-                    trainer.learn_one(last_features, last_outcome)
+                if last_features is not None and last_outcome is not None and last_fundamentals is not None:
+                    ensemble.learn(last_features, last_fundamentals, last_outcome)
                 
                 # Reset position
                 position = None
@@ -585,6 +648,7 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
                 holding = 0
                 last_features = None
                 last_outcome = None
+                last_fundamentals = None
                 
                 if enable_logging and len(detailed_trades) <= 5:  # Log first few trades in detail
                     logger.info(f"EXIT #{len(detailed_trades)}: {timestamp} @ {exit_price:.4f}, {exit_type}, PnL={trade_pnl:.2f} ({trade_pnl/(qty*entry_price)*100:.2f}%), hold={holding} bars")
@@ -634,172 +698,6 @@ def aggressive_strategy_backtest(df: pd.DataFrame, take_profit_pct: float = 0.00
         logger.info("="*60)
     
     return results
-    rs = roll_up / roll_down
-    df['rsi14'] = 100.0 - (100.0 / (1.0 + rs))
-
-    for i in range(len(df)):
-        row = df.iloc[i]
-        features = {col: float(row[col]) for col in ['close','high','low','volume','ret1','ma3','mom5','mom10','vol20','vol_ratio','atr14','rsi14'] if col in row}
-        if position is None:
-            # entry condition: breakout
-            if not pd.isna(row['rolling_high']) and row['close'] > row['rolling_high']:
-                # Adaptive filter: only enter if model predicts high probability
-                prob = trainer.predict_proba(features)
-                if prob < 0.6:
-                    continue
-                # optional trend filter: only enter if ema_fast > ema_slow
-                if trend_filter:
-                    if pd.isna(row.get('ema_fast')) or pd.isna(row.get('ema_slow')):
-                        continue
-                    if row['ema_fast'] <= row['ema_slow']:
-                        continue
-                if vol_filter:
-                    vol = row.get('vol', None)
-                    if vol is None or pd.isna(vol):
-                        continue
-                    med = df['vol'].median()
-                    if med == 0 or vol < med * vol_multiplier:
-                        continue
-
-                position = 'long'
-                entry_idx = row.name
-                entry_price = row['close']
-                raw_qty, notional = choose_position_size(balance, risk_per_trade, entry_price, entry_price * (1 - stop_loss_pct), leverage=leverage, min_qty=min_qty)
-                # round quantity to exchange lot and enforce minimums
-                qty = round_qty(raw_qty, step=0.0001, min_qty=min_qty)
-                notional = qty * entry_price
-                trades.append({'type': 'entry', 'time': entry_idx, 'price': entry_price, 'qty': qty, 'notional': notional})
-                holding = 0
-                peak_price = entry_price
-                trailing_stop_price = None
-                last_features = features
-        else:
-            holding += 1
-            if trailing_stop_pct is not None:
-                if row['high'] > peak_price:
-                    peak_price = row['high']
-                trailing_stop_price = peak_price * (1 - trailing_stop_pct)
-
-            # check TP/SL/trailing
-            trade_closed = False
-            if row['high'] >= entry_price * (1 + take_profit_pct):
-                exit_price = entry_price * (1 + take_profit_pct)
-                trades.append({'type': 'exit_tp', 'time': row.name, 'price': exit_price, 'qty': qty})
-                last_outcome = 1  # Win
-                trade_closed = True
-            elif row['low'] <= entry_price * (1 - stop_loss_pct):
-                exit_price = entry_price * (1 - stop_loss_pct)
-                trades.append({'type': 'exit_sl', 'time': row.name, 'price': exit_price, 'qty': qty})
-                last_outcome = 0  # Loss
-                trade_closed = True
-            elif trailing_stop_pct is not None and row['low'] <= trailing_stop_price:
-                exit_price = trailing_stop_price
-                trades.append({'type': 'exit_trail', 'time': row.name, 'price': exit_price, 'qty': qty})
-                last_outcome = 1 if exit_price > entry_price else 0
-                trade_closed = True
-            elif holding >= max_holding_bars:
-                exit_price = row['close']
-                trades.append({'type': 'exit_hold', 'time': row.name, 'price': exit_price, 'qty': qty})
-                last_outcome = 1 if exit_price > entry_price else 0
-                trade_closed = True
-
-            if trade_closed:
-                # Learn from the outcome
-                if last_features is not None and last_outcome is not None:
-                    trainer.learn_one(last_features, last_outcome)
-                position = None
-                entry_idx = None
-                entry_price = None
-                holding = 0
-                last_features = None
-                last_outcome = None
-                position = None
-            elif row['low'] <= entry_price * (1 - stop_loss_pct):
-                exit_price = entry_price * (1 - stop_loss_pct)
-                trades.append({'type': 'exit_sl', 'time': row.name, 'price': exit_price, 'qty': qty})
-                position = None
-            elif trailing_stop_pct is not None and trailing_stop_price is not None and row['low'] <= trailing_stop_price:
-                exit_price = trailing_stop_price
-                trades.append({'type': 'exit_trail', 'time': row.name, 'price': exit_price, 'qty': qty})
-                position = None
-            elif holding >= max_holding_bars:
-                exit_price = row['close']
-                trades.append({'type': 'exit_time', 'time': row.name, 'price': exit_price, 'qty': qty})
-                position = None
-
-    # pair entries and exits into trade-level results and build equity curve
-    entries = [t for t in trades if t['type'] == 'entry']
-    exits = [t for t in trades if t['type'].startswith('exit')]
-    n = min(len(entries), len(exits))
-    wins = 0
-    total = n
-    pnl = 0.0
-    trade_pairs = []
-    equity = []
-    bal = balance
-
-    for i in range(n):
-        e = entries[i]
-        x = exits[i]
-        qty = e.get('qty', 0.0)
-        # ensure qty is rounded and non-negative
-        qty = round_qty(qty, step=0.0001, min_qty=min_qty)
-        # apply slippage: assume worse execution on entry and exit
-        entry_px = e['price'] * (1 + slippage_pct)
-        exit_px = x['price'] * (1 - slippage_pct)
-        # optionally increase slippage when trade notional relative to recent volume is large
-        if slippage_vs_volume:
-            # attempt to read nearby vol_mean20 if present in df
-            try:
-                # use time index to lookup volume mean; fall back to simple average
-                idx_time = pd.to_datetime(e['time'])
-                if 'volume' in df.columns:
-                    # compute a simple recent avg volume per bar (20-bar) if not present
-                    vol_mean20 = df['volume'].rolling(20).mean()
-                    if idx_time in vol_mean20.index:
-                        recent_vol = float(vol_mean20.loc[idx_time]) if not pd.isna(vol_mean20.loc[idx_time]) else float(vol_mean20.mean())
-                    else:
-                        recent_vol = float(vol_mean20.mean())
-                else:
-                    recent_vol = 1.0
-            except Exception:
-                recent_vol = 1.0
-            # avoid div by zero
-            eps = 1e-8
-            extra = slippage_k * (qty / max(recent_vol, eps))
-            extra = min(extra, slippage_cap)
-            entry_px = e['price'] * (1 + slippage_pct + extra)
-            exit_px = x['price'] * (1 - slippage_pct - extra)
-        trade_pnl_price = exit_px - entry_px
-        # trade PnL before fees
-        trade_pnl = trade_pnl_price * qty
-        # fees: assume fee_pct applied to notional on both sides
-        fee_cost = (entry_px * qty + exit_px * qty) * fee_pct
-        trade_pnl = trade_pnl - fee_cost
-        pnl += trade_pnl
-        bal += trade_pnl
-        if trade_pnl > 0:
-            wins += 1
-        trade_pairs.append({
-            'entry_time': str(e['time']),
-            'exit_time': str(x['time']),
-            'entry_price': e['price'],
-            'exit_price': x['price'],
-            'qty': qty,
-            'pnl': trade_pnl
-        })
-        equity.append({'time': str(x['time']), 'balance': bal})
-
-    win_rate = (wins / total * 100) if total > 0 else 0.0
-    return {
-        'trades': total,
-        'wins': wins,
-        'win_rate_pct': win_rate,
-        'pnl': pnl,
-        'details': {'entries': len(entries), 'exits': len(exits)},
-        'trade_list': trade_pairs,
-        'equity_curve': equity,
-    }
 
 def main():
     """

--- a/tradingbot_ibkr/feature_extraction.py
+++ b/tradingbot_ibkr/feature_extraction.py
@@ -1,35 +1,133 @@
 """Feature extraction utilities for trading signals.
 
-Provides technical indicators, news sentiment, and order book features.
+The module now combines technical market structure, fundamental context, and
+microstructure order-flow signals so that downstream models receive a rich
+feature matrix.  Lightweight fallbacks are used when optional data (e.g.
+earnings releases) are not supplied.
 """
 from __future__ import annotations
-import pandas as pd
+
+from dataclasses import dataclass
+from typing import Optional
+
 import numpy as np
+import pandas as pd
 
 
-def technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
-    """Compute simple technical indicators.
+def technical_indicators(df: pd.DataFrame, *, rsi_period: int = 14) -> pd.DataFrame:
+    """Compute core technical indicators used by the ML stack.
 
-    Currently calculates fast/slow moving averages and RSI.
+    Parameters
+    ----------
+    df:
+        DataFrame with at least ``open``, ``high``, ``low``, ``close`` and
+        optionally ``volume`` columns.
+    rsi_period:
+        Number of periods for the RSI calculation.
 
-    Args:
-        df: DataFrame with at least a ``close`` column.
-
-    Returns:
-        DataFrame with added indicator columns.
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``df`` with additional indicator columns such as moving
+        averages, momentum, and volatility measures.
     """
-    df = df.copy()
-    df["ma_fast"] = df["close"].rolling(window=10, min_periods=1).mean()
-    df["ma_slow"] = df["close"].rolling(window=30, min_periods=1).mean()
 
-    delta = df["close"].diff()
+    if "close" not in df:
+        raise KeyError("technical_indicators requires a 'close' column")
+
+    out = df.copy()
+
+    # Moving averages for mean-reversion vs trend context
+    out["ma_fast"] = out["close"].rolling(window=10, min_periods=1).mean()
+    out["ma_slow"] = out["close"].rolling(window=30, min_periods=1).mean()
+
+    # Short-term momentum windows reused by the backtester
+    out["ret1"] = out["close"].pct_change().fillna(0.0)
+    out["ma3"] = out["close"].rolling(3, min_periods=1).mean()
+    out["mom5"] = out["close"].pct_change(5).fillna(0.0)
+    out["mom10"] = out["close"].pct_change(10).fillna(0.0)
+
+    # Average True Range / volatility proxies
+    high_low = out["high"] - out["low"]
+    high_close_prev = (out["high"] - out["close"].shift(1)).abs()
+    low_close_prev = (out["low"] - out["close"].shift(1)).abs()
+    tr = pd.concat([high_low, high_close_prev, low_close_prev], axis=1).max(axis=1)
+    out["atr14"] = tr.rolling(14, min_periods=1).mean().fillna(0.0)
+    out["vol20"] = out["ret1"].rolling(20, min_periods=1).std().fillna(0.0)
+
+    if "volume" in out:
+        out["vol_mean20"] = out["volume"].rolling(20, min_periods=1).mean().replace(0, np.nan)
+        out["vol_ratio"] = (out["volume"] / out["vol_mean20"]).fillna(0.0)
+    else:
+        out["vol_mean20"] = 0.0
+        out["vol_ratio"] = 0.0
+
+    # RSI with numerically-stable operations
+    delta = out["close"].diff()
     up = delta.clip(lower=0)
-    down = -delta.clip(upper=0)
-    roll_up = up.ewm(span=14, adjust=False).mean()
-    roll_down = down.ewm(span=14, adjust=False).mean()
-    rs = roll_up / roll_down.replace(0, np.nan)
-    df["rsi"] = 100 - (100 / (1 + rs))
-    return df
+    down = (-delta).clip(lower=0)
+    roll_up = up.ewm(span=rsi_period, adjust=False).mean()
+    roll_down = down.ewm(span=rsi_period, adjust=False).mean().replace(0, np.nan)
+    rs = roll_up / roll_down
+    out["rsi14"] = 100.0 - (100.0 / (1.0 + rs))
+    out["rsi14"] = out["rsi14"].fillna(method="bfill").fillna(50.0)
+
+    return out
+
+
+def fundamental_indicators(
+    df: pd.DataFrame,
+    earnings: Optional[pd.DataFrame] = None,
+    *,
+    trailing_pe_floor: float = 2.0,
+    trailing_pe_cap: float = 80.0,
+) -> pd.DataFrame:
+    """Create valuation and earnings-derived features.
+
+    The helper tolerates missing fundamental data by constructing
+    economically-reasonable proxies from price history when actual EPS
+    observations are absent.  These features are consumed both by ML models
+    and the fundamental guard-rails that gate live trades.
+    """
+
+    if "close" not in df:
+        raise KeyError("fundamental_indicators requires a 'close' column")
+
+    close = df["close"].astype(float)
+    out = pd.DataFrame(index=df.index)
+
+    if earnings is not None and not earnings.empty:
+        eps_actual = earnings.get("eps_actual")
+        eps_est = earnings.get("eps_estimate")
+        aligned = earnings.reindex(df.index, method="ffill")
+        trailing_eps = aligned.get("eps_actual", eps_actual)
+        surprise = (aligned.get("eps_actual", 0) - aligned.get("eps_estimate", 0)).fillna(0.0)
+        trailing_eps = trailing_eps.replace(0, np.nan)
+    else:
+        # Proxy EPS using a conservative earnings yield derived from long-term
+        # price averages; avoids division by zero and keeps the filter stable.
+        trailing_eps = (close.rolling(252, min_periods=30).mean() / 25.0).replace(0, np.nan)
+        surprise = close.pct_change(90).fillna(0.0)
+
+    pe_ratio = (close / trailing_eps).clip(lower=trailing_pe_floor, upper=trailing_pe_cap)
+    earnings_yield = (1.0 / pe_ratio).replace([np.inf, -np.inf], np.nan)
+    earnings_growth = close.pct_change(252).fillna(0.0)
+    earnings_surprise = surprise
+
+    # Composite score blending valuation, growth, and surprise.
+    fundamental_score = (
+        0.4 * earnings_growth.fillna(0.0)
+        + 0.3 * earnings_surprise.fillna(0.0)
+        + 0.3 * earnings_yield.fillna(0.0)
+    )
+
+    out["pe_ratio"] = pe_ratio.fillna(method="ffill").fillna(pe_ratio.median())
+    out["earnings_yield"] = earnings_yield.fillna(method="ffill").fillna(0.0)
+    out["earnings_growth"] = earnings_growth.fillna(0.0)
+    out["earnings_surprise"] = earnings_surprise.fillna(0.0)
+    out["fundamental_score"] = fundamental_score.fillna(0.0)
+
+    return out
 
 
 def news_sentiment(_: pd.DataFrame) -> pd.Series:
@@ -37,12 +135,67 @@ def news_sentiment(_: pd.DataFrame) -> pd.Series:
 
     Returns a neutral sentiment score for each row.
     """
+
     return pd.Series(0.0)
 
 
 def orderbook_features(_: pd.DataFrame) -> pd.Series:
-    """Placeholder for limit order book features.
+    """Backward compatible alias kept for legacy imports."""
 
-    Returns zeros until integrated with real order book data.
-    """
     return pd.Series(0.0)
+
+
+def orderflow_features(df: pd.DataFrame, window: int = 15) -> pd.DataFrame:
+    """Approximate limit-order-book style features from price/volume bars.
+
+    Parameters
+    ----------
+    df:
+        Input dataframe containing at least ``close`` and, when available,
+        ``volume``.
+    window:
+        Lookback window for smoothing the order-flow statistics.
+    """
+
+    vol = df.get("volume", pd.Series(0.0, index=df.index)).astype(float)
+    price_change = df["close"].diff().fillna(0.0)
+    signed_volume = vol * np.sign(price_change)
+
+    out = pd.DataFrame(index=df.index)
+    out["order_imbalance"] = signed_volume.rolling(window, min_periods=1).sum().fillna(0.0)
+
+    denom = vol.rolling(window, min_periods=1).sum().replace(0, np.nan)
+    out["flow_velocity"] = (out["order_imbalance"] / denom).fillna(0.0)
+
+    mean_vol = vol.rolling(window, min_periods=1).mean().replace(0, np.nan)
+    out["liquidity_ratio"] = (vol / mean_vol).fillna(0.0)
+    out["order_flow_trend"] = signed_volume.rolling(window, min_periods=1).mean().fillna(0.0)
+
+    return out
+
+
+@dataclass
+class FeatureBundle:
+    """Convenience container with pre-computed feature subsets."""
+
+    technical: pd.DataFrame
+    fundamentals: pd.DataFrame
+    orderflow: pd.DataFrame
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Concatenate the stored frames with proper column alignment."""
+
+        combined = self.technical.copy()
+        for frame in (self.fundamentals, self.orderflow):
+            for column in frame.columns:
+                combined[column] = frame[column]
+        return combined
+
+
+def build_feature_matrix(df: pd.DataFrame, earnings: Optional[pd.DataFrame] = None) -> FeatureBundle:
+    """Return a :class:`FeatureBundle` combining technical, fundamental, and order-flow features."""
+
+    technical = technical_indicators(df)
+    fundamentals = fundamental_indicators(df, earnings)
+    orderflow = orderflow_features(df)
+    return FeatureBundle(technical=technical, fundamentals=fundamentals, orderflow=orderflow)

--- a/tradingbot_ibkr/signal_prediction.py
+++ b/tradingbot_ibkr/signal_prediction.py
@@ -1,43 +1,310 @@
 """Signal prediction models for trading.
 
-Provides a common interface for different model types.
+Provides a common interface for different model types and orchestrates an
+ensemble that blends gradient boosting, LSTM-style sequence modelling, and a
+transformer-inspired order-flow module.  The ensemble exposes agreement-aware
+decisions which are combined with fundamental filters before orders are issued.
 """
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import Optional
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
+
 import numpy as np
-from sklearn.ensemble import GradientBoostingClassifier
+
+try:  # scikit-learn is optional in some deployment targets
+    from sklearn.ensemble import GradientBoostingClassifier
+except Exception:  # pragma: no cover - fallback when sklearn is unavailable
+    GradientBoostingClassifier = None  # type: ignore
+
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-np.clip(x, -60.0, 60.0)))
 
 
 @dataclass
 class SignalPredictor:
-    """Wrapper around a prediction model.
+    """Wrapper around a prediction model supporting several architectures."""
 
-    Parameters
-    ----------
-    model_type: str
-        Type of model to use. Currently supports ``"gbm"``.
-    """
     model_type: str = "gbm"
+    sequence_length: int = 16
+    input_keys: Optional[Iterable[str]] = None
+    learning_rate: float = 0.05
     model: Optional[GradientBoostingClassifier] = None
+    _history: deque = field(default_factory=lambda: deque(maxlen=128), init=False)
+    _gbm_X: list = field(default_factory=list, init=False)
+    _gbm_y: list = field(default_factory=list, init=False)
+    _weights: Optional[np.ndarray] = field(default=None, init=False)
+    _bias: float = field(default=0.0, init=False)
+    _lstm_params: Optional[Dict[str, np.ndarray]] = field(default=None, init=False)
+    _transformer_params: Optional[Dict[str, np.ndarray]] = field(default=None, init=False)
+    _last_hidden: Optional[np.ndarray] = field(default=None, init=False)
+    _last_context: Optional[np.ndarray] = field(default=None, init=False)
+    _last_vector: Optional[np.ndarray] = field(default=None, init=False)
 
-    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
-        """Fit the underlying model.
+    def _vectorize(self, features: Dict[str, float]) -> np.ndarray:
+        if self.input_keys is not None:
+            ordered = [features.get(key, 0.0) for key in self.input_keys]
+        else:
+            ordered = [features[key] for key in sorted(features.keys())]
+        vec = np.asarray(ordered, dtype=float)
+        if vec.ndim == 1:
+            return vec
+        return vec.reshape(-1)
 
-        Unrecognised model types fall back to gradient boosting.
-        """
-        if self.model_type != "gbm":
-            # Placeholder for LSTM/Transformer implementations
-            self.model_type = "gbm"
-        self.model = GradientBoostingClassifier()
-        self.model.fit(X, y)
+    # ------------------------------------------------------------------
+    # Observation / prediction interface
+    # ------------------------------------------------------------------
+    def observe(self, features: Dict[str, float]) -> None:
+        """Record the latest feature vector for sequential models."""
 
-    def predict(self, X: np.ndarray) -> np.ndarray:
-        """Predict signal probabilities for ``X``.
+        vector = self._vectorize(features)
+        self._last_vector = vector
+        if self.model_type in {"lstm", "transformer_orderflow"}:
+            self._history.append(vector)
 
-        Returns array of probabilities that can be fed into decision agents.
-        """
+    def predict(self, features: Dict[str, float]) -> float:
+        """Return probability of an upward move for the supplied features."""
+
+        self.observe(features)
+        if self.model_type == "gbm":
+            return self._predict_gbm(self._last_vector)
+        if self.model_type == "lstm":
+            return self._predict_lstm()
+        if self.model_type == "transformer_orderflow":
+            return self._predict_transformer()
+        # Default neutral probability when model type is unknown
+        return 0.5
+
+    # ------------------------------------------------------------------
+    # Gradient boosting implementation
+    # ------------------------------------------------------------------
+    def _predict_gbm(self, vector: Optional[np.ndarray]) -> float:
+        if vector is None or vector.size == 0:
+            return 0.5
+        if GradientBoostingClassifier is None:
+            score = float(vector.mean())
+            return float(_sigmoid(score))
         if self.model is None:
-            return np.zeros(len(X))
-        proba = self.model.predict_proba(X)
-        return proba[:, 1]
+            score = float(vector.mean())
+            return float(_sigmoid(score))
+        proba = self.model.predict_proba(vector.reshape(1, -1))[0, 1]
+        return float(proba)
+
+    # ------------------------------------------------------------------
+    # LSTM-style implementation
+    # ------------------------------------------------------------------
+    def _init_lstm_params(self, dim: int) -> None:
+        rng = np.random.default_rng(42)
+        self._lstm_params = {
+            "wi": rng.normal(scale=0.1, size=dim),
+            "wf": rng.normal(scale=0.1, size=dim),
+            "wo": rng.normal(scale=0.1, size=dim),
+            "wc": rng.normal(scale=0.1, size=dim),
+        }
+        self._weights = rng.normal(scale=0.1, size=dim)
+        self._bias = 0.0
+
+    def _predict_lstm(self) -> float:
+        if not self._history:
+            return 0.5
+        dim = self._history[0].shape[0]
+        if self._lstm_params is None or self._weights is None:
+            self._init_lstm_params(dim)
+
+        hidden = np.zeros(dim)
+        cell = np.zeros(dim)
+        for vec in list(self._history)[-self.sequence_length :]:
+            wi = self._lstm_params["wi"]
+            wf = self._lstm_params["wf"]
+            wo = self._lstm_params["wo"]
+            wc = self._lstm_params["wc"]
+            input_gate = _sigmoid(vec * wi)
+            forget_gate = _sigmoid(vec * wf)
+            output_gate = _sigmoid(vec * wo)
+            candidate = np.tanh(vec * wc)
+            cell = forget_gate * cell + input_gate * candidate
+            hidden = output_gate * np.tanh(cell)
+
+        if self._weights is None:
+            self._weights = np.ones(dim) / max(dim, 1)
+        score = float(hidden @ self._weights + self._bias)
+        self._last_hidden = hidden
+        return float(_sigmoid(score))
+
+    # ------------------------------------------------------------------
+    # Transformer-style order flow implementation
+    # ------------------------------------------------------------------
+    def _init_transformer_params(self, dim: int) -> None:
+        rng = np.random.default_rng(7)
+        self._transformer_params = {
+            "query": rng.normal(scale=0.2, size=(dim, dim)),
+            "key": rng.normal(scale=0.2, size=(dim, dim)),
+            "value": rng.normal(scale=0.2, size=(dim, dim)),
+            "proj": rng.normal(scale=0.1, size=dim),
+        }
+        self._bias = 0.0
+
+    def _predict_transformer(self) -> float:
+        if not self._history:
+            return 0.5
+        dim = self._history[0].shape[0]
+        if self._transformer_params is None:
+            self._init_transformer_params(dim)
+
+        query_w = self._transformer_params["query"]
+        key_w = self._transformer_params["key"]
+        value_w = self._transformer_params["value"]
+        proj_w = self._transformer_params["proj"]
+
+        seq = np.vstack(list(self._history)[-self.sequence_length :])
+        queries = seq @ query_w
+        keys = seq @ key_w
+        values = seq @ value_w
+
+        last_query = queries[-1]
+        attn_scores = (last_query @ keys.T) / np.sqrt(dim)
+        weights = np.exp(attn_scores - np.max(attn_scores))
+        weights /= weights.sum() if weights.sum() != 0 else 1.0
+        context = weights @ values
+        score = float(context @ proj_w + self._bias)
+        self._last_context = context
+        return float(_sigmoid(score))
+
+    # ------------------------------------------------------------------
+    # Learning updates
+    # ------------------------------------------------------------------
+    def learn(self, features: Dict[str, float], outcome: float) -> None:
+        vector = self._vectorize(features)
+        target = float(outcome)
+
+        if self.model_type == "gbm":
+            if GradientBoostingClassifier is None:
+                # Update simple linear weights as fallback
+                if self._weights is None:
+                    self._weights = np.zeros_like(vector)
+                pred = float(_sigmoid(vector @ self._weights + self._bias))
+                error = target - pred
+                self._weights += self.learning_rate * error * vector
+                self._bias += self.learning_rate * error
+                return
+
+            self._gbm_X.append(vector)
+            self._gbm_y.append(target)
+            if len(self._gbm_y) >= 25:
+                self.model = GradientBoostingClassifier(random_state=42)
+                self.model.fit(np.vstack(self._gbm_X), np.array(self._gbm_y))
+            return
+
+        if self.model_type == "lstm" and self._last_hidden is not None and self._weights is not None:
+            pred = float(_sigmoid(self._last_hidden @ self._weights + self._bias))
+            error = target - pred
+            self._weights += self.learning_rate * error * self._last_hidden
+            self._bias += self.learning_rate * error
+            return
+
+        if self.model_type == "transformer_orderflow" and self._last_context is not None:
+            proj_w = self._transformer_params["proj"] if self._transformer_params else None
+            if proj_w is None:
+                return
+            pred = float(_sigmoid(self._last_context @ proj_w + self._bias))
+            error = target - pred
+            self._transformer_params["proj"] = proj_w + self.learning_rate * error * self._last_context
+            self._bias += self.learning_rate * error
+
+
+@dataclass
+class EnsembleDecision:
+    """Container describing the ensemble vote."""
+
+    consensus: float
+    probabilities: Dict[str, float]
+    ml_agreement: bool
+    fundamentals_pass: bool
+    threshold: float
+
+
+@dataclass
+class FundamentalFilter:
+    """Rule-based filter using valuation and earnings features."""
+
+    max_pe: float = 60.0
+    min_earnings_growth: float = -0.05
+    min_fundamental_score: float = -0.1
+    history: deque = field(default_factory=lambda: deque(maxlen=256))
+
+    def observe(self, fundamentals: Dict[str, float]) -> None:
+        if fundamentals:
+            self.history.append(fundamentals)
+
+    def _dynamic_pe(self) -> float:
+        if not self.history:
+            return self.max_pe
+        pe_values = [f.get("pe_ratio") for f in self.history if f.get("pe_ratio") is not None]
+        if not pe_values:
+            return self.max_pe
+        return float(min(np.nanpercentile(pe_values, 85), self.max_pe))
+
+    def evaluate(self, fundamentals: Dict[str, float]) -> bool:
+        if not fundamentals:
+            return False
+        pe_ratio = fundamentals.get("pe_ratio")
+        earnings_growth = fundamentals.get("earnings_growth")
+        score = fundamentals.get("fundamental_score")
+
+        if pe_ratio is None or np.isnan(pe_ratio) or pe_ratio <= 0:
+            return False
+        if pe_ratio > self._dynamic_pe():
+            return False
+        if earnings_growth is None or earnings_growth < self.min_earnings_growth:
+            return False
+        if score is None or score < self.min_fundamental_score:
+            return False
+        return True
+
+    def learn(self, fundamentals: Dict[str, float], outcome: float) -> None:
+        self.observe(fundamentals)
+        if outcome <= 0:
+            # Tighten filters when losses occur on permissive fundamentals
+            growth = fundamentals.get("earnings_growth", 0.0)
+            score = fundamentals.get("fundamental_score", 0.0)
+            self.max_pe = max(10.0, self.max_pe * 0.98)
+            self.min_earnings_growth = min(growth, self.min_earnings_growth + 0.01)
+            self.min_fundamental_score = min(score, self.min_fundamental_score + 0.01)
+
+
+@dataclass
+class SignalEnsemble:
+    """Coordinate multiple predictors and the fundamental filter."""
+
+    predictors: Dict[str, SignalPredictor]
+    fundamental_filter: FundamentalFilter
+    min_confidence: float = 0.6
+
+    def observe(self, features: Dict[str, float], fundamentals: Optional[Dict[str, float]] = None) -> None:
+        for predictor in self.predictors.values():
+            predictor.observe(features)
+        if fundamentals is not None:
+            self.fundamental_filter.observe(fundamentals)
+
+    def evaluate(self, features: Dict[str, float], fundamentals: Dict[str, float]) -> EnsembleDecision:
+        probabilities = {
+            name: predictor.predict(features)
+            for name, predictor in self.predictors.items()
+        }
+        consensus = float(np.mean(list(probabilities.values()))) if probabilities else 0.5
+        ml_agreement = all(prob >= self.min_confidence for prob in probabilities.values())
+        fundamentals_pass = self.fundamental_filter.evaluate(fundamentals)
+        return EnsembleDecision(
+            consensus=consensus,
+            probabilities=probabilities,
+            ml_agreement=ml_agreement,
+            fundamentals_pass=fundamentals_pass,
+            threshold=self.min_confidence,
+        )
+
+    def learn(self, features: Dict[str, float], fundamentals: Dict[str, float], outcome: float) -> None:
+        for predictor in self.predictors.values():
+            predictor.learn(features, outcome)
+        self.fundamental_filter.learn(fundamentals, outcome)


### PR DESCRIPTION
## Summary
- extend feature extraction to blend technical indicators with new fundamental and order-flow signals
- introduce a supervised ensemble that combines gradient boosting, LSTM, and transformer-style predictors with a fundamental filter
- integrate the ensemble and fundamental gating logic into the backtest, capturing richer diagnostics and consensus data

## Testing
- pytest *(fails: missing pandas/numpy in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db487a1e38832c809a8a3e3dedc762