### PR TITLE
Add JSON logging formatter and tests

### DIFF
--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,76 @@
+"""Tests for the logging helper utilities."""
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+
+from tradingbot_core.logging_setup import JsonFormatter, setup_logging
+
+
+def test_json_formatter_serializes_basic_fields() -> None:
+    stream = io.StringIO()
+    logger = setup_logging(name="test.json", stream=stream, formatter="json")
+
+    logger.info("hello world")
+
+    payload = json.loads(stream.getvalue().strip())
+    assert payload["level"] == "INFO"
+    assert payload["name"] == "test.json"
+    assert payload["msg"] == "hello world"
+
+
+def test_json_formatter_serializes_exceptions() -> None:
+    stream = io.StringIO()
+    logger = setup_logging(name="test.exc", stream=stream, formatter="json")
+
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError:
+        logger.exception("captured")
+
+    payload = json.loads(stream.getvalue().strip())
+    assert payload["msg"] == "captured"
+    assert "RuntimeError: boom" in payload["exc_info"]
+
+
+def test_json_formatter_preserves_custom_attributes() -> None:
+    stream = io.StringIO()
+    logger = setup_logging(name="test.extra", stream=stream, formatter="json")
+
+    logger.info("hello", extra={"context": "value"})
+
+    payload = json.loads(stream.getvalue().strip())
+    assert payload["context"] == "value"
+
+
+def test_setup_logging_accepts_formatter_instances() -> None:
+    stream = io.StringIO()
+    formatter = JsonFormatter()
+    logger = setup_logging(name="test.instance", stream=stream, formatter=formatter)
+
+    logger.warning("warn")
+
+    payload = json.loads(stream.getvalue().strip())
+    assert payload["level"] == "WARNING"
+
+
+def test_setup_logging_accepts_string_format_specifier() -> None:
+    stream = io.StringIO()
+    logger = setup_logging(name="test.format", stream=stream, formatter="%(message)s")
+
+    logger.info("plain text")
+
+    assert stream.getvalue().strip() == "plain text"
+
+
+@pytest.mark.parametrize("level", ["info", "INFO", logging.INFO])
+def test_setup_logging_accepts_various_level_types(level: int | str) -> None:
+    stream = io.StringIO()
+    logger = setup_logging(name="test.level", stream=stream, level=level)
+
+    logger.info("hi")
+
+    assert "hi" in stream.getvalue()

--- a/tradingbot_core/logging_setup.py
+++ b/tradingbot_core/logging_setup.py
@@ -1,13 +1,71 @@
 """Centralised logging helpers used across services and scripts."""
 from __future__ import annotations
 
-from logging import Formatter, Logger, StreamHandler, getLogger
+import json
 import logging
-from pathlib import Path
-from typing import IO
 import sys
+from logging import Formatter, Logger, StreamHandler, getLogger
+from pathlib import Path
+from typing import IO, Any, Mapping
 
 DEFAULT_LOG_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+
+
+class JsonFormatter(Formatter):
+    """Serialize log records as JSON objects."""
+
+    #: Fields that are part of the :class:`logging.LogRecord` protocol that we
+    #: do not want to expose in the JSON payload.
+    _RESERVED_FIELDS = {
+        "args",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "stacklevel",
+        "thread",
+        "threadName",
+        "taskName",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "level": record.levelname,
+            "name": record.name,
+            "msg": record.getMessage(),
+        }
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        if record.stack_info:
+            payload["stack_info"] = record.stack_info
+
+        payload.update(self._extra_payload(record))
+        return json.dumps(payload, default=str)
+
+    def _extra_payload(self, record: logging.LogRecord) -> Mapping[str, Any]:
+        """Extract custom attributes added via ``LoggerAdapter`` or ``extra``."""
+
+        custom_fields: dict[str, Any] = {}
+        for key, value in record.__dict__.items():
+            if key.startswith("_") or key in self._RESERVED_FIELDS:
+                continue
+            custom_fields[key] = value
+        return custom_fields
 
 
 def setup_logging(
@@ -16,7 +74,7 @@ def setup_logging(
     level: int | str = logging.INFO,
     stream: IO[str] | None = None,
     log_path: str | Path | None = None,
-    formatter: Formatter | None = None,
+    formatter: Formatter | str | None = None,
     propagate: bool = False,
 ) -> Logger:
     """Configure and return a logger instance.
@@ -27,11 +85,15 @@ def setup_logging(
     """
 
     logger = getLogger(name)
+
+    if isinstance(level, str):
+        level = level.upper()
+
     logger.setLevel(level)
     logger.handlers.clear()
     logger.propagate = propagate
 
-    chosen_formatter = formatter or Formatter(DEFAULT_LOG_FORMAT)
+    chosen_formatter = _choose_formatter(formatter)
 
     stream_handler = StreamHandler(stream or sys.stdout)
     stream_handler.setFormatter(chosen_formatter)
@@ -45,4 +107,17 @@ def setup_logging(
     return logger
 
 
-__all__ = ["setup_logging", "DEFAULT_LOG_FORMAT"]
+def _choose_formatter(formatter: Formatter | str | None) -> Formatter:
+    if formatter is None:
+        return Formatter(DEFAULT_LOG_FORMAT)
+
+    if isinstance(formatter, Formatter):
+        return formatter
+
+    if formatter.lower() == "json":
+        return JsonFormatter()
+
+    return Formatter(formatter)
+
+
+__all__ = ["setup_logging", "DEFAULT_LOG_FORMAT", "JsonFormatter"]


### PR DESCRIPTION
## Summary
- add a JsonFormatter helper to emit structured JSON log entries while preserving custom fields
- update setup_logging to normalise string log levels and accept formatter specifiers, including the JSON formatter
- add unit tests that cover the new logging functionality and ensure compatibility with existing behaviours

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de0aa38b60832c9cece7d72bb816be