### PR TITLE
Add logging for Binance kline data gaps

### DIFF
--- a/tradingbot_ibkr/binance_to_gcs.py
+++ b/tradingbot_ibkr/binance_to_gcs.py
@@ -80,6 +80,17 @@ def download_and_upload(bucket_name: str, symbols: List[str], intervals: List[st
                     "taker_buy_base", "taker_buy_quote", "ignore",
                 ]
                 df = pd.DataFrame(klines, columns=cols)
+                timestamps = pd.to_datetime(df["open_time"], unit="ms")
+                expected_delta = pd.to_timedelta(INTERVAL_MS[interval], unit="ms")
+                gaps = timestamps.diff() > expected_delta
+                if gaps.any():
+                    logging.warning(
+                        "Data gaps detected for %s %s %s at %s",
+                        market,
+                        symbol,
+                        interval,
+                        timestamps[gaps].dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ").tolist(),
+                    )
                 data_str = df.to_csv(index=False)
                 blob_name = (
                     f"{dest_path}/{market}/{symbol}/{interval}/"


### PR DESCRIPTION
## Summary
- detect gaps in Binance kline data based on interval length
- log warnings listing timestamps where data gaps occur before uploading to GCS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd68009200832cad50eafe7571d1f2