### PR TITLE
Document lint issues causing CI failures

### DIFF
--- a/DIAGNOSTICS.md
+++ b/DIAGNOSTICS.md
@@ -10,3 +10,13 @@ git rev-parse --abbrev-ref HEAD
 ```
 
 These commands confirm the repository root at `/workspace/trading-bot`, list the contents of the directory, display a clean working tree, and identify the current branch as `work`.
+
+## CI failure analysis
+
+To reproduce the failing GitHub Actions job locally, the static analysis step from `.github/workflows/ci.yml` was executed with `ruff`.
+
+```bash
+ruff check .
+```
+
+This command currently reports hundreds of lint violations spread across the legacy `tradingbot_ibkr` utilities and other helper modules. Because the CI workflow executes `ruff check .` on every pull request, these pre-existing violations cause the workflow to fail before tests can run, leading to the systematic failure of all pull requests.


### PR DESCRIPTION
## Summary
- capture the result of replicating the failing GitHub Actions lint step locally
- document that the `ruff check .` invocation from the CI workflow fails due to hundreds of pre-existing violations, causing every pull request to fail

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e099412b78832cbca610c09fa72d97