### PR TITLE
Add matplotlib to Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pyarrow>=17.0
 duckdb>=1.1.3
 tenacity>=9.0.0
 backtesting==0.3.3
+matplotlib>=3.8


### PR DESCRIPTION
## Summary
- add matplotlib to the Python requirements so it is available in environments that install from this list

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dcb95a0ab4832cbba7cb9d9f8b1b37