### PR TITLE
Add spot-futures arbitrage helpers and tests

### DIFF
--- a/backtest/strategies/arbitrage.py
+++ b/backtest/strategies/arbitrage.py
@@ -11,7 +11,7 @@ brokers.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Mapping
 
 import numpy as np
 import pandas as pd
@@ -127,5 +127,137 @@ def generate_basis_signals(data: Any, config: ArbitrageConfig | None = None) -> 
     return result
 
 
-__all__ = ["ArbitrageConfig", "generate_basis_signals"]
+def check_live_basis(
+    symbol: str = "BTC/USDT",
+    threshold: float = 0.005,
+    *,
+    exchange: Any | None = None,
+) -> dict[str, float | int]:
+    """Check the basis between spot and futures prices in real time.
+
+    Parameters
+    ----------
+    symbol:
+        Base trading pair to evaluate on the spot market.
+    threshold:
+        Minimum absolute fractional difference between futures and spot prices
+        required to emit a trading signal.
+    exchange:
+        Optional pre-configured CCXT exchange instance.  When omitted the
+        function instantiates :class:`ccxt.binance` lazily.  Passing an
+        instance makes the function easier to test and avoids repeated logins
+        in production code.
+
+    Returns
+    -------
+    dict
+        Mapping with ``signal`` (``1`` = buy spot / sell futures, ``-1`` = the
+        opposite, ``0`` = no trade), ``diff`` (fractional basis), and the
+        ``spot``/``futures`` prices that produced the reading.
+    """
+
+    if threshold < 0:
+        raise ValueError("threshold must be non-negative")
+
+    if exchange is None:
+        try:  # pragma: no cover - exercised via dependency injection in tests
+            import ccxt  # type: ignore
+        except ImportError as exc:  # pragma: no cover - requires missing dep
+            raise RuntimeError("ccxt is required to fetch live market data") from exc
+        exchange = ccxt.binance()
+
+    spot_ticker: Mapping[str, Any] = exchange.fetch_ticker(symbol)
+    futures_symbol = symbol if ":USDT" in symbol else f"{symbol}:USDT"
+    futures_ticker: Mapping[str, Any] = exchange.fetch_ticker(futures_symbol)
+
+    spot_price = float(spot_ticker.get("last"))
+    futures_price = float(futures_ticker.get("last"))
+    if spot_price == 0:
+        raise ValueError("Spot price returned by exchange must be non-zero")
+
+    diff = (futures_price - spot_price) / spot_price
+    signal = 0
+    if abs(diff) > threshold:
+        signal = 1 if diff > 0 else -1
+
+    return {
+        "signal": signal,
+        "diff": diff,
+        "spot": spot_price,
+        "futures": futures_price,
+    }
+
+
+def generate_threshold_signals(
+    data_spot: pd.DataFrame,
+    data_futures: pd.DataFrame,
+    *,
+    threshold: float = 0.005,
+    price_column: str = "Close",
+) -> pd.DataFrame:
+    """Generate spot/futures arbitrage signals on historical data.
+
+    The helper merges two OHLCV-style DataFrames on their ``timestamp`` column,
+    computes the fractional basis, and emits long/short instructions whenever
+    the absolute basis exceeds ``threshold``.
+    """
+
+    if threshold < 0:
+        raise ValueError("threshold must be non-negative")
+
+    required_cols = {"timestamp", price_column}
+    missing_spot = required_cols - set(data_spot.columns)
+    missing_futures = required_cols - set(data_futures.columns)
+    if missing_spot:
+        raise ValueError(f"Spot data missing required columns: {sorted(missing_spot)}")
+    if missing_futures:
+        raise ValueError(
+            f"Futures data missing required columns: {sorted(missing_futures)}"
+        )
+
+    spot_records = {
+        timestamp: price
+        for timestamp, price in zip(
+            data_spot["timestamp"], data_spot[price_column]
+        )
+    }
+    futures_records = {
+        timestamp: price
+        for timestamp, price in zip(
+            data_futures["timestamp"], data_futures[price_column]
+        )
+    }
+
+    common_timestamps = sorted(set(spot_records) & set(futures_records))
+    rows: list[dict[str, Any]] = []
+    for ts in common_timestamps:
+        spot_close = float(spot_records[ts])
+        futures_close = float(futures_records[ts])
+        if spot_close == 0:
+            raise ValueError("Spot prices must be non-zero to compute basis")
+        basis = (futures_close - spot_close) / spot_close
+        signal = 0
+        if basis > threshold:
+            signal = 1
+        elif basis < -threshold:
+            signal = -1
+        rows.append(
+            {
+                "timestamp": ts,
+                "spot_close": spot_close,
+                "futures_close": futures_close,
+                "basis": basis,
+                "signal": signal,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+__all__ = [
+    "ArbitrageConfig",
+    "generate_basis_signals",
+    "check_live_basis",
+    "generate_threshold_signals",
+]
 

--- a/tests/test_arbitrage_threshold.py
+++ b/tests/test_arbitrage_threshold.py
@@ -1,0 +1,66 @@
+"""Tests for simple spot-futures arbitrage helpers."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.strategies.arbitrage import check_live_basis, generate_threshold_signals
+
+
+class DummyExchange:
+    """Minimal CCXT-like exchange for deterministic tests."""
+
+    def __init__(self, prices: dict[str, float]):
+        self._prices = prices
+
+    def fetch_ticker(self, symbol: str):
+        return {"last": self._prices[symbol]}
+
+
+def test_check_live_basis_generates_positive_signal():
+    exchange = DummyExchange({"BTC/USDT": 100.0, "BTC/USDT:USDT": 101.0})
+    result = check_live_basis(exchange=exchange, threshold=0.005)
+    assert result["signal"] == 1
+    assert abs(result["diff"] - 0.01) < 1e-12
+    assert result["spot"] == 100.0
+    assert result["futures"] == 101.0
+
+
+def test_check_live_basis_negative_signal():
+    exchange = DummyExchange({"BTC/USDT": 100.0, "BTC/USDT:USDT": 99.0})
+    result = check_live_basis(exchange=exchange, threshold=0.005)
+    assert result["signal"] == -1
+    assert abs(result["diff"] + 0.01) < 1e-12
+
+
+def test_check_live_basis_requires_non_negative_threshold():
+    with pytest.raises(ValueError):
+        check_live_basis(threshold=-0.1)
+
+
+def test_generate_threshold_signals_outputs_basis_and_signal():
+    timestamps = pd.date_range("2024-01-01", periods=3, freq="1H")
+    spot = pd.DataFrame({"timestamp": timestamps, "Close": [100.0, 101.0, 102.0]})
+    futures = pd.DataFrame({"timestamp": timestamps, "Close": [101.0, 100.0, 102.5]})
+
+    result = generate_threshold_signals(spot, futures, threshold=0.005)
+
+    expected_basis = [0.01, -0.009900990099009901, 0.004901960784313725]
+    for actual, expected in zip(result["basis"], expected_basis):
+        assert abs(actual - expected) < 1e-12
+    assert result["signal"].to_list() == [1, -1, 0]
+
+
+def test_generate_threshold_signals_validates_columns():
+    spot = pd.DataFrame({"timestamp": [1, 2, 3], "close": [1, 1, 1]})
+    futures = pd.DataFrame({"timestamp": [1, 2, 3], "Close": [1, 1, 1]})
+    with pytest.raises(ValueError):
+        generate_threshold_signals(spot, futures)
+
+
+def test_generate_threshold_signals_rejects_zero_spot_price():
+    timestamps = pd.date_range("2024-01-01", periods=1, freq="1H")
+    spot = pd.DataFrame({"timestamp": timestamps, "Close": [0.0]})
+    futures = pd.DataFrame({"timestamp": timestamps, "Close": [100.0]})
+    with pytest.raises(ValueError):
+        generate_threshold_signals(spot, futures)


### PR DESCRIPTION
## Summary
- add a lightweight `check_live_basis` helper for monitoring spot-futures spreads with ccxt
- introduce `generate_threshold_signals` to build simple basis signals from historical data
- cover the new helpers with deterministic unit tests using a dummy exchange and stub data

## Testing
- pytest tests/test_arbitrage_threshold.py

------
https://chatgpt.com/codex/tasks/task_e_68dd63b3788c832cb8a076409c9e57e8