### PR TITLE
Add PAT authentication for daily trends workflow

### DIFF
--- a/.github/workflows/daily-market-trends.yml
+++ b/.github/workflows/daily-market-trends.yml
@@ -27,6 +27,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Authenticate to target repo
+        run: |
+          git remote set-url origin "https://x-access-token:${{ secrets.PAT_DATA_PUSH }}@github.com/${{ github.repository }}.git"
+
       - name: Fetch daily trends
         run: |
           python scripts/fetch_daily_trends.py


### PR DESCRIPTION
## Summary
- add a workflow step to retarget the git remote with the PAT credential before pushing the daily market trends snapshot

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dff0c704a4832c8649813b7531cb19