### PR TITLE
Make reconciler compatible with legacy broker API

### DIFF
--- a/brokers/__init__.py
+++ b/brokers/__init__.py
@@ -1,4 +1,6 @@
 """Broker implementations and abstractions."""
 from .broker_base import Broker
 from .alpaca_broker import AlpacaBroker
-__all__ = ["Broker", "AlpacaBroker"]
+from .reconciler import Reconciler, RiskLimits
+
+__all__ = ["Broker", "AlpacaBroker", "Reconciler", "RiskLimits"]

--- a/brokers/reconciler.py
+++ b/brokers/reconciler.py
@@ -1,0 +1,177 @@
+"""Utilities for reconciling intended orders with broker state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from .broker_base import Broker
+from models import OrderRequest, OrderStatus
+
+_TERMINAL_STATUSES = {
+    "FILLED",
+    "CANCELED",
+    "CANCELLED",
+    "REJECTED",
+    "DONE",
+    "EXPIRED",
+}
+
+
+@dataclass(slots=True)
+class RiskLimits:
+    """Configuration for broker level risk controls."""
+
+    max_daily_loss_pct: float
+    kill_switch_drawdown_pct: float
+    max_position_risk_pct: float
+
+
+class Reconciler:
+    """Synchronise the intended orders with the broker state."""
+
+    def __init__(
+        self,
+        broker: Broker,
+        limits: RiskLimits,
+        logger,
+        *,
+        account_id: str | None = None,
+    ) -> None:
+        self.broker = broker
+        self.account_id = account_id
+        self.limits = limits
+        self.log = logger
+
+    # ---------------------------------------------------------------------
+    # Broker helpers
+    # ------------------------------------------------------------------
+    def _place(self, order: OrderRequest | Mapping[str, Any] | object) -> OrderStatus:
+        """Submit ``order`` via whichever broker API is available."""
+
+        if hasattr(self.broker, "place_order"):
+            account_id = "" if self.account_id is None else self.account_id
+            return self.broker.place_order(account_id, order)  # type: ignore[arg-type]
+
+        if hasattr(self.broker, "place"):
+            # Legacy interface used by older broker implementations.
+            return self.broker.place(order)  # type: ignore[attr-defined]
+
+        raise AttributeError("Broker does not expose place_order/place")
+
+    def _list_orders(self) -> Sequence[OrderStatus] | Iterable[OrderStatus]:
+        if hasattr(self.broker, "list_orders"):
+            account_id = "" if self.account_id is None else self.account_id
+            return self.broker.list_orders(account_id)  # type: ignore[attr-defined]
+
+        if hasattr(self.broker, "fetch_open_orders"):
+            return self.broker.fetch_open_orders()  # type: ignore[attr-defined]
+
+        raise NotImplementedError("Broker cannot provide open orders")
+
+    def _list_positions(self) -> Sequence[object] | Iterable[object]:
+        if hasattr(self.broker, "get_positions"):
+            account_id = "" if self.account_id is None else self.account_id
+            return self.broker.get_positions(account_id)  # type: ignore[attr-defined]
+
+        if hasattr(self.broker, "fetch_positions"):
+            return self.broker.fetch_positions()  # type: ignore[attr-defined]
+
+        raise NotImplementedError("Broker cannot provide positions")
+
+    # ------------------------------------------------------------------
+    def submit_idempotent(self, order: OrderRequest | Mapping[str, Any] | object) -> OrderStatus:
+        """Submit ``order`` while avoiding duplicate broker entries."""
+
+        status = self._place(order)
+        status_desc = None
+        client_id = None
+
+        if isinstance(status, Mapping):
+            status_desc = status.get("status") or status.get("state")
+            client_id = status.get("client_order_id") or status.get("client_id")
+        else:
+            status_desc = getattr(status, "status", None) or getattr(status, "state", None)
+            client_id = getattr(status, "client_order_id", None) or getattr(status, "client_id", None)
+
+        self.log.info("submit_idempotent: status=%s id=%s", status_desc, client_id)
+        return status
+
+    @staticmethod
+    def _order_key(order: OrderRequest | OrderStatus | Mapping[str, object]) -> str | None:
+        """Return the preferred reconciliation key for an order-like payload."""
+
+        # Support explicit idempotency hints provided either as attributes or via mappings.
+        id_fields = ("idempotency_key", "idemp_key", "client_order_id", "client_id")
+
+        if isinstance(order, Mapping):
+            for field in id_fields:
+                value = order.get(field)
+                if value:
+                    return str(value)
+            return None
+
+        meta = getattr(order, "meta", None)
+        if isinstance(meta, Mapping):
+            for field in id_fields:
+                value = meta.get(field)
+                if value:
+                    return str(value)
+
+        for field in ("idemp_key", "client_id", "client_order_id"):
+            value = getattr(order, field, None)
+            if value:
+                return str(value)
+
+        return None
+
+    def reconcile(self, intended_orders: Iterable[OrderRequest]) -> None:
+        """Compare intended state vs broker state and heal any drift."""
+
+        try:
+            broker_orders = self._list_orders()
+        except NotImplementedError:
+            broker_orders = ()
+
+        open_now: dict[str, OrderStatus] = {}
+        for broker_order in broker_orders:
+            if isinstance(broker_order, Mapping):
+                status_value = broker_order.get("status") or broker_order.get("state")
+            else:
+                status_value = getattr(broker_order, "status", None) or getattr(broker_order, "state", None)
+
+            if isinstance(status_value, str) and status_value.upper() in _TERMINAL_STATUSES:
+                continue
+
+            key = self._order_key(broker_order)
+            if key is not None:
+                open_now[key] = broker_order
+
+        try:
+            positions = tuple(self._list_positions())
+        except NotImplementedError:
+            positions = ()
+        self.log.info("reconcile: open=%d positions=%s", len(open_now), positions)
+
+        for order in intended_orders:
+            key = self._order_key(order)
+            if key is None or key not in open_now:
+                self.submit_idempotent(order)
+
+    def check_kill_switch(self, equity_curve: list[float]) -> bool:
+        """Return ``True`` when the drawdown breaches the configured limit."""
+
+        if not equity_curve:
+            return False
+
+        equity = equity_curve[-1]
+        peak = max(equity_curve)
+        drawdown_pct = 100.0 * (1 - equity / peak) if peak > 0 else 0.0
+        if drawdown_pct >= self.limits.kill_switch_drawdown_pct:
+            self.log.error("KILL SWITCH TRIGGERED: drawdown %.2f%%", drawdown_pct)
+            return True
+        return False
+
+
+__all__ = ["RiskLimits", "Reconciler"]
+

--- a/tests/test_broker_reconciler.py
+++ b/tests/test_broker_reconciler.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+from brokers.broker_base import Broker
+from brokers.reconciler import Reconciler, RiskLimits
+from models import OrderRequest, OrderStatus, OrderType, Side, TimeInForce
+
+
+def _order_request(
+    *,
+    client_order_id: str | None,
+    symbol: str = "AAPL",
+    side: Side = Side.BUY,
+    qty: float = 1.0,
+    order_type: OrderType = OrderType.MARKET,
+    tif: TimeInForce = TimeInForce.DAY,
+) -> OrderRequest:
+    return OrderRequest(
+        symbol=symbol,
+        side=side,
+        qty=qty,
+        order_type=order_type,
+        tif=tif,
+        client_order_id=client_order_id,
+    )
+
+
+@dataclass
+class FakeBroker(Broker):
+    open_orders: List[OrderStatus] = field(default_factory=list)
+    positions: List[str] = field(default_factory=list)
+    submitted: List[OrderRequest] = field(default_factory=list)
+
+    def place_order(self, account_id: str, req: OrderRequest) -> OrderStatus:
+        self.submitted.append(req)
+        return OrderStatus(
+            broker="fake",
+            broker_order_id=f"order-{len(self.submitted)}",
+            client_order_id=req.client_order_id,
+            status="NEW",
+            filled_qty=0.0,
+            avg_price=None,
+            ts=0.0,
+            raw={},
+        )
+
+    def list_orders(self, account_id: str) -> Iterable[OrderStatus]:
+        return list(self.open_orders)
+
+    def get_positions(self, account_id: str) -> Iterable[str]:
+        return list(self.positions)
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, tuple[object, ...]]] = []
+
+    def info(self, message: str, *args: object) -> None:
+        self.messages.append((message, args))
+
+    def error(self, message: str, *args: object) -> None:
+        self.messages.append((message, args))
+
+
+def test_reconcile_ignores_orders_with_same_idempotency_key() -> None:
+    broker = FakeBroker(
+        open_orders=[
+            OrderStatus(
+                broker="fake",
+                broker_order_id="open-1",
+                client_order_id="abc",
+                status="NEW",
+                filled_qty=0.0,
+                avg_price=None,
+                ts=0.0,
+                raw={},
+            )
+        ]
+    )
+    reconciler = Reconciler(
+        broker,
+        limits=RiskLimits(max_daily_loss_pct=10, kill_switch_drawdown_pct=15, max_position_risk_pct=5),
+        logger=DummyLogger(),
+        account_id="acct",
+    )
+
+    reconciler.reconcile([_order_request(client_order_id="abc")])
+
+    assert broker.submitted == []
+
+
+def test_reconcile_submits_when_no_matching_idempotency_key() -> None:
+    broker = FakeBroker(
+        open_orders=[
+            OrderStatus(
+                broker="fake",
+                broker_order_id="open-1",
+                client_order_id="abc",
+                status="NEW",
+                filled_qty=0.0,
+                avg_price=None,
+                ts=0.0,
+                raw={},
+            )
+        ]
+    )
+    reconciler = Reconciler(
+        broker,
+        limits=RiskLimits(max_daily_loss_pct=10, kill_switch_drawdown_pct=15, max_position_risk_pct=5),
+        logger=DummyLogger(),
+        account_id="acct",
+    )
+
+    intended = _order_request(client_order_id="xyz")
+    reconciler.reconcile([intended])
+
+    assert broker.submitted == [intended]
+
+
+def test_reconcile_falls_back_to_client_id_when_idemp_key_missing() -> None:
+    broker = FakeBroker(
+        open_orders=[
+            OrderStatus(
+                broker="fake",
+                broker_order_id="open-1",
+                client_order_id="client-123",
+                status="NEW",
+                filled_qty=0.0,
+                avg_price=None,
+                ts=0.0,
+                raw={},
+            )
+        ]
+    )
+    reconciler = Reconciler(
+        broker,
+        limits=RiskLimits(max_daily_loss_pct=10, kill_switch_drawdown_pct=15, max_position_risk_pct=5),
+        logger=DummyLogger(),
+        account_id="acct",
+    )
+
+    reconciler.reconcile([_order_request(client_order_id="client-123")])
+
+    assert broker.submitted == []
+
+
+class LegacyBroker:
+    def __init__(self) -> None:
+        self.open_orders: list[dict[str, object]] = []
+        self.positions: list[str] = []
+        self.submitted: list[object] = []
+
+    def place(self, order: object) -> dict[str, object]:
+        self.submitted.append(order)
+        if isinstance(order, dict):
+            client_id = order.get("client_id") or order.get("client_order_id")
+        else:
+            client_id = getattr(order, "client_id", None) or getattr(order, "client_order_id", None)
+        return {
+            "status": "NEW",
+            "client_id": client_id,
+        }
+
+    def fetch_open_orders(self) -> list[dict[str, object]]:
+        return list(self.open_orders)
+
+    def fetch_positions(self) -> list[str]:
+        return list(self.positions)
+
+
+def test_reconcile_with_legacy_broker_interfaces() -> None:
+    broker = LegacyBroker()
+    broker.open_orders = [
+        {
+            "status": "NEW",
+            "client_id": "legacy-1",
+        }
+    ]
+    logger = DummyLogger()
+    reconciler = Reconciler(
+        broker,
+        limits=RiskLimits(max_daily_loss_pct=10, kill_switch_drawdown_pct=15, max_position_risk_pct=5),
+        logger=logger,
+    )
+
+    reconciler.reconcile([{"client_id": "legacy-1"}])
+
+    assert broker.submitted == []
+
+    reconciler.reconcile([{"client_id": "legacy-2"}])
+
+    assert broker.submitted[-1]["client_id"] == "legacy-2"
+
+    reconciler.reconcile([_order_request(client_order_id="legacy-3")])
+
+    assert getattr(broker.submitted[-1], "client_order_id", None) == "legacy-3"
+


### PR DESCRIPTION
## Summary
- extend the broker reconciler to work with both modern account-aware and legacy broker interfaces while preserving idempotent submissions
- improve reconciliation logging and order-key detection to tolerate different payload shapes
- expand the unit tests to cover legacy broker compatibility alongside the existing OrderRequest flows

## Testing
- pytest tests/test_broker_reconciler.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de0cedb028832ca114eef0af1980bc