### PR TITLE
Add workflow to fetch and commit daily market trends

### DIFF
--- a/.github/workflows/daily-market-trends.yml
+++ b/.github/workflows/daily-market-trends.yml
@@ -1,0 +1,37 @@
+name: Daily Market Trends
+
+on:
+  schedule:
+    - cron: "15 14 * * *"   # 14:15 UTC daily (~07:15 PT)
+  workflow_dispatch: {}
+
+jobs:
+  fetch-and-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Fetch daily trends
+        run: |
+          python scripts/fetch_daily_trends.py
+
+      - name: Commit snapshot
+        run: |
+          git config user.name "market-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add data/daily
+          git commit -m "chore(data): daily market trends $(date -u +'%Y-%m-%d')" || echo "No changes"
+          git push


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Actions workflow that installs dependencies and runs the daily trends fetcher
- commit and push updated market trend snapshots when changes are produced

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca2c510bc832cbdcb25f837bb4aa7