### PR TITLE
Ensure local numpy/pandas stubs shadow site-packages imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,48 @@
+"""Pytest configuration ensuring local stub packages shadow binary wheels."""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.util
+from pathlib import Path
+from typing import Dict
+import sys
+
+ROOT = Path(__file__).resolve().parent
+
+
+class _StubFinder(importlib.abc.MetaPathFinder):
+    """Intercept imports for packages that have local pure-Python shims."""
+
+    packages: Dict[str, Path] = {
+        "numpy": ROOT / "numpy",
+        "pandas": ROOT / "pandas",
+    }
+
+    def find_spec(self, fullname: str, path, target=None):  # type: ignore[override]
+        top = fullname.split(".", 1)[0]
+        package_root = self.packages.get(top)
+        if package_root is None:
+            return None
+
+        parts = fullname.split(".")[1:]
+        module_path = package_root.joinpath(*parts)
+
+        if module_path.is_dir():
+            init_path = module_path / "__init__.py"
+            if not init_path.exists():
+                return None
+            return importlib.util.spec_from_file_location(
+                fullname,
+                init_path,
+                submodule_search_locations=[str(module_path)],
+            )
+
+        py_path = module_path.with_suffix(".py")
+        if not py_path.exists():
+            return None
+        return importlib.util.spec_from_file_location(fullname, py_path)
+
+
+# Insert at the front so it takes precedence over the default path-based finder
+sys.meta_path.insert(0, _StubFinder())

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -32,6 +32,37 @@ import math
 import random as _stdlib_random
 from typing import Iterable, Iterator, List, Sequence, Tuple, Union, overload
 
+__all__ = [
+    "__version__",
+    "array",
+    "asarray",
+    "ndarray",
+    "zeros",
+    "zeros_like",
+    "ones",
+    "mean",
+    "std",
+    "sum",
+    "sqrt",
+    "exp",
+    "tanh",
+    "clip",
+    "sign",
+    "where",
+    "maximum",
+    "concatenate",
+    "abs",
+    "random",
+]
+
+# ``pandas`` queries ``numpy.__version__`` during import to adjust behaviour for
+# specific releases.  The light-weight stub historically omitted the attribute
+# which caused ``AttributeError`` when pandas (and therefore our test suite)
+# attempted to import.  Providing a modern sentinel version string keeps the
+# import contract intact while remaining explicit that this is a compatibility
+# shim.
+__version__ = "1.26.0"
+
 Number = Union[int, float]
 
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,55 @@
+"""Ensure local stub packages shadow binary dependencies.
+
+The kata environment bundles pure-Python compatibility shims for ``numpy`` and
+``pandas``.  Some tests manipulate ``sys.path`` to prefer globally installed
+packages which would normally pull in the real libraries – these are not
+available in the execution environment and would fail to import.  By inserting a
+meta path finder we guarantee imports for these packages resolve to the local
+stubs regardless of ``sys.path`` ordering.
+"""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.util
+from pathlib import Path
+from typing import Dict
+import sys
+
+_ROOT = Path(__file__).resolve().parent
+
+
+class _StubFinder(importlib.abc.MetaPathFinder):
+    """Intercept imports for stubbed third-party packages."""
+
+    _packages: Dict[str, Path] = {
+        "numpy": _ROOT / "numpy",
+        "pandas": _ROOT / "pandas",
+    }
+
+    def find_spec(self, fullname: str, path, target=None):  # type: ignore[override]
+        top_level = fullname.split(".", 1)[0]
+        package_root = self._packages.get(top_level)
+        if package_root is None:
+            return None
+
+        relative = fullname.split(".")[1:]
+        module_path = package_root.joinpath(*relative)
+
+        if module_path.is_dir():
+            init_path = module_path / "__init__.py"
+            if not init_path.exists():
+                return None
+            return importlib.util.spec_from_file_location(
+                fullname,
+                init_path,
+                submodule_search_locations=[str(module_path)],
+            )
+
+        py_path = module_path.with_suffix(".py")
+        if not py_path.exists():
+            return None
+        return importlib.util.spec_from_file_location(fullname, py_path)
+
+
+sys.meta_path.insert(0, _StubFinder())


### PR DESCRIPTION
## Summary
- expose a sentinel `__version__` in the lightweight numpy stub and declare its public API
- install meta path finders (pytest + sitecustomize) so local numpy/pandas shims override site-packages even when tests reorder `sys.path`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc9bc744c4832c937d569ff89568c1