### PR TITLE
Add timestamps to JSON log output

### DIFF
--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+from datetime import datetime
 
 import pytest
 
@@ -17,6 +18,11 @@ def test_json_formatter_serializes_basic_fields() -> None:
     logger.info("hello world")
 
     payload = json.loads(stream.getvalue().strip())
+    # The JSON payload should include a timestamp formatted using the standard
+    # logging formatter.  ``datetime.strptime`` raises ``ValueError`` if the
+    # value does not match the expected format, which doubles as an assertion
+    # that the field is present and non-empty.
+    datetime.strptime(payload["timestamp"], "%Y-%m-%d %H:%M:%S,%f")
     assert payload["level"] == "INFO"
     assert payload["name"] == "test.json"
     assert payload["msg"] == "hello world"

--- a/tradingbot_core/logging_setup.py
+++ b/tradingbot_core/logging_setup.py
@@ -43,6 +43,7 @@ class JsonFormatter(Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         payload: dict[str, Any] = {
+            "timestamp": self.formatTime(record),
             "level": record.levelname,
             "name": record.name,
             "msg": record.getMessage(),


### PR DESCRIPTION
## Summary
- add the log record timestamp to the JSON formatter payload
- update the logging setup test suite to validate the timestamp field

## Testing
- pytest tests/test_logging_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68dff130a578832c9469e19c023e536d