### PR TITLE
Add portfolio statistics helper to metrics module

### DIFF
--- a/tests/test_portfolio_stats.py
+++ b/tests/test_portfolio_stats.py
@@ -1,0 +1,66 @@
+import math
+
+import pytest
+
+from tradingbot_core.metrics import PortfolioStats, compute_portfolio_stats
+
+
+def _downside_std(values):
+    downside = [v for v in values if v < 0]
+    if not downside:
+        return 0.0
+    mean = sum(downside) / len(downside)
+    variance = sum((v - mean) ** 2 for v in downside) / len(downside)
+    return math.sqrt(variance)
+
+
+def _max_drawdown(values):
+    cumulative = []
+    total = 1.0
+    for r in values:
+        total *= 1 + r
+        cumulative.append(total)
+    peak = cumulative[0]
+    max_dd = 0.0
+    for value in cumulative:
+        if value > peak:
+            peak = value
+        drawdown = 1 - value / peak if peak else 0.0
+        max_dd = max(max_dd, drawdown)
+    return max_dd
+
+
+def _cvar(values):
+    sorted_returns = sorted(values)
+    position = 0.05 * (len(sorted_returns) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if upper == lower:
+        percentile = sorted_returns[int(position)]
+    else:
+        weight = position - lower
+        percentile = sorted_returns[lower] * (1 - weight) + sorted_returns[upper] * weight
+    tail = [v for v in sorted_returns if v <= percentile] or [percentile]
+    return -sum(tail) / len(tail)
+
+
+def test_compute_portfolio_stats_basic():
+    returns = [0.01, 0.02, -0.015, 0.005, -0.03]
+
+    stats = compute_portfolio_stats(returns, risk_free=0.0)
+
+    mean = sum(returns) / len(returns)
+    variance = sum((r - mean) ** 2 for r in returns) / len(returns)
+    std_dev = math.sqrt(variance)
+    downside_std = _downside_std(returns)
+
+    assert isinstance(stats, PortfolioStats)
+    assert math.isclose(stats.sharpe, mean / max(std_dev, 1e-12), rel_tol=1e-6)
+    assert math.isclose(stats.sortino, mean / max(downside_std, 1e-12), rel_tol=1e-6)
+    assert math.isclose(stats.max_drawdown, _max_drawdown(returns), rel_tol=1e-6)
+    assert math.isclose(stats.cvar_95, _cvar(returns), rel_tol=1e-6)
+
+
+def test_compute_portfolio_stats_requires_data():
+    with pytest.raises(ValueError):
+        compute_portfolio_stats([])

--- a/tradingbot_core/metrics.py
+++ b/tradingbot_core/metrics.py
@@ -15,6 +15,16 @@ class Drawdown:
     depth: float
 
 
+@dataclass(frozen=True)
+class PortfolioStats:
+    """Aggregate portfolio statistics computed from a return series."""
+
+    sharpe: float
+    sortino: float
+    max_drawdown: float
+    cvar_95: float
+
+
 def _validate_series(series: Sequence[float]) -> None:
     if not series:
         raise ValueError("Expected a non-empty series")
@@ -71,10 +81,84 @@ def calculate_sortino_ratio(returns: Sequence[float], *, risk_free_rate: float =
     return (mean_return - risk_free_rate / periods_per_year) / downside_deviation * math.sqrt(periods_per_year)
 
 
+def compute_portfolio_stats(returns: Sequence[float], *, risk_free: float = 0.0) -> PortfolioStats:
+    """Compute common portfolio statistics from a series of returns.
+
+    Args:
+        returns: Iterable of periodic returns expressed as decimals (e.g. ``0.01`` for 1%).
+        risk_free: Periodic risk-free rate used for excess return calculations.
+
+    Returns:
+        PortfolioStats dataclass containing Sharpe ratio, Sortino ratio, maximum drawdown,
+        and Conditional Value at Risk (CVaR) at the 95% level.
+
+    Raises:
+        ValueError: If ``returns`` is empty.
+    """
+
+    _validate_series(returns)
+
+    values = [float(r) for r in returns]
+    eps = 1e-12
+
+    mean_return = sum(values) / len(values)
+    variance = sum((r - mean_return) ** 2 for r in values) / len(values)
+    std_dev = math.sqrt(variance)
+    std_dev = std_dev if std_dev > eps else eps
+
+    downside = [r for r in values if r < 0.0]
+    if downside:
+        downside_mean = sum(downside) / len(downside)
+        downside_var = sum((r - downside_mean) ** 2 for r in downside) / len(downside)
+        downside_dev = math.sqrt(downside_var)
+    else:
+        downside_dev = 0.0
+    downside_dev = downside_dev if downside_dev > eps else eps
+
+    sharpe = (mean_return - risk_free) / std_dev
+    sortino = (mean_return - risk_free) / downside_dev
+
+    cumulative = []
+    total = 1.0
+    for r in values:
+        total *= 1.0 + r
+        cumulative.append(total)
+
+    max_drawdown = 0.0
+    peak = cumulative[0] if cumulative else 0.0
+    for value in cumulative:
+        if value > peak:
+            peak = value
+        drawdown = 1.0 - value / peak if peak else 0.0
+        if drawdown > max_drawdown:
+            max_drawdown = drawdown
+
+    sorted_returns = sorted(values)
+    if sorted_returns:
+        position = 0.05 * (len(sorted_returns) - 1)
+        lower = math.floor(position)
+        upper = math.ceil(position)
+        if upper == lower:
+            percentile = sorted_returns[int(position)]
+        else:
+            weight = position - lower
+            percentile = sorted_returns[lower] * (1 - weight) + sorted_returns[upper] * weight
+        tail_losses = [r for r in sorted_returns if r <= percentile]
+        if not tail_losses:
+            tail_losses = [percentile]
+        cvar = -sum(tail_losses) / len(tail_losses)
+    else:
+        cvar = 0.0
+
+    return PortfolioStats(sharpe=sharpe, sortino=sortino, max_drawdown=max_drawdown, cvar_95=cvar)
+
+
 __all__ = [
     "Drawdown",
+    "PortfolioStats",
     "calculate_cumulative_returns",
     "calculate_max_drawdown",
     "calculate_sharpe_ratio",
     "calculate_sortino_ratio",
+    "compute_portfolio_stats",
 ]


### PR DESCRIPTION
## Summary
- add a `PortfolioStats` dataclass and `compute_portfolio_stats` helper to aggregate common metrics from return series
- cover the new helper with tests that validate Sharpe, Sortino, drawdown, and CVaR calculations

## Testing
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68de0b0d8a50832ca0208db1c555332f