### PR TITLE
Add config loader and runtime overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ pip-wheel-metadata/
 
 # Virtual environments
 .venv/
-env/
+/env/
 venv/
 
 # PyTest cache

--- a/config/env/paper.yaml
+++ b/config/env/paper.yaml
@@ -1,0 +1,8 @@
+name: paper
+mode: paper
+broker: paper
+fees_profile: binance_spot
+risk_limits:
+  daily_loss_limit: 1000
+  max_position_notional: 50000
+notes: Simulated paper-trading environment used for development and tests.

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from tradingbot_core.config import ConfigBundle, load_config
+
+
+def test_load_config_returns_expected_sections() -> None:
+    bundle = load_config("paper", "sample_meanrev")
+
+    assert isinstance(bundle, ConfigBundle)
+    assert bundle.env["name"] == "paper"
+    assert bundle.strategy["name"] == "sample_meanrev"
+    assert bundle.fees["name"] == "binance_spot"
+    assert "runtime" in bundle.as_dict()
+
+
+def test_runtime_overrides_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TB_MODE", "paper")
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+    monkeypatch.setenv("BROKER", "IBKR")
+    monkeypatch.setenv("IBKR_BASE_URL", "https://localhost:5000")
+    monkeypatch.setenv("IBKR_CLIENT_ID", "1111")
+    monkeypatch.setenv("IBKR_ACCOUNT_ID", "DU1234567")
+    monkeypatch.setenv("EXCHANGE_ID", "binance")
+    monkeypatch.setenv("EXCHANGE_API_KEY", "replace_me")
+    monkeypatch.setenv("EXCHANGE_SECRET", "replace_me")
+
+    bundle = load_config("paper", "sample_meanrev")
+    runtime = bundle.runtime
+
+    assert runtime["mode"] == "paper"
+    assert runtime["logging"]["level"] == "INFO"
+    assert runtime["broker"]["name"] == "IBKR"
+    assert runtime["broker"]["ibkr"]["base_url"] == "https://localhost:5000"
+    assert runtime["broker"]["ibkr"]["client_id"] == 1111
+    assert runtime["broker"]["ibkr"]["account_id"] == "DU1234567"
+    assert runtime["exchange"]["id"] == "binance"
+    assert runtime["exchange"]["api_key"] == "replace_me"
+    assert runtime["exchange"]["secret"] == "replace_me"

--- a/tradingbot_core/config/__init__.py
+++ b/tradingbot_core/config/__init__.py
@@ -1,0 +1,116 @@
+"""Configuration loader that stitches together environment, strategy, and fee profiles."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+import os
+
+import yaml
+
+_CONFIG_ROOT = Path(__file__).resolve().parents[2] / "config"
+
+
+def _coerce_int(value: str | None) -> int | str | None:
+    """Attempt to coerce a string to an integer when possible."""
+
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return value
+
+
+@dataclass(frozen=True)
+class ConfigBundle:
+    """Bundle of related configuration sections used by trading services."""
+
+    env: Mapping[str, Any]
+    strategy: Mapping[str, Any]
+    fees: Mapping[str, Any]
+    runtime: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the bundle as a serialisable dictionary."""
+
+        return {
+            "env": dict(self.env),
+            "strategy": dict(self.strategy),
+            "fees": dict(self.fees),
+            "runtime": dict(self.runtime),
+        }
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise TypeError(f"Configuration file must contain a mapping: {path}")
+    return data
+
+
+def _runtime_overrides() -> dict[str, Any]:
+    runtime: dict[str, Any] = {}
+
+    mode = os.getenv("TB_MODE")
+    if mode:
+        runtime["mode"] = mode
+
+    log_level = os.getenv("LOG_LEVEL")
+    if log_level:
+        runtime.setdefault("logging", {})["level"] = log_level
+
+    broker_name = os.getenv("BROKER")
+    if broker_name:
+        broker: dict[str, Any] = {"name": broker_name}
+        ibkr_base = os.getenv("IBKR_BASE_URL")
+        ibkr_client = _coerce_int(os.getenv("IBKR_CLIENT_ID"))
+        ibkr_account = os.getenv("IBKR_ACCOUNT_ID")
+        if any(value is not None for value in (ibkr_base, ibkr_client, ibkr_account)):
+            broker["ibkr"] = {
+                key: value
+                for key, value in {
+                    "base_url": ibkr_base,
+                    "client_id": ibkr_client,
+                    "account_id": ibkr_account,
+                }.items()
+                if value is not None
+            }
+        runtime["broker"] = broker
+
+    exchange_id = os.getenv("EXCHANGE_ID")
+    if exchange_id:
+        exchange: dict[str, Any] = {"id": exchange_id}
+        api_key = os.getenv("EXCHANGE_API_KEY")
+        secret = os.getenv("EXCHANGE_SECRET")
+        if api_key:
+            exchange["api_key"] = api_key
+        if secret:
+            exchange["secret"] = secret
+        runtime["exchange"] = exchange
+
+    return runtime
+
+
+def load_config(env_name: str, strategy_name: str, *, config_dir: str | Path | None = None) -> ConfigBundle:
+    """Load configuration sections for a given environment and strategy."""
+
+    base_dir = Path(config_dir) if config_dir else _CONFIG_ROOT
+
+    env_config = _load_yaml(base_dir / "env" / f"{env_name}.yaml")
+    strategy_config = _load_yaml(base_dir / "strategy" / f"{strategy_name}.yaml")
+
+    fees_profile = env_config.get("fees_profile") or strategy_config.get("fees_profile")
+    fees_config: dict[str, Any] = {}
+    if fees_profile:
+        fees_config = _load_yaml(base_dir / "fees" / f"{fees_profile}.yaml")
+
+    runtime = _runtime_overrides()
+
+    return ConfigBundle(env=env_config, strategy=strategy_config, fees=fees_config, runtime=runtime)
+
+
+__all__ = ["ConfigBundle", "load_config"]


### PR DESCRIPTION
## Summary
- add a configuration loader that stitches together environment, strategy, and fee profiles while capturing runtime overrides from environment variables
- add a paper trading environment profile and adjust the gitignore so environment configs are versioned
- cover the loader with unit tests to verify base loading and runtime overrides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de06bda494832cb7b03a75fc14bd2f