### PR TITLE
Add Makefile targets for daily trend pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: daily-trends show-trends
+
+daily-trends:
+@python -m src.pipelines.daily_trends_pipeline
+
+show-trends:
+@python - <<'PY'
+import duckdb, os
+db = "data/daily/market_trends.duckdb"
+if not os.path.exists(db):
+    raise SystemExit("No DB yet. Run `make daily-trends` first.")
+con = duckdb.connect(db)
+print(con.execute("SELECT date, symbol, asset_class, close, rsi_14, macd_hist, vol_20d FROM market_trends ORDER BY ts DESC LIMIT 30").df())
+PY


### PR DESCRIPTION
## Summary
- add a Makefile with a daily-trends target to run the pipeline module
- provide a show-trends target that queries the DuckDB results table for recent entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca25291ec832ca50b4d395139da69