### PR TITLE
Capture environment metadata when saving backtest results

### DIFF
--- a/tests/test_backtest_harness.py
+++ b/tests/test_backtest_harness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import platform
 from pathlib import Path
 
 from tradingbot_core.backtest_harness import BacktestContext, BacktestHarness
@@ -37,13 +38,20 @@ def test_backtest_harness_persists_metrics(tmp_path: Path) -> None:
 
     payload = json.loads(output_path.read_text())
 
-    assert payload["metadata"]["strategy"] == "mean_reversion"
-    assert payload["metadata"]["fees"] == {"maker": 0.0005}
-    assert payload["metadata"]["seed"] == 1337
-    assert payload["metadata"]["captured_at"] == 123.0
+    assert payload["meta"]["git_sha"] == "<local>"
+    assert payload["meta"]["python"] == platform.python_version()
+    assert isinstance(payload["meta"]["deps"], str)
+    assert payload["meta"]["timestamp"].endswith("Z") or payload["meta"]["timestamp"].endswith("+00:00")
 
-    metrics = payload["result"]["metrics"]
+    results = payload["results"]
+
+    assert results["metadata"]["strategy"] == "mean_reversion"
+    assert results["metadata"]["fees"] == {"maker": 0.0005}
+    assert results["metadata"]["seed"] == 1337
+    assert results["metadata"]["captured_at"] == 123.0
+
+    metrics = results["result"]["metrics"]
     assert set(metrics.keys()) == {"sharpe", "sortino", "max_drawdown", "cvar_95"}
     assert metrics["max_drawdown"] >= 0
 
-    assert payload["fees_paid"] == 12.5
+    assert results["fees_paid"] == 12.5

--- a/tradingbot_core/backtest_save.py
+++ b/tradingbot_core/backtest_save.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 import json
+import os
+import platform
+
+from .results import deps_fingerprint
 
 
 def _default_serializer(value: Any) -> Any:
@@ -36,8 +40,20 @@ def save_backtest_results(
     filename = f"{prefix}_{ts.strftime('%Y%m%dT%H%M%SZ')}.json"
     target = output_dir / filename
 
+    env_meta: MutableMapping[str, Any] = {
+        "git_sha": os.getenv("GITHUB_SHA", "<local>"),
+        "python": platform.python_version(),
+        "deps": deps_fingerprint(),
+        "timestamp": ts.isoformat(),
+    }
+
+    payload = {
+        "meta": dict(env_meta),
+        "results": dict(results),
+    }
+
     with target.open("w", encoding="utf-8") as handle:
-        json.dump(results, handle, default=_default_serializer, indent=2, sort_keys=True)
+        json.dump(payload, handle, default=_default_serializer, indent=2, sort_keys=True)
         handle.write("\n")
 
     return target


### PR DESCRIPTION
## Summary
- capture git SHA, python version, dependency fingerprint and timestamp whenever backtest results are persisted
- wrap stored payloads in a meta/results structure while keeping existing result data intact
- update the backtest harness test to exercise the new metadata fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df67681d34832c905895d224a41bef