### PR TITLE
Add standalone SMA crossover backtesting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ The command writes the trade blotter, equity curve, and metrics beneath
 `artifacts/`.  A copy of the latest run is kept under
 `backtest/sample_results/` for reference.
 
+## Quick SMA Crossover Demo
+
+If you want to experiment with the third-party ``backtesting`` package, run the
+standalone moving-average example that ships with the repository:
+
+```bash
+python scripts/backtesting_sma_cross_example.py
+```
+
+The script prints summary statistics to the console and, when a display backend
+is available, pops up an interactive equity-curve plot.
+
+
 ## Trading Readiness Check
 
 Before using the trading bot, run the comprehensive readiness checker:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ python-dotenv>=1.0.1
 pyarrow>=17.0
 duckdb>=1.1.3
 tenacity>=9.0.0
+backtesting==0.3.3

--- a/scripts/backtesting_sma_cross_example.py
+++ b/scripts/backtesting_sma_cross_example.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Simple moving-average crossover example using the `backtesting` package.
+
+This script mirrors the canonical example from the ``backtesting`` project and
+serves as a quick sanity check that the environment can execute the Strategy
+API.  It relies on the bundled ``GOOG`` sample data, so it is completely
+self-contained.
+"""
+
+from __future__ import annotations
+
+from backtesting import Backtest, Strategy
+from backtesting.lib import crossover
+from backtesting.test import GOOG, SMA
+
+
+class SmaCross(Strategy):
+    """Classic 50/200 simple moving-average crossover strategy."""
+
+    n1 = 50  # Short SMA window
+    n2 = 200  # Long SMA window
+
+    def init(self) -> None:
+        close = self.data.Close
+        self.sma1 = self.I(SMA, close, self.n1)
+        self.sma2 = self.I(SMA, close, self.n2)
+
+    def next(self) -> None:
+        if crossover(self.sma1, self.sma2):
+            self.position.close()
+            self.buy()
+        elif crossover(self.sma2, self.sma1):
+            self.position.close()
+            self.sell()  # Assumes shorting allowed; adjust for long-only
+
+
+def main() -> None:
+    """Execute the backtest and print the resulting performance metrics."""
+
+    bt = Backtest(GOOG, SmaCross, cash=10_000, commission=0.002)
+    stats = bt.run()
+    print(stats)
+
+    try:
+        bt.plot()
+    except Exception as exc:  # pragma: no cover - plotting can fail headless
+        print("Plotting failed (likely due to headless environment):", exc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a lightweight script that demonstrates running a 50/200 SMA crossover strategy with the backtesting package
- document how to launch the example in the README and declare the dependency in requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcb3d034a4832c88c9ed730702b7bc