### PR TITLE
Add risk limit evaluation to reconciler and server metadata

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -3,24 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import yaml
-from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from tradingbot_core.config import AppSettings
 
 
 # The repository root is two levels up from this file (``src/settings.py``).
 ROOT = Path(__file__).resolve().parents[1]
-
-
-class AppSettings(BaseSettings):
-    """Typed runtime settings sourced from environment variables."""
-
-    TB_MODE: Literal["paper", "live"] = "paper"
-    BROKER: str = "IBKR"
-    LOG_LEVEL: str = "INFO"
-
-    model_config = SettingsConfigDict(env_file=ROOT / ".env", case_sensitive=False)
 
 
 def load_yaml(path: Path) -> dict[str, Any]:

--- a/tests/test_reconciler_risk.py
+++ b/tests/test_reconciler_risk.py
@@ -1,0 +1,45 @@
+"""Tests for the reconciliation risk helpers."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from tradingbot_ibkr.execution import PaperBroker, Reconciler, RiskEvaluation, RiskLimits
+
+
+def test_risk_limits_validate_inputs() -> None:
+    with pytest.raises(ValueError):
+        RiskLimits(max_daily_loss_pct=-1.0, kill_switch_drawdown_pct=5.0, max_position_risk_pct=1.0)
+
+
+def test_evaluate_risk_triggers_breaches(caplog: pytest.LogCaptureFixture) -> None:
+    broker = PaperBroker()
+    limits = RiskLimits(max_daily_loss_pct=3.0, kill_switch_drawdown_pct=8.0, max_position_risk_pct=1.0)
+    reconciler = Reconciler(broker, limits=limits, logger=logging.getLogger("test.reconciler"))
+
+    with caplog.at_level(logging.WARNING, logger="test.reconciler"):
+        evaluation = reconciler.evaluate_risk(
+            daily_loss_pct=4.0,
+            drawdown_pct=2.0,
+            position_risk_pct=0.5,
+        )
+
+    assert isinstance(evaluation, RiskEvaluation)
+    assert evaluation.breached_limits == ("max_daily_loss_pct",)
+    assert evaluation.kill_switch_triggered
+    assert "Risk limits breached" in caplog.text
+
+
+def test_evaluate_risk_without_limits() -> None:
+    reconciler = Reconciler(PaperBroker())
+
+    evaluation = reconciler.evaluate_risk(
+        daily_loss_pct=10.0,
+        drawdown_pct=10.0,
+        position_risk_pct=2.0,
+    )
+
+    assert evaluation.breached_limits == ()
+    assert not evaluation.kill_switch_triggered

--- a/tradingbot_core/config/__init__.py
+++ b/tradingbot_core/config/__init__.py
@@ -1,14 +1,26 @@
-"""Configuration loader that stitches together environment, strategy, and fee profiles."""
+"""Configuration helpers used by services across the trading bot platform."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 import os
 
 import yaml
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
-_CONFIG_ROOT = Path(__file__).resolve().parents[2] / "config"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_ROOT = _REPO_ROOT / "config"
+
+
+class AppSettings(BaseSettings):
+    """Typed runtime settings sourced from environment variables."""
+
+    TB_MODE: Literal["paper", "live"] = "paper"
+    BROKER: str = "IBKR"
+    LOG_LEVEL: str = "INFO"
+
+    model_config = SettingsConfigDict(env_file=_REPO_ROOT / ".env", case_sensitive=False)
 
 
 def _coerce_int(value: str | None) -> int | str | None:
@@ -141,4 +153,4 @@ def load_config(env_name: str, strategy_name: str, *, config_dir: str | Path | N
     return ConfigBundle(env=env_config, strategy=strategy_config, fees=fees_config, runtime=runtime)
 
 
-__all__ = ["ConfigBundle", "load_config"]
+__all__ = ["AppSettings", "ConfigBundle", "load_config"]

--- a/tradingbot_ibkr/execution/__init__.py
+++ b/tradingbot_ibkr/execution/__init__.py
@@ -2,7 +2,7 @@
 
 from .broker_base import BrokerBase, Order, Position
 from .paper_broker import PaperBroker
-from .reconciler import ReconciliationReport, Reconciler
+from .reconciler import ReconciliationReport, Reconciler, RiskEvaluation, RiskLimits
 
 __all__ = [
     "BrokerBase",
@@ -11,4 +11,6 @@ __all__ = [
     "PaperBroker",
     "ReconciliationReport",
     "Reconciler",
+    "RiskEvaluation",
+    "RiskLimits",
 ]

--- a/tradingbot_ibkr/execution/reconciler.py
+++ b/tradingbot_ibkr/execution/reconciler.py
@@ -1,11 +1,54 @@
-"""Utilities to compare local state with broker state."""
+"""Utilities to compare local state with broker state and enforce risk limits."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Iterable, Mapping, MutableMapping
+from typing import Iterable, Mapping, MutableMapping, Sequence
+import logging
 
 from .broker_base import BrokerBase, Order, Position
+
+
+@dataclass(frozen=True)
+class RiskLimits:
+    """Container describing the risk thresholds enforced by the reconciler."""
+
+    max_daily_loss_pct: float
+    kill_switch_drawdown_pct: float
+    max_position_risk_pct: float
+
+    def __post_init__(self) -> None:  # pragma: no cover - small validation helper
+        for name, value in (
+            ("max_daily_loss_pct", self.max_daily_loss_pct),
+            ("kill_switch_drawdown_pct", self.kill_switch_drawdown_pct),
+            ("max_position_risk_pct", self.max_position_risk_pct),
+        ):
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative")
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "max_daily_loss_pct": self.max_daily_loss_pct,
+            "kill_switch_drawdown_pct": self.kill_switch_drawdown_pct,
+            "max_position_risk_pct": self.max_position_risk_pct,
+        }
+
+
+@dataclass(frozen=True)
+class RiskEvaluation:
+    """Outcome of assessing account state against configured risk limits."""
+
+    daily_loss_pct: float
+    drawdown_pct: float
+    position_risk_pct: float
+    breached_limits: Sequence[str] = ()
+
+    @property
+    def kill_switch_triggered(self) -> bool:
+        return any(
+            limit in {"max_daily_loss_pct", "kill_switch_drawdown_pct"}
+            for limit in self.breached_limits
+        )
 
 
 @dataclass(frozen=True)
@@ -22,9 +65,18 @@ class ReconciliationReport:
 
 
 class Reconciler:
-    def __init__(self, broker: BrokerBase, *, quantity_tolerance: float = 1e-6) -> None:
+    def __init__(
+        self,
+        broker: BrokerBase,
+        *,
+        quantity_tolerance: float = 1e-6,
+        limits: RiskLimits | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
         self._broker = broker
         self._quantity_tolerance = quantity_tolerance
+        self._limits = limits
+        self._logger = logger or logging.getLogger(__name__)
 
     def _coerce_orders(self, orders: Iterable[Order] | Mapping[str, Order]) -> MutableMapping[str, Order]:
         if isinstance(orders, Mapping):
@@ -75,5 +127,43 @@ class Reconciler:
             position_deltas=position_deltas,
         )
 
+    def evaluate_risk(
+        self,
+        *,
+        daily_loss_pct: float,
+        drawdown_pct: float,
+        position_risk_pct: float,
+    ) -> RiskEvaluation:
+        """Compare metrics against configured limits and log any breaches."""
 
-__all__ = ["ReconciliationReport", "Reconciler"]
+        limits = self._limits
+        breached: list[str] = []
+
+        if limits:
+            if daily_loss_pct > limits.max_daily_loss_pct:
+                breached.append("max_daily_loss_pct")
+            if drawdown_pct > limits.kill_switch_drawdown_pct:
+                breached.append("kill_switch_drawdown_pct")
+            if position_risk_pct > limits.max_position_risk_pct:
+                breached.append("max_position_risk_pct")
+
+            if breached:
+                self._logger.warning(
+                    "Risk limits breached",
+                    extra={
+                        "breached_limits": tuple(breached),
+                        "daily_loss_pct": daily_loss_pct,
+                        "drawdown_pct": drawdown_pct,
+                        "position_risk_pct": position_risk_pct,
+                    },
+                )
+
+        return RiskEvaluation(
+            daily_loss_pct=daily_loss_pct,
+            drawdown_pct=drawdown_pct,
+            position_risk_pct=position_risk_pct,
+            breached_limits=tuple(breached),
+        )
+
+
+__all__ = ["RiskLimits", "RiskEvaluation", "ReconciliationReport", "Reconciler"]

--- a/tradingbot_ibkr/server.py
+++ b/tradingbot_ibkr/server.py
@@ -2,44 +2,115 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Mapping
 import os
 
 from fastapi import FastAPI
 
-from tradingbot_core.config import load_config
+from tradingbot_core.config import AppSettings, ConfigBundle, load_config
 from tradingbot_core.logging_setup import setup_logging
+from tradingbot_ibkr.execution import BrokerBase, PaperBroker, Reconciler, RiskLimits
 
-_DEFAULT_ENV = os.getenv("TRADINGBOT_ENV", "paper")
-_DEFAULT_STRATEGY = os.getenv("TRADINGBOT_STRATEGY", "sample_meanrev")
 _START_TIME = datetime.now(timezone.utc)
 
 
-def _build_meta_payload(env_name: str, strategy_name: str) -> dict[str, object]:
+def _risk_limits_from_bundle(bundle: ConfigBundle) -> RiskLimits | None:
+    risk_cfg = bundle.env.get("risk") or {}
+    required_keys = {"max_daily_loss_pct", "kill_switch_drawdown_pct", "max_position_risk_pct"}
+    if not required_keys.issubset(risk_cfg):
+        return None
+    try:
+        return RiskLimits(
+            max_daily_loss_pct=float(risk_cfg["max_daily_loss_pct"]),
+            kill_switch_drawdown_pct=float(risk_cfg["kill_switch_drawdown_pct"]),
+            max_position_risk_pct=float(risk_cfg["max_position_risk_pct"]),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_meta_payload(
+    env_name: str,
+    strategy_name: str,
+    *,
+    settings: AppSettings | None = None,
+    overrides: Mapping[str, object] | None = None,
+) -> dict[str, object]:
     bundle = load_config(env_name, strategy_name)
     now = datetime.now(timezone.utc)
-    return {
+    payload: dict[str, object] = {
         "environment": bundle.env.get("name", env_name),
         "strategy": bundle.strategy.get("name", strategy_name),
         "fees": bundle.fees,
         "config": bundle.as_dict(),
         "started_at": _START_TIME.isoformat(),
         "uptime_seconds": (now - _START_TIME).total_seconds(),
+        "version": "0.1.0",
     }
 
+    if settings is not None:
+        payload["runtime"] = {"mode": settings.TB_MODE, "broker": settings.BROKER}
 
-def create_app() -> FastAPI:
-    setup_logging(name="tradingbot_ibkr.server")
+    limits = _risk_limits_from_bundle(bundle)
+    if limits:
+        payload["risk_limits"] = limits.as_dict()
+
+    if overrides:
+        payload.update(overrides)
+
+    return payload
+
+
+def create_app(
+    *,
+    env_name: str | None = None,
+    strategy_name: str | None = None,
+    broker: BrokerBase | None = None,
+    limits: RiskLimits | None = None,
+) -> FastAPI:
+    settings = AppSettings()
+    logger = setup_logging(name="tradingbot_ibkr.server", level=settings.LOG_LEVEL)
+
+    default_env = env_name or os.getenv("TRADINGBOT_ENV", settings.TB_MODE)
+    default_strategy = strategy_name or os.getenv("TRADINGBOT_STRATEGY", "sample_meanrev")
+
+    bundle = load_config(default_env, default_strategy)
+    resolved_limits = limits or _risk_limits_from_bundle(bundle)
+
+    broker_impl = broker or PaperBroker()
+    reconciler = Reconciler(broker_impl, limits=resolved_limits, logger=logger)
+
     app = FastAPI(title="Trading Bot IBKR", version="0.1.0")
+    app.state.settings = settings
+    app.state.reconciler = reconciler
+    app.state.broker = broker_impl
+    app.state.default_env = default_env
+    app.state.default_strategy = default_strategy
+    app.state.risk_limits = resolved_limits
 
     @app.get("/health")
+    @app.get("/healthz")
     def healthcheck() -> dict[str, str]:
         return {"status": "ok"}
 
     @app.get("/meta")
     def meta(env: str | None = None, strategy: str | None = None) -> dict[str, object]:
-        env_name = env or _DEFAULT_ENV
-        strategy_name = strategy or _DEFAULT_STRATEGY
-        return _build_meta_payload(env_name, strategy_name)
+        env_name = env or app.state.default_env
+        strategy_name = strategy or app.state.default_strategy
+
+        overrides: dict[str, object] = {}
+        limits_for_payload = (
+            app.state.risk_limits.as_dict() if app.state.risk_limits else None
+        )
+        if limits_for_payload:
+            overrides.setdefault("risk_limits", limits_for_payload)
+
+        return _build_meta_payload(
+            env_name,
+            strategy_name,
+            settings=app.state.settings,
+            overrides=overrides,
+        )
 
     return app
 


### PR DESCRIPTION
## Summary
- centralize the AppSettings model in tradingbot_core and reuse it from the FastAPI server
- extend the IBKR reconciler with RiskLimits/Evaluation helpers and logging when limits breach
- expose broker, runtime, and risk limit metadata via the IBKR FastAPI app and add focused tests

## Testing
- pytest tests/test_reconciler_risk.py

------
https://chatgpt.com/codex/tasks/task_e_68de15539f30832cafa78634be156754