### PR TITLE
Add documentation for remote authentication setup

### DIFF
--- a/docs/remote_setup.md
+++ b/docs/remote_setup.md
@@ -1,0 +1,9 @@
+# Remote Authentication Setup
+
+To authenticate pushes to the target repository from a local checkout, update the `origin` remote to use a Personal Access Token (PAT):
+
+```bash
+git remote set-url origin https://x-access-token:${PAT_DATA_PUSH}@github.com/OWNER/REPO.git
+```
+
+Replace `PAT_DATA_PUSH` with an environment variable or inline token value that has the necessary permissions for the repository.


### PR DESCRIPTION
## Summary
- add a short guide describing how to configure the origin remote with a Personal Access Token for authentication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff0a10b10832ca7edbfc854c1d2dd