### PR TITLE
Add broker abstractions and shared order models

### DIFF
--- a/tradingbot_ibkr/brokers/__init__.py
+++ b/tradingbot_ibkr/brokers/__init__.py
@@ -1,0 +1,5 @@
+"""Common broker abstractions for the trading bot."""
+from .broker_base import Broker
+from . import models
+
+__all__ = ["Broker", "models"]

--- a/tradingbot_ibkr/brokers/broker_base.py
+++ b/tradingbot_ibkr/brokers/broker_base.py
@@ -1,0 +1,52 @@
+"""Abstract base class defining the broker integration contract."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable, Iterable
+
+from .models import OrderRequest, OrderStatus, Position
+
+BrokerEventHandler = Callable[[OrderStatus], None]
+
+
+class Broker(ABC):
+    """Interface that concrete broker adapters must implement."""
+
+    name: str
+    supports_crypto: bool = False
+    supports_equities: bool = True
+    supports_options: bool = False
+    supports_futures: bool = False
+    paper_trading: bool = False
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Establish any network connections or authentication sessions."""
+
+    @abstractmethod
+    def place_order(self, account_id: str, req: OrderRequest) -> OrderStatus:
+        """Submit an order request and return its initial status."""
+
+    @abstractmethod
+    def cancel_order(self, account_id: str, broker_order_id: str) -> OrderStatus:
+        """Attempt to cancel an outstanding order."""
+
+    @abstractmethod
+    def get_order(self, account_id: str, broker_order_id: str) -> OrderStatus:
+        """Fetch the latest status for a given order."""
+
+    @abstractmethod
+    def get_positions(self, account_id: str) -> Iterable[Position]:
+        """Return all open positions for the provided account."""
+
+    @abstractmethod
+    def get_cash(self, account_id: str) -> float:
+        """Return the available cash balance in the account's base currency."""
+
+    @abstractmethod
+    def stream_events(self, on_event: BrokerEventHandler) -> None:
+        """Stream order updates to the provided callback."""
+
+    @abstractmethod
+    def normalize_symbol(self, symbol: str) -> str:
+        """Convert user provided symbols to the broker specific format."""

--- a/tradingbot_ibkr/brokers/models.py
+++ b/tradingbot_ibkr/brokers/models.py
@@ -1,0 +1,81 @@
+"""Data structures shared by broker integrations."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class OrderSide(str, Enum):
+    """Enumerates the supported order sides."""
+
+    BUY = "buy"
+    SELL = "sell"
+
+
+class OrderType(str, Enum):
+    """Supported order types for broker requests."""
+
+    MARKET = "market"
+    LIMIT = "limit"
+    STOP = "stop"
+    STOP_LIMIT = "stop_limit"
+
+
+class TimeInForce(str, Enum):
+    """Supported time in force policies."""
+
+    DAY = "day"
+    GTC = "gtc"
+    IOC = "ioc"
+    FOK = "fok"
+
+
+@dataclass(slots=True)
+class OrderRequest:
+    """Represents a request to submit an order to a broker."""
+
+    symbol: str
+    quantity: float
+    side: OrderSide
+    order_type: OrderType = OrderType.MARKET
+    limit_price: Optional[float] = None
+    stop_price: Optional[float] = None
+    time_in_force: TimeInForce = TimeInForce.DAY
+    client_order_id: Optional[str] = None
+
+
+class OrderState(str, Enum):
+    """High level state machine for order execution."""
+
+    NEW = "new"
+    PARTIALLY_FILLED = "partially_filled"
+    FILLED = "filled"
+    CANCELED = "canceled"
+    REJECTED = "rejected"
+
+
+@dataclass(slots=True)
+class OrderStatus:
+    """Represents the most recent status of an order."""
+
+    broker_order_id: str
+    state: OrderState
+    filled_quantity: float = 0.0
+    avg_fill_price: Optional[float] = None
+    submitted_at: Optional[datetime] = None
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+    message: Optional[str] = None
+
+
+@dataclass(slots=True)
+class Position:
+    """Represents an open position at the broker."""
+
+    symbol: str
+    quantity: float
+    avg_price: float
+    market_price: Optional[float] = None
+    unrealized_pnl: Optional[float] = None
+    realized_pnl: Optional[float] = None


### PR DESCRIPTION
## Summary
- add a brokers package that centralizes broker-related abstractions
- define order request/status/position data models for reuse across integrations
- document the broker interface and its callback signature for streaming events

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcae7e99f0832c84a5149705a1122b