### PR TITLE
Expose config helper loaders and add tests

### DIFF
--- a/tests/test_tradingbot_core_config_loaders.py
+++ b/tests/test_tradingbot_core_config_loaders.py
@@ -1,0 +1,17 @@
+"""Tests for convenience configuration loader helpers."""
+
+from tradingbot_core.config import load_env_config, load_strategy_config
+
+
+def test_env_load_includes_identifier() -> None:
+    cfg = load_env_config("paper")
+
+    assert cfg["env"] == "paper"
+    assert cfg["name"] == "paper"
+
+
+def test_strategy_load_contains_expected_fields() -> None:
+    strategy = load_strategy_config("sample_meanrev")
+
+    assert strategy["name"] == "sample_meanrev"
+    assert "entry_z" in strategy

--- a/tradingbot_core/config/__init__.py
+++ b/tradingbot_core/config/__init__.py
@@ -141,4 +141,45 @@ def load_config(env_name: str, strategy_name: str, *, config_dir: str | Path | N
     return ConfigBundle(env=env_config, strategy=strategy_config, fees=fees_config, runtime=runtime)
 
 
-__all__ = ["ConfigBundle", "load_config"]
+def load_env_config(env_name: str, *, config_dir: str | Path | None = None) -> dict[str, Any]:
+    """Load an environment configuration mapping.
+
+    Parameters
+    ----------
+    env_name:
+        Identifier of the environment configuration file to load.
+    config_dir:
+        Optional alternative configuration root directory. When omitted the
+        package's default ``config`` directory is used.
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed configuration mapping containing at least an ``"env"`` key with
+        the requested ``env_name``.
+    """
+
+    base_dir = Path(config_dir) if config_dir else _CONFIG_ROOT
+    env_config = _load_yaml(base_dir / "env" / f"{env_name}.yaml")
+
+    if "env" not in env_config:
+        # Preserve the original mapping while guaranteeing callers can rely on
+        # the presence of the environment identifier.
+        env_config = {"env": env_name, **env_config}
+
+    return env_config
+
+
+def load_strategy_config(strategy_name: str, *, config_dir: str | Path | None = None) -> dict[str, Any]:
+    """Load a strategy configuration mapping."""
+
+    base_dir = Path(config_dir) if config_dir else _CONFIG_ROOT
+    return _load_yaml(base_dir / "strategy" / f"{strategy_name}.yaml")
+
+
+__all__ = [
+    "ConfigBundle",
+    "load_config",
+    "load_env_config",
+    "load_strategy_config",
+]


### PR DESCRIPTION
## Summary
- add helper functions in `tradingbot_core.config` to load environment and strategy mappings
- ensure the environment loader injects the environment identifier for callers
- cover the new helpers with targeted unit tests

## Testing
- pytest tests/test_tradingbot_core_config_loaders.py

------
https://chatgpt.com/codex/tasks/task_e_68de159e9420832c88407208b315bf81