### PR TITLE
Respect session boundaries when canonicalizing OHLCV data

### DIFF
--- a/data_pipeline.py
+++ b/data_pipeline.py
@@ -73,22 +73,46 @@ def canonicalize_ohlcv(df: pd.DataFrame, freq: str, session_tz: str = "UTC") -> 
     df["timestamp"] = utc_values
 
     valid_times = [ts for ts in utc_values if isinstance(ts, datetime)]
+    if len(valid_times) != len(df):
+        raise ValueError("timestamp column must contain datetime-like values")
     if not valid_times:
         raise ValueError("timestamp column must contain datetime-like values")
 
-    # Reindex to expected frequency and forward fill within the session
-    start, end = min(valid_times), max(valid_times)
-    full_range = pd.date_range(start=start, end=end, freq=freq, tz="UTC")
-    df = df.set_index("timestamp").reindex(full_range)
-    df = df.ffill()
-    df.index.name = "timestamp"
+    session_dates = [
+        ts.astimezone(session_tzinfo).date() if isinstance(ts, datetime) else None
+        for ts in utc_values
+    ]
+    df["_session_date"] = session_dates
 
-    records = []
-    for row in df.reset_index().to_dict("records"):
-        if "index" in row:
-            row["timestamp"] = row.pop("index")
-        records.append(row)
-    return pd.DataFrame(records)
+    grouped_records: dict = {}
+    for record in df.to_dict("records"):
+        key = record.get("_session_date")
+        grouped_records.setdefault(key, []).append(record)
+
+    output_records = []
+    for key in sorted(grouped_records):
+        rows = grouped_records[key]
+        if not rows:
+            continue
+        rows.sort(key=lambda row: row["timestamp"])
+        start = rows[0]["timestamp"]
+        end = rows[-1]["timestamp"]
+        session_df = pd.DataFrame(rows)
+        session_df = session_df.set_index("timestamp")
+        session_range = pd.date_range(start=start, end=end, freq=freq, tz="UTC")
+        reindexed = session_df.reindex(session_range)
+        reindexed = reindexed.ffill()
+        session_records = reindexed.reset_index().to_dict("records")
+        for row in session_records:
+            row.pop("_session_date", None)
+            if "index" in row:
+                row["timestamp"] = row.pop("index")
+            output_records.append(row)
+
+    if not output_records:
+        raise ValueError("timestamp column must contain datetime-like values")
+
+    return pd.DataFrame(output_records)
 
 
 def drop_anomalies(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -43,3 +43,28 @@ def test_canonicalize_ohlcv_localizes_naive_timestamps():
         "2024-01-01 14:30", periods=2, freq="1min", tz="UTC"
     )
     assert list(out["timestamp"]) == list(expected_index)
+
+
+def test_canonicalize_ohlcv_respects_session_boundaries():
+    df = pd.DataFrame(
+        {
+            "timestamp": [
+                "2024-01-01 09:30:00",
+                "2024-01-01 09:31:00",
+                "2024-01-02 09:30:00",
+            ],
+            "open": [1.0, 1.1, 2.0],
+            "high": [1.2, 1.3, 2.2],
+            "low": [0.9, 1.0, 1.9],
+            "close": [1.05, 1.15, 2.05],
+            "volume": [100, 120, 150],
+        }
+    )
+
+    out = canonicalize_ohlcv(df, "1min", session_tz="America/New_York")
+
+    assert len(out) == 3
+    # Ensure there is no forward fill bridging across different sessions
+    first_session_end = out.iloc[1]["timestamp"]
+    second_session_start = out.iloc[2]["timestamp"]
+    assert (second_session_start - first_session_end).total_seconds() > 3600


### PR DESCRIPTION
## Summary
- ensure `canonicalize_ohlcv` validates datetime inputs and forward-fills only within individual trading sessions
- build session-aware reindexing logic that avoids leaking values across multi-day gaps
- add regression test covering session-boundary behaviour in the data pipeline utilities

## Testing
- pytest tests/test_data_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a8477758832c88d8952bceaef4d2