### PR TITLE
Align reconciler with base broker contract

### DIFF
--- a/brokers/__init__.py
+++ b/brokers/__init__.py
@@ -1,4 +1,7 @@
 """Broker implementations and abstractions."""
-from .broker_base import Broker
+
 from .alpaca_broker import AlpacaBroker
-__all__ = ["Broker", "AlpacaBroker"]
+from .broker_base import Broker
+from .reconciler import Reconciler, RiskLimits
+
+__all__ = ["Broker", "AlpacaBroker", "Reconciler", "RiskLimits"]

--- a/brokers/reconciler.py
+++ b/brokers/reconciler.py
@@ -1,0 +1,144 @@
+"""Utilities for reconciling intended orders with broker state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from models import OrderRequest, OrderStatus, Position
+
+from .broker_base import Broker
+
+_TERMINAL_STATUSES = {
+    "FILLED",
+    "CANCELED",
+    "CANCELLED",
+    "REJECTED",
+    "DONE",
+    "EXPIRED",
+}
+
+
+@dataclass(slots=True)
+class RiskLimits:
+    """Configuration for broker level risk controls."""
+
+    max_daily_loss_pct: float
+    kill_switch_drawdown_pct: float
+    max_position_risk_pct: float
+
+
+class Reconciler:
+    """Synchronise the intended orders with the broker state."""
+
+    def __init__(
+        self,
+        broker: Broker,
+        limits: RiskLimits,
+        logger,
+        *,
+        account_id: str = "",
+    ) -> None:
+        self.broker = broker
+        self.account_id = account_id
+        self.limits = limits
+        self.log = logger
+
+    def _list_orders(self) -> Sequence[OrderStatus]:
+        """Return the broker's non-terminal orders for the configured account."""
+
+        try:
+            return self.broker.list_orders(self.account_id)
+        except NotImplementedError:
+            return ()
+
+    def _list_positions(self) -> Sequence[Position]:
+        """Return open positions for logging purposes."""
+
+        try:
+            return self.broker.get_positions(self.account_id)
+        except NotImplementedError:
+            return ()
+
+    @staticmethod
+    def _order_key(order: OrderRequest | OrderStatus | Mapping[str, object]) -> str | None:
+        """Return a reconciliation key for an order-like payload."""
+
+        id_fields = ("idempotency_key", "idemp_key", "client_order_id", "client_id")
+
+        if isinstance(order, Mapping):
+            for field in id_fields:
+                value = order.get(field)
+                if value:
+                    return str(value)
+            return None
+
+        meta = getattr(order, "meta", None)
+        if isinstance(meta, Mapping):
+            for field in id_fields:
+                value = meta.get(field)
+                if value:
+                    return str(value)
+
+        raw = getattr(order, "raw", None)
+        if isinstance(raw, Mapping):
+            for field in id_fields:
+                value = raw.get(field)
+                if value:
+                    return str(value)
+
+        for field in ("client_order_id", "client_id"):
+            value = getattr(order, field, None)
+            if value:
+                return str(value)
+
+        return None
+
+    def submit_idempotent(self, order: OrderRequest) -> OrderStatus:
+        """Submit ``order`` while avoiding duplicate broker entries."""
+
+        status = self.broker.place_order(self.account_id, order)
+        self.log.info(
+            "submit_idempotent: status=%s id=%s",
+            status.status,
+            status.client_order_id,
+        )
+        return status
+
+    def reconcile(self, intended_orders: Iterable[OrderRequest]) -> None:
+        """Compare intended state vs broker state and heal any drift."""
+
+        open_now: dict[str, OrderStatus] = {}
+        for broker_order in self._list_orders():
+            status_value = broker_order.status
+            if isinstance(status_value, str) and status_value.upper() in _TERMINAL_STATUSES:
+                continue
+
+            key = self._order_key(broker_order)
+            if key is not None:
+                open_now[key] = broker_order
+
+        positions = tuple(self._list_positions())
+        self.log.info("reconcile: open=%d positions=%s", len(open_now), positions)
+
+        for order in intended_orders:
+            key = self._order_key(order)
+            if key is None or key not in open_now:
+                self.submit_idempotent(order)
+
+    def check_kill_switch(self, equity_curve: list[float]) -> bool:
+        """Return ``True`` when the drawdown breaches the configured limit."""
+
+        if not equity_curve:
+            return False
+
+        equity = equity_curve[-1]
+        peak = max(equity_curve)
+        drawdown_pct = 100.0 * (1 - equity / peak) if peak > 0 else 0.0
+        if drawdown_pct >= self.limits.kill_switch_drawdown_pct:
+            self.log.error("KILL SWITCH TRIGGERED: drawdown %.2f%%", drawdown_pct)
+            return True
+        return False
+
+
+__all__ = ["RiskLimits", "Reconciler"]

--- a/tests/test_broker_reconciler.py
+++ b/tests/test_broker_reconciler.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+from brokers.broker_base import Broker
+from brokers.reconciler import Reconciler, RiskLimits
+from models import OrderRequest, OrderStatus, OrderType, Position, Side, TimeInForce
+
+
+def _order_request(
+    *,
+    client_order_id: str | None,
+    symbol: str = "AAPL",
+    side: Side = Side.BUY,
+    qty: float = 1.0,
+    order_type: OrderType = OrderType.MARKET,
+    tif: TimeInForce = TimeInForce.DAY,
+    meta: dict[str, object] | None = None,
+) -> OrderRequest:
+    return OrderRequest(
+        symbol=symbol,
+        side=side,
+        qty=qty,
+        order_type=order_type,
+        tif=tif,
+        client_order_id=client_order_id,
+        meta=meta,
+    )
+
+
+@dataclass
+class FakeBroker(Broker):
+    open_orders: List[OrderStatus] = field(default_factory=list)
+    positions: List[Position] = field(default_factory=list)
+    submitted: List[OrderRequest] = field(default_factory=list)
+
+    def place_order(self, account_id: str, req: OrderRequest) -> OrderStatus:
+        self.submitted.append(req)
+        return OrderStatus(
+            broker="fake",
+            broker_order_id=f"order-{len(self.submitted)}",
+            client_order_id=req.client_order_id,
+            status="NEW",
+            filled_qty=0.0,
+            avg_price=None,
+            ts=0.0,
+            raw={},
+        )
+
+    def list_orders(self, account_id: str) -> Iterable[OrderStatus]:
+        return list(self.open_orders)
+
+    def get_positions(self, account_id: str) -> Iterable[Position]:
+        return list(self.positions)
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, tuple[object, ...]]] = []
+
+    def info(self, message: str, *args: object) -> None:
+        self.messages.append((message, args))
+
+    def error(self, message: str, *args: object) -> None:
+        self.messages.append((message, args))
+
+
+def test_reconcile_skips_orders_with_matching_key() -> None:
+    broker = FakeBroker(
+        open_orders=[
+            OrderStatus(
+                broker="fake",
+                broker_order_id="open-1",
+                client_order_id="abc",
+                status="NEW",
+                filled_qty=0.0,
+                avg_price=None,
+                ts=0.0,
+                raw={},
+            )
+        ]
+    )
+    reconciler = Reconciler(
+        broker,
+        limits=RiskLimits(max_daily_loss_pct=10, kill_switch_drawdown_pct=15, max_position_risk_pct=5),
+        logger=DummyLogger(),
+        account_id="acct",
+    )
+
+    reconciler.reconcile([_order_request(client_order_id="abc")])
+
+    assert broker.submitted == []
+
+
+def test_reconcile_submits_missing_orders() -> None:
+    broker = FakeBroker(
+        open_orders=[
+            OrderStatus(
+                broker="fake",
+                broker_order_id="open-1",
+                client_order_id="abc",
+                status="NEW",
+                filled_qty=0.0,
+                avg_price=None,
+                ts=0.0,
+                raw={},
+            )
+        ]
+    )
+    reconciler = Reconciler(
+        broker,
+        limits=RiskLimits(max_daily_loss_pct=10, kill_switch_drawdown_pct=15, max_position_risk_pct=5),
+        logger=DummyLogger(),
+        account_id="acct",
+    )
+
+    intended = _order_request(client_order_id="xyz")
+    reconciler.reconcile([intended])
+
+    assert broker.submitted == [intended]
+
+
+def test_reconcile_matches_meta_idempotency_key() -> None:
+    broker = FakeBroker(
+        open_orders=[
+            OrderStatus(
+                broker="fake",
+                broker_order_id="open-1",
+                client_order_id=None,
+                status="NEW",
+                filled_qty=0.0,
+                avg_price=None,
+                ts=0.0,
+                raw={"idempotency_key": "meta-1"},
+            )
+        ]
+    )
+    reconciler = Reconciler(
+        broker,
+        limits=RiskLimits(max_daily_loss_pct=10, kill_switch_drawdown_pct=15, max_position_risk_pct=5),
+        logger=DummyLogger(),
+        account_id="acct",
+    )
+
+    reconciler.reconcile([
+        _order_request(client_order_id=None, meta={"idempotency_key": "meta-1"})
+    ])
+
+    assert broker.submitted == []
+
+
+def test_check_kill_switch_triggers_on_drawdown() -> None:
+    logger = DummyLogger()
+    reconciler = Reconciler(
+        FakeBroker(),
+        limits=RiskLimits(max_daily_loss_pct=10, kill_switch_drawdown_pct=15, max_position_risk_pct=5),
+        logger=logger,
+        account_id="acct",
+    )
+
+    assert not reconciler.check_kill_switch([100_000.0, 105_000.0, 100_000.0])
+    assert reconciler.check_kill_switch([100_000.0, 110_000.0, 90_000.0])


### PR DESCRIPTION
## Summary
- expose the reconciler utilities directly from the brokers package to match main
- rebuild the reconciler around the standard Broker.place_order, list_orders, and get_positions interfaces while keeping idempotent submissions and kill switch checks
- refresh the reconciler unit tests to cover meta idempotency keys and drawdown handling

## Testing
- pytest tests/test_broker_reconciler.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de0cedb028832ca114eef0af1980bc