### PR TITLE
Add readiness-based effectiveness evaluation

### DIFF
--- a/docs/bot_effectiveness_review.md
+++ b/docs/bot_effectiveness_review.md
@@ -1,0 +1,32 @@
+# Trading Bot Effectiveness Evaluation
+
+## Executive Summary
+The trading bot demonstrates a reasonably comprehensive operational surface area, but it is **not production-ready** in its current state. The latest automated readiness assessment reports an overall score of **81.2/100** with a terminal status of `NOT_READY`. Two critical dependency failures and numerous warning-level items prevent safe live deployment. 【4183be†L1-L74】
+
+## Assessment Inputs
+- `python check_trading_readiness.py --verbose` executed on the current repository snapshot. 【4183be†L1-L74】
+- Static inspection of repository structure, documentation, and safety tooling.
+
+## Strengths
+- **Core infrastructure is present.** The bot includes modules for authentication, rate limiting, risk management, and position sizing, all of which pass readiness checks. 【4183be†L37-L74】
+- **Data foundations exist.** Required directories and at least one BTC/USDT market data sample are available, enabling immediate experimentation. 【4183be†L27-L33】
+- **Automated readiness tooling.** The comprehensive checker surfaces configuration, dependency, and validation gaps with actionable guidance, accelerating onboarding. 【4183be†L1-L74】
+
+## Weaknesses
+- **Critical dependency gaps.** Missing `ccxt` and `python-dotenv` packages halt exchange connectivity and environment configuration loading. 【4183be†L13-L24】
+- **Configuration incompleteness.** Absence of a populated `.env` file blocks secure credential management and final safety toggles. 【4183be†L23-L30】
+- **Data coverage issues.** ETH/USDT reference data is missing, limiting multi-asset validation breadth. 【4183be†L27-L33】
+- **Validation quality concerns.** Stress reports show extreme drawdowns and scenarios with no trades, implying strategies are either misconfigured or unsuitable for live trading without further tuning. 【4183be†L33-L52】
+
+## Risk Assessment
+The confluence of missing exchange libraries, absent configuration, and questionable validation metrics indicates heightened operational risk. Attempting live trading without resolving these items could lead to execution failures, unmanaged exposure, or strategy underperformance.
+
+## Recommendations
+1. **Resolve dependency failures:** install `ccxt` and `python-dotenv` inside a managed virtual environment. 【4183be†L53-L68】
+2. **Complete configuration:** derive a `.env` from the provided template and verify safety toggles before any live deployment. 【4183be†L53-L68】
+3. **Fill data gaps:** acquire ETH/USDT datasets (or regenerate) to ensure coverage across targeted assets. 【4183be†L23-L33】
+4. **Re-run validation workflows:** investigate abnormal drawdowns and zero-trade outcomes; adjust model parameters or strategy logic as required. 【4183be†L33-L52】
+5. **Re-assess readiness:** repeat the readiness checker post-remediation to confirm a `READY` status before paper or live trading. 【4183be†L53-L74】
+
+## Conclusion
+The bot provides a solid scaffolding for a systematic trading pipeline, yet it currently falls short of live-trading readiness. Addressing the highlighted dependency, configuration, data, and validation deficiencies should be prioritized before progressing to production trials. 【4183be†L1-L74】


### PR DESCRIPTION
## Summary
- add a trading bot effectiveness evaluation document based on the latest readiness check
- capture strengths, weaknesses, and remediation recommendations preventing live-readiness

## Testing
- python check_trading_readiness.py --verbose

------
https://chatgpt.com/codex/tasks/task_e_68dcb7022e04832ca51820f3d6b4e083