### PR TITLE
Add paper trading environment configuration

### DIFF
--- a/config/environments/paper.yaml
+++ b/config/environments/paper.yaml
@@ -1,0 +1,12 @@
+env: paper
+base_currency: USD
+risk:
+  max_daily_loss_pct: 3.0
+  max_position_risk_pct: 1.0
+  kill_switch_drawdown_pct: 8.0
+execution:
+  slippage_bps: 2
+  commission_bps: 1
+universe:
+  - BTC/USDT
+  - ETH/USDT


### PR DESCRIPTION
## Summary
- add a paper trading environment configuration with USD base currency
- specify risk limits, execution costs, and the BTC/USDT + ETH/USDT universe

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de0772e008832ca9876b7cfedb4ff8