### PR TITLE
Add git diagnostics step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,12 @@ jobs:
       - run: python -m pip install .[dev] || true
       - run: python -m pip install numpy pandas
       - run: python scripts/summarize_backtests.py
+
+      - name: Git diagnostics
+        if: ${{ always() }}
+        run: |
+          set -x
+          git rev-parse --is-inside-work-tree
+          git remote -v
+          git status
+          git branch -vv


### PR DESCRIPTION
## Summary
- add a Git diagnostics step that always runs at the end of the CI job to capture repository metadata for debugging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff3e9dbc8832cbc5f656e794398a9