### PR TITLE
Enhance broker base primitives for reconciler tests

### DIFF
--- a/tradingbot_ibkr/execution/broker_base.py
+++ b/tradingbot_ibkr/execution/broker_base.py
@@ -1,13 +1,26 @@
-"""Abstract interfaces shared by execution back-ends."""
+"""Foundational data structures and protocols for the execution layer.
+
+The production code base contains substantially richer models, however the
+exercises in this kata only rely on a narrow subset of that functionality.  The
+lightweight implementations below focus on capturing the behaviour required by
+the reconciler tests while remaining convenient to use in the in-memory paper
+broker used throughout the suite.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Iterable, Mapping, Protocol
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Order:
-    """Represents a simplified order used by the reconciler."""
+    """Minimal representation of an order tracked by the reconciler.
+
+    The object purposely omits broker specific attributes and only models the
+    small set of fields that the tests exercise.  ``metadata`` acts as an escape
+    hatch so callers can attach additional context without having to extend the
+    dataclass.
+    """
 
     id: str
     symbol: str
@@ -19,11 +32,15 @@ class Order:
     metadata: Mapping[str, object] = field(default_factory=dict)
 
     def remaining(self) -> float:
+        """Return the amount of quantity that is yet to be filled."""
+
         return max(self.quantity - self.filled_quantity, 0.0)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Position:
+    """Simplified view of a broker position."""
+
     symbol: str
     quantity: float
     average_price: float | None = None
@@ -31,13 +48,13 @@ class Position:
 
 
 class BrokerBase(Protocol):
-    """Protocol describing the methods used by the reconciler."""
+    """Protocol describing the minimal broker surface consumed by the reconciler."""
 
     def list_open_orders(self) -> Iterable[Order]:
-        ...
+        """Return the currently open orders known to the broker."""
 
     def list_positions(self) -> Iterable[Position]:
-        ...
+        """Return the positions tracked by the broker."""
 
 
 __all__ = ["Order", "Position", "BrokerBase"]


### PR DESCRIPTION
## Summary
- expand the execution broker base module documentation for clarity
- enable slots on the lightweight Order and Position dataclasses used by tests
- document the BrokerBase protocol methods consumed by the reconciler

## Testing
- pytest tests/test_reconciler_orders.py

------
https://chatgpt.com/codex/tasks/task_e_68df679e221c832c947960c19727f83e