### PR TITLE
Add shared core utilities and IBKR execution reconciliation tools

### DIFF
--- a/config/fees/binance_spot.yaml
+++ b/config/fees/binance_spot.yaml
@@ -1,0 +1,4 @@
+name: binance_spot
+maker: 0.001
+taker: 0.001
+notes: Maker/taker fees expressed as decimal percentages.

--- a/config/strategy/sample_meanrev.yaml
+++ b/config/strategy/sample_meanrev.yaml
@@ -1,0 +1,11 @@
+name: sample_meanrev
+parameters:
+  lookback: 20
+  entry_threshold: 1.5
+  exit_threshold: 0.5
+risk:
+  stop_loss_pct: 0.02
+  take_profit_pct: 0.04
+position_sizing:
+  mode: volatility
+  max_trades: 3

--- a/tradingbot_core/__init__.py
+++ b/tradingbot_core/__init__.py
@@ -1,0 +1,13 @@
+"""Core utilities shared across trading bot services."""
+
+from .config import ConfigBundle, load_config
+from .logging_setup import setup_logging
+from .backtest_save import save_backtest_results, load_backtest_results
+
+__all__ = [
+    "ConfigBundle",
+    "load_config",
+    "setup_logging",
+    "save_backtest_results",
+    "load_backtest_results",
+]

--- a/tradingbot_core/backtest_save.py
+++ b/tradingbot_core/backtest_save.py
@@ -1,0 +1,54 @@
+"""Helpers for persisting and retrieving backtest results."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+import json
+
+
+def _default_serializer(value: Any) -> Any:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def save_backtest_results(
+    results: Mapping[str, Any],
+    directory: str | Path,
+    *,
+    prefix: str = "backtest",
+    timestamp: datetime | None = None,
+) -> Path:
+    """Persist a mapping of results to a timestamped JSON file.
+
+    The helper returns the path to the written file which makes it convenient to
+    reference in logs or follow-up processing steps.  The directory is created on
+    demand if necessary.
+    """
+
+    output_dir = Path(directory)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = (timestamp or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    filename = f"{prefix}_{ts.strftime('%Y%m%dT%H%M%SZ')}.json"
+    target = output_dir / filename
+
+    with target.open("w", encoding="utf-8") as handle:
+        json.dump(results, handle, default=_default_serializer, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    return target
+
+
+def load_backtest_results(path: str | Path) -> dict[str, Any]:
+    """Load a backtest result file previously written by :func:`save_backtest_results`."""
+
+    target = Path(path)
+    with target.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+__all__ = ["save_backtest_results", "load_backtest_results"]

--- a/tradingbot_core/logging_setup.py
+++ b/tradingbot_core/logging_setup.py
@@ -1,0 +1,48 @@
+"""Centralised logging helpers used across services and scripts."""
+from __future__ import annotations
+
+from logging import Formatter, Logger, StreamHandler, getLogger
+import logging
+from pathlib import Path
+from typing import IO
+import sys
+
+DEFAULT_LOG_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+
+
+def setup_logging(
+    *,
+    name: str = "tradingbot",
+    level: int | str = logging.INFO,
+    stream: IO[str] | None = None,
+    log_path: str | Path | None = None,
+    formatter: Formatter | None = None,
+    propagate: bool = False,
+) -> Logger:
+    """Configure and return a logger instance.
+
+    The helper is intentionally opinionated but still provides a handful of
+    extension points so that tests can exercise behaviour without touching the
+    global logging configuration from multiple locations.
+    """
+
+    logger = getLogger(name)
+    logger.setLevel(level)
+    logger.handlers.clear()
+    logger.propagate = propagate
+
+    chosen_formatter = formatter or Formatter(DEFAULT_LOG_FORMAT)
+
+    stream_handler = StreamHandler(stream or sys.stdout)
+    stream_handler.setFormatter(chosen_formatter)
+    logger.addHandler(stream_handler)
+
+    if log_path is not None:
+        file_handler = logging.FileHandler(Path(log_path))
+        file_handler.setFormatter(chosen_formatter)
+        logger.addHandler(file_handler)
+
+    return logger
+
+
+__all__ = ["setup_logging", "DEFAULT_LOG_FORMAT"]

--- a/tradingbot_core/metrics.py
+++ b/tradingbot_core/metrics.py
@@ -1,0 +1,80 @@
+"""Common performance metrics used in reports and dashboards."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Iterable
+import math
+
+
+@dataclass(frozen=True)
+class Drawdown:
+    peak: float
+    trough: float
+    recovery: float
+    depth: float
+
+
+def _validate_series(series: Sequence[float]) -> None:
+    if not series:
+        raise ValueError("Expected a non-empty series")
+
+
+def calculate_cumulative_returns(returns: Iterable[float]) -> list[float]:
+    cumulative = []
+    total = 1.0
+    for value in returns:
+        total *= 1.0 + value
+        cumulative.append(total - 1.0)
+    return cumulative
+
+
+def calculate_max_drawdown(equity_curve: Sequence[float]) -> Drawdown:
+    _validate_series(equity_curve)
+    peak = equity_curve[0]
+    trough = equity_curve[0]
+    max_depth = 0.0
+    recovery = equity_curve[0]
+
+    for value in equity_curve[1:]:
+        if value > peak:
+            peak = value
+            trough = value
+        elif value < trough:
+            trough = value
+            depth = (trough - peak) / peak if peak else 0.0
+            if depth < max_depth:
+                max_depth = depth
+                recovery = value
+    return Drawdown(peak=peak, trough=trough, recovery=recovery, depth=max_depth)
+
+
+def calculate_sharpe_ratio(returns: Sequence[float], *, risk_free_rate: float = 0.0, periods_per_year: int = 252) -> float:
+    _validate_series(returns)
+    mean_return = sum(returns) / len(returns)
+    excess_returns = [r - risk_free_rate / periods_per_year for r in returns]
+    variance = sum((r - mean_return) ** 2 for r in returns) / len(returns)
+    std_dev = math.sqrt(variance)
+    if std_dev == 0:
+        raise ValueError("Standard deviation is zero; Sharpe ratio undefined")
+    return (mean_return - risk_free_rate / periods_per_year) / std_dev * math.sqrt(periods_per_year)
+
+
+def calculate_sortino_ratio(returns: Sequence[float], *, risk_free_rate: float = 0.0, periods_per_year: int = 252) -> float:
+    _validate_series(returns)
+    downside = [min(0.0, r - risk_free_rate / periods_per_year) for r in returns]
+    downside_squared = [r ** 2 for r in downside]
+    downside_deviation = math.sqrt(sum(downside_squared) / len(returns))
+    if downside_deviation == 0:
+        raise ValueError("Downside deviation is zero; Sortino ratio undefined")
+    mean_return = sum(returns) / len(returns)
+    return (mean_return - risk_free_rate / periods_per_year) / downside_deviation * math.sqrt(periods_per_year)
+
+
+__all__ = [
+    "Drawdown",
+    "calculate_cumulative_returns",
+    "calculate_max_drawdown",
+    "calculate_sharpe_ratio",
+    "calculate_sortino_ratio",
+]

--- a/tradingbot_ibkr/execution/__init__.py
+++ b/tradingbot_ibkr/execution/__init__.py
@@ -1,0 +1,14 @@
+"""Execution layer primitives for IBKR and paper trading back-ends."""
+
+from .broker_base import BrokerBase, Order, Position
+from .paper_broker import PaperBroker
+from .reconciler import ReconciliationReport, Reconciler
+
+__all__ = [
+    "BrokerBase",
+    "Order",
+    "Position",
+    "PaperBroker",
+    "ReconciliationReport",
+    "Reconciler",
+]

--- a/tradingbot_ibkr/execution/broker_base.py
+++ b/tradingbot_ibkr/execution/broker_base.py
@@ -1,0 +1,43 @@
+"""Abstract interfaces shared by execution back-ends."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, Protocol
+
+
+@dataclass(frozen=True)
+class Order:
+    """Represents a simplified order used by the reconciler."""
+
+    id: str
+    symbol: str
+    side: str
+    quantity: float
+    filled_quantity: float = 0.0
+    status: str = "open"
+    price: float | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def remaining(self) -> float:
+        return max(self.quantity - self.filled_quantity, 0.0)
+
+
+@dataclass(frozen=True)
+class Position:
+    symbol: str
+    quantity: float
+    average_price: float | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+class BrokerBase(Protocol):
+    """Protocol describing the methods used by the reconciler."""
+
+    def list_open_orders(self) -> Iterable[Order]:
+        ...
+
+    def list_positions(self) -> Iterable[Position]:
+        ...
+
+
+__all__ = ["Order", "Position", "BrokerBase"]

--- a/tradingbot_ibkr/execution/ibkr_broker.py
+++ b/tradingbot_ibkr/execution/ibkr_broker.py
@@ -1,0 +1,26 @@
+"""Thin adapter over the Interactive Brokers API.
+
+The real project contains a significantly more involved implementation.  For
+this kata we only need a minimal class that satisfies the reconciler tests by
+conforming to :class:`~tradingbot_ibkr.execution.broker_base.BrokerBase`.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from .broker_base import BrokerBase, Order, Position
+
+
+class IBKRBroker(BrokerBase):
+    def __init__(self, *, orders: Sequence[Order] | None = None, positions: Sequence[Position] | None = None) -> None:
+        self._orders = list(orders or [])
+        self._positions = list(positions or [])
+
+    def list_open_orders(self) -> Iterable[Order]:
+        return [order for order in self._orders if order.status == "open"]
+
+    def list_positions(self) -> Iterable[Position]:
+        return list(self._positions)
+
+
+__all__ = ["IBKRBroker"]

--- a/tradingbot_ibkr/execution/paper_broker.py
+++ b/tradingbot_ibkr/execution/paper_broker.py
@@ -1,0 +1,59 @@
+"""In-memory broker used for tests and simple simulations."""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Dict, Iterable, Mapping
+import uuid
+
+from .broker_base import BrokerBase, Order, Position
+
+
+class PaperBroker(BrokerBase):
+    def __init__(self, *, initial_positions: Mapping[str, float] | None = None) -> None:
+        self._orders: Dict[str, Order] = {}
+        self._positions: Dict[str, Position] = {
+            symbol: Position(symbol=symbol, quantity=qty)
+            for symbol, qty in (initial_positions or {}).items()
+        }
+
+    def submit_order(self, symbol: str, side: str, quantity: float, *, price: float | None = None) -> Order:
+        order_id = uuid.uuid4().hex
+        order = Order(id=order_id, symbol=symbol, side=side, quantity=quantity, price=price)
+        self._orders[order_id] = order
+        return order
+
+    def fill_order(self, order_id: str, *, filled_quantity: float | None = None) -> Order:
+        order = self._orders[order_id]
+        qty = order.quantity if filled_quantity is None else min(filled_quantity, order.quantity)
+        updated = replace(order, filled_quantity=qty, status="filled")
+        self._orders[order_id] = updated
+        self._update_position(updated)
+        return updated
+
+    def cancel_order(self, order_id: str) -> Order:
+        order = self._orders[order_id]
+        cancelled = replace(order, status="cancelled")
+        self._orders[order_id] = cancelled
+        return cancelled
+
+    def _update_position(self, order: Order) -> None:
+        if order.status != "filled" or order.filled_quantity == 0:
+            return
+        multiplier = 1 if order.side.lower() == "buy" else -1
+        qty_change = multiplier * order.filled_quantity
+        position = self._positions.get(order.symbol)
+        new_qty = (position.quantity if position else 0.0) + qty_change
+        if abs(new_qty) < 1e-9:
+            self._positions.pop(order.symbol, None)
+        else:
+            self._positions[order.symbol] = Position(symbol=order.symbol, quantity=new_qty)
+
+    # -- BrokerBase interface -------------------------------------------------
+    def list_open_orders(self) -> Iterable[Order]:
+        return [order for order in self._orders.values() if order.status == "open"]
+
+    def list_positions(self) -> Iterable[Position]:
+        return list(self._positions.values())
+
+
+__all__ = ["PaperBroker"]

--- a/tradingbot_ibkr/execution/reconciler.py
+++ b/tradingbot_ibkr/execution/reconciler.py
@@ -1,0 +1,79 @@
+"""Utilities to compare local state with broker state."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableMapping
+
+from .broker_base import BrokerBase, Order, Position
+
+
+@dataclass(frozen=True)
+class ReconciliationReport:
+    missing_orders: tuple[str, ...] = ()
+    unexpected_orders: tuple[Order, ...] = ()
+    quantity_mismatches: Mapping[str, float] = field(default_factory=dict)
+    position_deltas: Mapping[str, float] = field(default_factory=dict)
+    generated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def is_clean(self) -> bool:
+        return not (self.missing_orders or self.unexpected_orders or self.quantity_mismatches or self.position_deltas)
+
+
+class Reconciler:
+    def __init__(self, broker: BrokerBase, *, quantity_tolerance: float = 1e-6) -> None:
+        self._broker = broker
+        self._quantity_tolerance = quantity_tolerance
+
+    def _coerce_orders(self, orders: Iterable[Order] | Mapping[str, Order]) -> MutableMapping[str, Order]:
+        if isinstance(orders, Mapping):
+            return dict(orders)
+        return {order.id: order for order in orders}
+
+    def _coerce_positions(self, positions: Mapping[str, float] | Iterable[Position]) -> MutableMapping[str, float]:
+        if isinstance(positions, Mapping):
+            return dict(positions)
+        return {pos.symbol: pos.quantity for pos in positions}
+
+    def reconcile(
+        self,
+        *,
+        local_orders: Iterable[Order] | Mapping[str, Order],
+        local_positions: Mapping[str, float] | Iterable[Position],
+    ) -> ReconciliationReport:
+        broker_orders = {order.id: order for order in self._broker.list_open_orders()}
+        broker_positions = {position.symbol: position.quantity for position in self._broker.list_positions()}
+
+        local_orders_map = self._coerce_orders(local_orders)
+        local_positions_map = self._coerce_positions(local_positions)
+
+        missing_orders = tuple(sorted(order_id for order_id in local_orders_map.keys() - broker_orders.keys()))
+        unexpected_orders = tuple(broker_orders[oid] for oid in broker_orders.keys() - local_orders_map.keys())
+
+        quantity_mismatches: dict[str, float] = {}
+        for order_id in broker_orders.keys() & local_orders_map.keys():
+            broker_order = broker_orders[order_id]
+            local_order = local_orders_map[order_id]
+            delta = broker_order.remaining() - local_order.remaining()
+            if abs(delta) > self._quantity_tolerance:
+                quantity_mismatches[order_id] = delta
+
+        position_deltas: dict[str, float] = {}
+        symbols = broker_positions.keys() | local_positions_map.keys()
+        for symbol in symbols:
+            broker_qty = broker_positions.get(symbol, 0.0)
+            local_qty = local_positions_map.get(symbol, 0.0)
+            delta = broker_qty - local_qty
+            if abs(delta) > self._quantity_tolerance:
+                position_deltas[symbol] = delta
+
+        return ReconciliationReport(
+            missing_orders=missing_orders,
+            unexpected_orders=unexpected_orders,
+            quantity_mismatches=quantity_mismatches,
+            position_deltas=position_deltas,
+        )
+
+
+__all__ = ["ReconciliationReport", "Reconciler"]

--- a/tradingbot_ibkr/server.py
+++ b/tradingbot_ibkr/server.py
@@ -1,0 +1,49 @@
+"""FastAPI application exposing health and metadata endpoints."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import os
+
+from fastapi import FastAPI
+
+from tradingbot_core.config import load_config
+from tradingbot_core.logging_setup import setup_logging
+
+_DEFAULT_ENV = os.getenv("TRADINGBOT_ENV", "paper")
+_DEFAULT_STRATEGY = os.getenv("TRADINGBOT_STRATEGY", "sample_meanrev")
+_START_TIME = datetime.now(timezone.utc)
+
+
+def _build_meta_payload(env_name: str, strategy_name: str) -> dict[str, object]:
+    bundle = load_config(env_name, strategy_name)
+    now = datetime.now(timezone.utc)
+    return {
+        "environment": bundle.env.get("name", env_name),
+        "strategy": bundle.strategy.get("name", strategy_name),
+        "fees": bundle.fees,
+        "config": bundle.as_dict(),
+        "started_at": _START_TIME.isoformat(),
+        "uptime_seconds": (now - _START_TIME).total_seconds(),
+    }
+
+
+def create_app() -> FastAPI:
+    setup_logging(name="tradingbot_ibkr.server")
+    app = FastAPI(title="Trading Bot IBKR", version="0.1.0")
+
+    @app.get("/health")
+    def healthcheck() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/meta")
+    def meta(env: str | None = None, strategy: str | None = None) -> dict[str, object]:
+        env_name = env or _DEFAULT_ENV
+        strategy_name = strategy or _DEFAULT_STRATEGY
+        return _build_meta_payload(env_name, strategy_name)
+
+    return app
+
+
+app = create_app()
+
+__all__ = ["app", "create_app"]


### PR DESCRIPTION
## Summary
- add reusable YAML-driven configuration loader with sample environment, strategy, and fee files
- provide logging, metrics, and backtest persistence helpers for reuse across services
- implement execution layer primitives, reconciliation logic, and a FastAPI server with health and metadata endpoints

## Testing
- pytest tradingbot_ibkr/tests/test_store_trade.py -k test_store_trade -q
- python -m compileall tradingbot_core tradingbot_ibkr/execution tradingbot_ibkr/server.py

------
https://chatgpt.com/codex/tasks/task_e_68ddd14777f4832c981c08191e8c0fc4