### PR TITLE
Normalize fee configs with basis points support

### DIFF
--- a/config/fees/binance_spot.yaml
+++ b/config/fees/binance_spot.yaml
@@ -1,4 +1,5 @@
 name: binance_spot
-maker: 0.001
-taker: 0.001
-notes: Maker/taker fees expressed as decimal percentages.
+vip_tier: 0
+maker_bps: 8
+taker_bps: 10
+notes: Maker/taker fees expressed in basis points for VIP tier 0.

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import math
+import pathlib
+
 import pytest
 
 from tradingbot_core.config import ConfigBundle, load_config
@@ -13,6 +16,42 @@ def test_load_config_returns_expected_sections() -> None:
     assert bundle.strategy["name"] == "sample_meanrev"
     assert bundle.fees["name"] == "binance_spot"
     assert "runtime" in bundle.as_dict()
+
+
+def test_fee_config_accepts_basis_points(tmp_path: pathlib.Path) -> None:
+    config_dir = tmp_path
+    env_dir = config_dir / "env"
+    strategy_dir = config_dir / "strategy"
+    fees_dir = config_dir / "fees"
+
+    env_dir.mkdir()
+    strategy_dir.mkdir()
+    fees_dir.mkdir()
+
+    (env_dir / "custom.yaml").write_text(
+        """
+name: custom
+fees_profile: custom_fee
+""".strip()
+    )
+
+    (strategy_dir / "custom.yaml").write_text("name: custom\n")
+
+    (fees_dir / "custom_fee.yaml").write_text(
+        """
+name: custom_fee
+vip_tier: 0
+maker_bps: 8
+taker_bps: 10
+notes: Sample configuration expressed in basis points.
+""".strip()
+    )
+
+    bundle = load_config("custom", "custom", config_dir=config_dir)
+
+    assert math.isclose(bundle.fees["maker"], 0.0008, rel_tol=0, abs_tol=1e-9)
+    assert math.isclose(bundle.fees["taker"], 0.001, rel_tol=0, abs_tol=1e-9)
+    assert bundle.fees["vip_tier"] == 0
 
 
 def test_runtime_overrides_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tradingbot_core/config/__init__.py
+++ b/tradingbot_core/config/__init__.py
@@ -95,6 +95,33 @@ def _runtime_overrides() -> dict[str, Any]:
     return runtime
 
 
+def _normalise_fees_config(fees: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a normalised copy of a fee configuration mapping.
+
+    Binance (and some other exchanges) express maker/taker fees in basis
+    points rather than decimal percentages.  The legacy configuration format
+    in this project stores the decimal representation under ``maker`` and
+    ``taker`` keys.  To keep backwards compatibility while allowing the more
+    human-friendly basis point inputs, we derive the decimal values when
+    ``maker_bps``/``taker_bps`` are supplied.
+    """
+
+    if not fees:
+        return dict(fees)
+
+    normalised = dict(fees)
+
+    maker_bps = normalised.get("maker_bps")
+    if "maker" not in normalised and maker_bps is not None:
+        normalised["maker"] = float(maker_bps) / 10_000.0
+
+    taker_bps = normalised.get("taker_bps")
+    if "taker" not in normalised and taker_bps is not None:
+        normalised["taker"] = float(taker_bps) / 10_000.0
+
+    return normalised
+
+
 def load_config(env_name: str, strategy_name: str, *, config_dir: str | Path | None = None) -> ConfigBundle:
     """Load configuration sections for a given environment and strategy."""
 
@@ -106,7 +133,8 @@ def load_config(env_name: str, strategy_name: str, *, config_dir: str | Path | N
     fees_profile = env_config.get("fees_profile") or strategy_config.get("fees_profile")
     fees_config: dict[str, Any] = {}
     if fees_profile:
-        fees_config = _load_yaml(base_dir / "fees" / f"{fees_profile}.yaml")
+        fees_raw = _load_yaml(base_dir / "fees" / f"{fees_profile}.yaml")
+        fees_config = _normalise_fees_config(fees_raw)
 
     runtime = _runtime_overrides()
 


### PR DESCRIPTION
## Summary
- normalise fee profile data to derive decimal maker/taker rates from basis-point inputs
- update the default Binance spot fee profile to record VIP tier 0 maker/taker basis points
- extend the config loader tests to cover basis-point fee configurations

## Testing
- pytest tests/test_config_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68de098128d0832c8e3af815d0b5838b