### PR TITLE
Add multi-strategy orchestration layer

### DIFF
--- a/config/portfolio.yaml
+++ b/config/portfolio.yaml
@@ -1,0 +1,17 @@
+base_currency: USD
+total_capital: 100000
+portfolio_limits:
+  max_symbol_notional: 120000
+strategies:
+  grid:
+    capital: 30000
+    max_position_notional: 60000
+  momentum:
+    capital: 25000
+    max_position_notional: 50000
+  dca:
+    capital: 20000
+    max_position_notional: 45000
+  arbitrage:
+    capital: 25000
+    max_position_notional: 75000

--- a/config/strategy/arbitrage.yaml
+++ b/config/strategy/arbitrage.yaml
@@ -1,0 +1,6 @@
+primary_market_key: binance:BTC/USDT
+hedge_market_key: kraken:BTC/USDT
+trade_size: 0.25
+min_edge: 0.002
+fee_rate: 0.0005
+symbol: BTC/USDT

--- a/config/strategy/dca.yaml
+++ b/config/strategy/dca.yaml
@@ -1,0 +1,8 @@
+symbol: BTC/USDT
+venue: binance
+market_key: binance:BTC/USDT
+base_order_size: 0.01
+dca_step: 0.02
+scale_factor: 1.5
+max_layers: 5
+take_profit: 0.015

--- a/config/strategy/grid.yaml
+++ b/config/strategy/grid.yaml
@@ -1,0 +1,7 @@
+symbol: BTC/USDT
+venue: binance
+market_key: binance:BTC/USDT
+lower_bound: 25000
+upper_bound: 35000
+levels: 9
+base_order_size: 0.02

--- a/config/strategy/momentum.yaml
+++ b/config/strategy/momentum.yaml
@@ -1,0 +1,7 @@
+symbol: BTC/USDT
+venue: binance
+market_key: binance:BTC/USDT
+fast_window: 12
+slow_window: 26
+threshold: 0.0015
+order_size: 0.05

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,30 @@
+"""Execution agnostic orchestration primitives for the trading bot."""
+
+from .datafeed import MarketData, MarketInstrument, UnifiedDataFeed
+from .portfolio import (
+    OrderFill,
+    Portfolio,
+    PortfolioSnapshot,
+    PositionView,
+    StrategyAllocation,
+    StrategyPnL,
+)
+from .risk import RiskDecision, RiskManager, RiskViolation
+from .orchestrator import MultiStrategyOrchestrator, StrategyBinding
+
+__all__ = [
+    "MarketData",
+    "MarketInstrument",
+    "UnifiedDataFeed",
+    "OrderFill",
+    "Portfolio",
+    "PortfolioSnapshot",
+    "PositionView",
+    "StrategyAllocation",
+    "StrategyPnL",
+    "RiskDecision",
+    "RiskManager",
+    "RiskViolation",
+    "MultiStrategyOrchestrator",
+    "StrategyBinding",
+]

--- a/engine/datafeed.py
+++ b/engine/datafeed.py
@@ -1,0 +1,164 @@
+"""Unified data feed abstraction built on top of ccxt-style clients."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MarketInstrument:
+    """Descriptor of a market stream to subscribe to."""
+
+    venue: str
+    symbol: str
+    timeframe: str | None = None
+    alias: str | None = None
+
+    def key(self) -> str:
+        """Return the canonical identifier for the instrument."""
+
+        return self.alias or f"{self.venue}:{self.symbol}"
+
+
+@dataclass(frozen=True)
+class OHLCV:
+    """Simple OHLCV datapoint."""
+
+    timestamp: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+@dataclass(frozen=True)
+class MarketData:
+    """Snapshot of market information for an instrument."""
+
+    venue: str
+    symbol: str
+    timestamp: datetime
+    price: float
+    ohlcv: tuple[OHLCV, ...] = field(default_factory=tuple)
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def key(self) -> str:
+        return f"{self.venue}:{self.symbol}"
+
+
+class UnifiedDataFeed:
+    """Collects market data across venues via ccxt compatible clients."""
+
+    def __init__(
+        self,
+        clients: Mapping[str, Any],
+        instruments: Iterable[MarketInstrument],
+        *,
+        ohlcv_candles: int = 0,
+        default_timeframe: str = "1m",
+        log: logging.Logger | None = None,
+    ) -> None:
+        if not clients:
+            raise ValueError("At least one client must be supplied")
+        self._clients = dict(clients)
+        self._instruments = tuple(instruments)
+        if not self._instruments:
+            raise ValueError("At least one instrument must be supplied")
+        self._ohlcv_candles = int(max(0, ohlcv_candles))
+        self._default_timeframe = default_timeframe
+        self._log = log or logger
+
+    def fetch(self) -> dict[str, MarketData]:
+        """Fetch the latest snapshot for all configured instruments."""
+
+        snapshots: dict[str, MarketData] = {}
+        for instrument in self._instruments:
+            client = self._clients.get(instrument.venue)
+            if client is None:
+                raise KeyError(f"No client configured for venue {instrument.venue!r}")
+
+            ticker = client.fetch_ticker(instrument.symbol)
+            timestamp = self._extract_timestamp(ticker)
+            price = self._extract_price(ticker)
+
+            ohlcv: tuple[OHLCV, ...] = ()
+            raw_ohlcv: list[Any] | None = None
+            if self._ohlcv_candles and hasattr(client, "fetch_ohlcv"):
+                tf = instrument.timeframe or self._default_timeframe
+                try:
+                    raw_ohlcv = client.fetch_ohlcv(
+                        instrument.symbol, tf, limit=self._ohlcv_candles
+                    )
+                except Exception as exc:  # pragma: no cover - ccxt errors are runtime specific
+                    self._log.warning(
+                        "Failed to fetch OHLCV for %s on %s: %s",
+                        instrument.symbol,
+                        instrument.venue,
+                        exc,
+                    )
+                else:
+                    ohlcv = tuple(self._transform_ohlcv(raw_ohlcv))
+
+            key = instrument.key()
+            snapshots[key] = MarketData(
+                venue=instrument.venue,
+                symbol=instrument.symbol,
+                timestamp=timestamp,
+                price=price,
+                ohlcv=ohlcv,
+                raw={"ticker": ticker, "ohlcv": raw_ohlcv} if raw_ohlcv is not None else {"ticker": ticker},
+            )
+        return snapshots
+
+    @staticmethod
+    def _extract_timestamp(ticker: Mapping[str, Any]) -> datetime:
+        value = ticker.get("timestamp") or ticker.get("datetime")
+        if value is None:
+            return datetime.now(timezone.utc)
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(value / 1000 if value > 10_000_000_000 else value, tz=timezone.utc)
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return datetime.now(timezone.utc)
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc)
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def _extract_price(ticker: Mapping[str, Any]) -> float:
+        for key in ("last", "close", "bid", "ask"):
+            value = ticker.get(key)
+            if value is not None:
+                return float(value)
+        raise ValueError("Ticker payload does not contain a usable price")
+
+    @staticmethod
+    def _transform_ohlcv(raw: Iterable[Iterable[Any]]) -> Iterable[OHLCV]:
+        for candle in raw:
+            if len(candle) < 6:
+                continue
+            ts, o, h, l, c, v = candle[:6]
+            if isinstance(ts, (int, float)):
+                timestamp = datetime.fromtimestamp(ts / 1000 if ts > 10_000_000_000 else ts, tz=timezone.utc)
+            else:
+                timestamp = datetime.now(timezone.utc)
+            yield OHLCV(
+                timestamp=timestamp,
+                open=float(o),
+                high=float(h),
+                low=float(l),
+                close=float(c),
+                volume=float(v),
+            )
+
+
+__all__ = ["MarketInstrument", "OHLCV", "MarketData", "UnifiedDataFeed"]

--- a/engine/orchestrator.py
+++ b/engine/orchestrator.py
@@ -1,0 +1,108 @@
+"""High level orchestration for coordinating multiple strategies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol, Sequence
+import logging
+
+from .datafeed import MarketData, UnifiedDataFeed
+from .portfolio import OrderFill, Portfolio, PortfolioSnapshot, StrategyAllocation
+from .risk import RiskManager
+from strategies.base import Strategy, StrategyContext, StrategySignal
+
+logger = logging.getLogger(__name__)
+
+
+class OrderExecutor(Protocol):
+    """Protocol for submitting strategy signals to an execution venue."""
+
+    def execute(self, signal: StrategySignal) -> OrderFill | None:
+        ...
+
+
+@dataclass(frozen=True)
+class StrategyBinding:
+    """Glue object combining a strategy implementation with its config."""
+
+    name: str
+    strategy: Strategy
+    allocation: StrategyAllocation
+
+
+class MultiStrategyOrchestrator:
+    """Coordinates market data, strategies, risk checks and execution."""
+
+    def __init__(
+        self,
+        *,
+        data_feed: UnifiedDataFeed,
+        portfolio: Portfolio,
+        risk_manager: RiskManager,
+        strategies: Sequence[StrategyBinding],
+        executor: OrderExecutor | None = None,
+        log: logging.Logger | None = None,
+    ) -> None:
+        if not strategies:
+            raise ValueError("At least one strategy must be configured")
+        self._data_feed = data_feed
+        self._portfolio = portfolio
+        self._risk = risk_manager
+        self._strategies = list(strategies)
+        self._executor = executor
+        self._log = log or logger
+
+    def run_cycle(self) -> list[OrderFill]:
+        """Run a single evaluation cycle across all strategies."""
+
+        market_data = self._data_feed.fetch()
+        snapshot = self._portfolio.snapshot(
+            mark_prices={data.symbol: data.price for data in market_data.values()}
+        )
+        timestamp = datetime.now(timezone.utc)
+        fills: list[OrderFill] = []
+
+        for binding in self._strategies:
+            context = self._build_context(binding, market_data, snapshot, timestamp)
+            signals = list(binding.strategy.generate_signals(context))
+            if not signals:
+                continue
+
+            decision = self._risk.evaluate_signals(binding.name, signals, snapshot)
+            if not decision.accepted:
+                self._log.debug("No signals accepted for %s", binding.name)
+                continue
+
+            if self._executor is None:
+                self._log.debug("Executor not configured; skipping execution for %s", binding.name)
+                continue
+
+            for signal in decision.accepted:
+                fill = self._executor.execute(signal)
+                if fill:
+                    fills.append(fill)
+                    self._portfolio.apply_fills(binding.name, [fill])
+
+        return fills
+
+    def _build_context(
+        self,
+        binding: StrategyBinding,
+        market_data: dict[str, MarketData],
+        snapshot: PortfolioSnapshot,
+        timestamp: datetime,
+    ) -> StrategyContext:
+        state = snapshot.state_for(binding.name)
+        return StrategyContext(
+            strategy=binding.name,
+            timestamp=timestamp,
+            market_data=market_data,
+            allocation=binding.allocation,
+            cash=state.cash,
+            positions=state.positions,
+            pnl=state.pnl,
+        )
+
+
+__all__ = ["OrderExecutor", "StrategyBinding", "MultiStrategyOrchestrator"]

--- a/engine/portfolio.py
+++ b/engine/portfolio.py
@@ -1,0 +1,170 @@
+"""Portfolio level accounting for multi-strategy execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
+from collections import defaultdict
+import logging
+
+from tradingbot_ibkr.execution.broker_base import BrokerBase
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PositionView:
+    """Lightweight snapshot of a held position."""
+
+    symbol: str
+    quantity: float
+    average_price: float | None = None
+
+    @property
+    def market_value(self) -> float:
+        if self.average_price is None:
+            return 0.0
+        return self.quantity * self.average_price
+
+
+@dataclass(frozen=True)
+class StrategyPnL:
+    """Profit and loss snapshot."""
+
+    realised: float
+    unrealised: float
+
+
+@dataclass
+class StrategyAllocation:
+    """Configuration describing how much capital a strategy can deploy."""
+
+    name: str
+    capital: float
+    max_position_notional: float | None = None
+    max_drawdown: float | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OrderFill:
+    """Event representing a completed order fill."""
+
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    fee: float = 0.0
+
+    @property
+    def notional(self) -> float:
+        return self.quantity * self.price
+
+
+@dataclass(frozen=True)
+class StrategyState:
+    """Current capital and exposures for a strategy."""
+
+    allocation: StrategyAllocation
+    cash: float
+    positions: tuple[PositionView, ...]
+    pnl: StrategyPnL
+
+
+@dataclass(frozen=True)
+class PortfolioSnapshot:
+    """Point-in-time view of the whole book."""
+
+    total_equity: float
+    states: Mapping[str, StrategyState]
+
+    def state_for(self, name: str) -> StrategyState:
+        return self.states[name]
+
+
+class Portfolio:
+    """Track capital splits and aggregate realised/unrealised PnL."""
+
+    def __init__(
+        self,
+        allocations: Iterable[StrategyAllocation],
+        *,
+        broker: BrokerBase,
+        base_currency: str = "USD",
+        log: logging.Logger | None = None,
+    ) -> None:
+        allocations = list(allocations)
+        if not allocations:
+            raise ValueError("At least one strategy allocation must be configured")
+        self._allocations = {alloc.name: alloc for alloc in allocations}
+        self._cash_balances = {alloc.name: alloc.capital for alloc in allocations}
+        self._realised_pnl = defaultdict(float)
+        self._broker = broker
+        self._base_currency = base_currency
+        self._log = log or logger
+
+    def allocation_for(self, name: str) -> StrategyAllocation:
+        return self._allocations[name]
+
+    def apply_fills(self, strategy: str, fills: Iterable[OrderFill]) -> None:
+        cash = self._cash_balances[strategy]
+        for fill in fills:
+            notional = fill.notional
+            if fill.side.lower() == "buy":
+                cash -= notional + fill.fee
+            else:
+                cash += notional - fill.fee
+                self._realised_pnl[strategy] += notional - fill.fee
+        self._cash_balances[strategy] = cash
+
+    def snapshot(self, mark_prices: Mapping[str, float] | None = None) -> PortfolioSnapshot:
+        positions = list(self._broker.list_positions())
+
+        states: dict[str, StrategyState] = {}
+        total_equity = 0.0
+        for name, allocation in self._allocations.items():
+            cash = self._cash_balances[name]
+            held_positions: list[PositionView] = []
+            unrealised = 0.0
+            for position in positions:
+                mark = None
+                if mark_prices and position.symbol in mark_prices:
+                    mark = mark_prices[position.symbol]
+                elif position.average_price is not None:
+                    mark = position.average_price
+                if mark is None:
+                    continue
+                position_view = PositionView(
+                    symbol=position.symbol,
+                    quantity=position.quantity,
+                    average_price=mark,
+                )
+                held_positions.append(position_view)
+                unrealised += (mark - (position.average_price or mark)) * position.quantity
+
+            pnl = StrategyPnL(realised=self._realised_pnl[name], unrealised=unrealised)
+            equity = cash + sum(p.market_value for p in held_positions) + pnl.realised + pnl.unrealised
+            total_equity += equity
+            states[name] = StrategyState(
+                allocation=allocation,
+                cash=cash,
+                positions=tuple(held_positions),
+                pnl=pnl,
+            )
+        return PortfolioSnapshot(total_equity=total_equity, states=states)
+
+    def available_notional(self, strategy: str) -> float:
+        allocation = self._allocations[strategy]
+        limit = allocation.max_position_notional or allocation.capital
+        consumed = allocation.capital - self._cash_balances[strategy]
+        return max(limit - consumed, 0.0)
+
+
+__all__ = [
+    "OrderFill",
+    "Portfolio",
+    "PortfolioSnapshot",
+    "PositionView",
+    "StrategyAllocation",
+    "StrategyPnL",
+]

--- a/engine/risk.py
+++ b/engine/risk.py
@@ -1,0 +1,107 @@
+"""Risk management utilities for multi-strategy coordination."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+import logging
+
+from .portfolio import OrderFill, PortfolioSnapshot, StrategyAllocation
+from strategies.base import StrategySignal
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RiskDecision:
+    """Outcome of evaluating a strategy's proposed signals."""
+
+    accepted: tuple[StrategySignal, ...]
+    rejected: tuple[StrategySignal, ...]
+
+
+class RiskViolation(RuntimeError):
+    """Raised when a signal violates hard risk constraints."""
+
+    def __init__(self, message: str, *, signal: StrategySignal | None = None) -> None:
+        super().__init__(message)
+        self.signal = signal
+
+
+class RiskManager:
+    """Performs per-strategy and portfolio wide risk checks."""
+
+    def __init__(
+        self,
+        limits: Mapping[str, StrategyAllocation],
+        *,
+        portfolio_limits: Mapping[str, float] | None = None,
+        log: logging.Logger | None = None,
+    ) -> None:
+        self._limits = dict(limits)
+        self._portfolio_limits = dict(portfolio_limits or {})
+        self._log = log or logger
+
+    def evaluate_signals(
+        self,
+        strategy: str,
+        signals: Sequence[StrategySignal],
+        snapshot: PortfolioSnapshot,
+        *,
+        pending_fills: Iterable[OrderFill] | None = None,
+    ) -> RiskDecision:
+        allocation = self._limits[strategy]
+        accepted: list[StrategySignal] = []
+        rejected: list[StrategySignal] = []
+        available_notional = allocation.max_position_notional or allocation.capital
+
+        if pending_fills:
+            for fill in pending_fills:
+                notional = fill.notional
+                available_notional -= notional
+
+        if available_notional <= 0:
+            self._log.warning("Strategy %s has no remaining notional capacity", strategy)
+            return RiskDecision(accepted=(), rejected=tuple(signals))
+
+        for signal in signals:
+            notional = abs(signal.notional)
+            if notional > available_notional:
+                self._log.info(
+                    "Rejecting %s signal for %s: notional %.2f exceeds remaining capacity %.2f",
+                    strategy,
+                    signal.symbol,
+                    notional,
+                    available_notional,
+                )
+                rejected.append(signal)
+                continue
+
+            if self._violates_portfolio_limits(signal, snapshot):
+                rejected.append(signal)
+                continue
+
+            accepted.append(signal)
+            available_notional -= notional
+
+        return RiskDecision(accepted=tuple(accepted), rejected=tuple(rejected))
+
+    def _violates_portfolio_limits(self, signal: StrategySignal, snapshot: PortfolioSnapshot) -> bool:
+        max_symbol = self._portfolio_limits.get("max_symbol_notional")
+        if max_symbol is None:
+            return False
+        state = snapshot.state_for(signal.strategy)
+        current = sum(p.market_value for p in state.positions if p.symbol == signal.symbol)
+        projected = current + signal.notional
+        if abs(projected) > max_symbol:
+            self._log.info(
+                "Rejecting signal for %s: projected exposure %.2f exceeds symbol limit %.2f",
+                signal.symbol,
+                projected,
+                max_symbol,
+            )
+            return True
+        return False
+
+
+__all__ = ["RiskDecision", "RiskManager", "RiskViolation"]

--- a/execution/__init__.py
+++ b/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Execution layer adapters for third party brokers."""

--- a/execution/adapters/__init__.py
+++ b/execution/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Concrete broker adapters built on external APIs."""
+
+from .ccxt_broker import CCXTBroker
+
+__all__ = ["CCXTBroker"]

--- a/execution/adapters/ccxt_broker.py
+++ b/execution/adapters/ccxt_broker.py
@@ -1,0 +1,118 @@
+"""Adapter exposing a ccxt client via the :mod:`tradingbot_ibkr` broker protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+import logging
+import uuid
+
+from tradingbot_ibkr.execution.broker_base import BrokerBase, Order, Position
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CCXTBroker(BrokerBase):
+    """Translate ccxt order/position data into the shared broker protocol."""
+
+    client: Any
+    account_type: str = "spot"
+    log: logging.Logger | None = None
+
+    def __post_init__(self) -> None:
+        self._log = self.log or logger
+        self._orders: dict[str, Order] = {}
+
+    def list_open_orders(self) -> Iterable[Order]:
+        try:
+            payload = self.client.fetch_open_orders()
+        except Exception as exc:  # pragma: no cover - depends on network access
+            self._log.warning("Failed to fetch open orders from ccxt: %s", exc)
+            return [order for order in self._orders.values() if order.status == "open"]
+
+        for raw in payload:
+            self._ingest_order(raw)
+        return [order for order in self._orders.values() if order.status == "open"]
+
+    def list_positions(self) -> Iterable[Position]:
+        positions: list[Position] = []
+        if hasattr(self.client, "fetch_positions"):
+            try:
+                payload = self.client.fetch_positions()
+            except Exception as exc:  # pragma: no cover - depends on network access
+                self._log.warning("Failed to fetch positions via ccxt: %s", exc)
+            else:
+                positions.extend(self._transform_position(raw) for raw in payload if raw)
+        else:
+            try:
+                balance: Mapping[str, Mapping[str, float]] = self.client.fetch_balance()
+            except Exception as exc:  # pragma: no cover
+                self._log.warning("Failed to fetch balance via ccxt: %s", exc)
+            else:
+                totals = balance.get("total", {})
+                for symbol, quantity in totals.items():
+                    qty = float(quantity)
+                    if abs(qty) <= 0:
+                        continue
+                    positions.append(
+                        Position(symbol=symbol, quantity=qty, average_price=None, metadata={"balance": quantity})
+                    )
+        return positions
+
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        *,
+        order_type: str = "market",
+        price: float | None = None,
+        client_id: str | None = None,
+        params: Mapping[str, object] | None = None,
+    ) -> Order:
+        client_order_id = client_id or uuid.uuid4().hex
+        if client_order_id in self._orders:
+            return self._orders[client_order_id]
+
+        payload_params = dict(params or {})
+        payload_params.setdefault("clientOrderId", client_order_id)
+        if self.account_type:
+            payload_params.setdefault("type", self.account_type)
+
+        order = self.client.create_order(symbol, order_type, side, quantity, price, payload_params)
+        broker_order = self._ingest_order(order, client_order_id=client_order_id)
+        return broker_order
+
+    # ------------------------------------------------------------------
+    def _ingest_order(self, raw: Mapping[str, object], *, client_order_id: str | None = None) -> Order:
+        cid = client_order_id or raw.get("clientOrderId") or raw.get("id") or uuid.uuid4().hex
+        order_id = str(raw.get("id") or raw.get("orderId") or cid)
+        filled = float(raw.get("filled") or raw.get("filledAmount") or raw.get("executed") or 0.0)
+        status = str(raw.get("status") or ("closed" if filled else "open"))
+        price = raw.get("average") or raw.get("price")
+        broker_order = Order(
+            id=order_id,
+            symbol=str(raw.get("symbol")),
+            side=str(raw.get("side")),
+            quantity=float(raw.get("amount") or raw.get("quantity") or raw.get("origQty") or 0.0),
+            filled_quantity=filled,
+            status=status,
+            price=float(price) if price else None,
+            metadata={"raw": raw, "client_order_id": cid},
+        )
+        self._orders[cid] = broker_order
+        return broker_order
+
+    def _transform_position(self, raw: Mapping[str, object]) -> Position:
+        qty = raw.get("contracts") or raw.get("positionAmt") or raw.get("size") or raw.get("amount") or 0.0
+        price = raw.get("entryPrice") or raw.get("avgEntryPrice") or raw.get("markPrice")
+        return Position(
+            symbol=str(raw.get("symbol")),
+            quantity=float(qty),
+            average_price=float(price) if price else None,
+            metadata={"raw": raw},
+        )
+
+
+__all__ = ["CCXTBroker"]

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,17 @@
+"""Collection of trading strategy implementations."""
+
+from .base import Strategy, StrategyContext, StrategySignal
+from .grid import GridTradingStrategy
+from .momentum_ema import MomentumEMAStrategy
+from .dca_martingale import DCAMartingaleStrategy
+from .arbitrage_xex import CrossExchangeArbitrageStrategy
+
+__all__ = [
+    "Strategy",
+    "StrategyContext",
+    "StrategySignal",
+    "GridTradingStrategy",
+    "MomentumEMAStrategy",
+    "DCAMartingaleStrategy",
+    "CrossExchangeArbitrageStrategy",
+]

--- a/strategies/arbitrage_xex.py
+++ b/strategies/arbitrage_xex.py
@@ -1,0 +1,88 @@
+"""Cross-exchange arbitrage strategy operating on pre-positioned balances."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .base import Strategy, StrategyContext, StrategySignal
+
+
+class CrossExchangeArbitrageStrategy(Strategy):
+    """Looks for dislocations between two venues and trades the spread."""
+
+    def __init__(
+        self,
+        *,
+        primary_market_key: str,
+        hedge_market_key: str,
+        trade_size: float,
+        min_edge: float = 0.001,
+        fee_rate: float = 0.0005,
+        symbol: str | None = None,
+    ) -> None:
+        self._primary_key = primary_market_key
+        self._hedge_key = hedge_market_key
+        self._size = trade_size
+        self._min_edge = min_edge
+        self._fee = fee_rate
+        self.symbol = symbol
+
+    def generate_signals(self, context: StrategyContext) -> Iterable[StrategySignal]:
+        primary = context.data(self._primary_key)
+        hedge = context.data(self._hedge_key)
+        symbol = self.symbol or primary.symbol
+
+        spread = hedge.price - primary.price
+        edge = spread / primary.price if primary.price else 0.0
+
+        signals: List[StrategySignal] = []
+        if edge > self._min_edge + 2 * self._fee:
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=symbol,
+                    side="buy",
+                    quantity=self._size,
+                    price=primary.price,
+                    venue=primary.venue,
+                    tags={"type": "xex", "leg": "primary", "edge": edge},
+                )
+            )
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=symbol,
+                    side="sell",
+                    quantity=self._size,
+                    price=hedge.price,
+                    venue=hedge.venue,
+                    tags={"type": "xex", "leg": "hedge", "edge": edge},
+                )
+            )
+        elif edge < -self._min_edge - 2 * self._fee:
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=symbol,
+                    side="sell",
+                    quantity=self._size,
+                    price=primary.price,
+                    venue=primary.venue,
+                    tags={"type": "xex", "leg": "primary", "edge": edge},
+                )
+            )
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=symbol,
+                    side="buy",
+                    quantity=self._size,
+                    price=hedge.price,
+                    venue=hedge.venue,
+                    tags={"type": "xex", "leg": "hedge", "edge": edge},
+                )
+            )
+        return signals
+
+
+__all__ = ["CrossExchangeArbitrageStrategy"]

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,0 +1,54 @@
+"""Strategy interface and shared helper data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, Mapping, Protocol, Sequence
+
+if False:  # pragma: no cover - type checking helper
+    from engine.datafeed import MarketData
+    from engine.portfolio import PositionView, StrategyAllocation, StrategyPnL
+
+
+@dataclass(frozen=True)
+class StrategySignal:
+    """Signal instructing the execution layer to place an order."""
+
+    strategy: str
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    venue: str | None = None
+    tags: Mapping[str, object] = field(default_factory=dict)
+
+    @property
+    def notional(self) -> float:
+        return self.quantity * self.price
+
+
+@dataclass(frozen=True)
+class StrategyContext:
+    """Context passed to strategies on each evaluation cycle."""
+
+    strategy: str
+    timestamp: datetime
+    market_data: Mapping[str, "MarketData"]
+    allocation: "StrategyAllocation"
+    cash: float
+    positions: Sequence["PositionView"]
+    pnl: "StrategyPnL"
+
+    def data(self, key: str) -> "MarketData":
+        return self.market_data[key]
+
+
+class Strategy(Protocol):
+    """Protocol implemented by trading strategies."""
+
+    def generate_signals(self, context: StrategyContext) -> Iterable[StrategySignal]:
+        ...
+
+
+__all__ = ["Strategy", "StrategyContext", "StrategySignal"]

--- a/strategies/dca_martingale.py
+++ b/strategies/dca_martingale.py
@@ -1,0 +1,103 @@
+"""DCA-first martingale-lite strategy."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .base import Strategy, StrategyContext, StrategySignal
+
+
+class DCAMartingaleStrategy(Strategy):
+    """Progressively increases position size on drawdowns and exits on recovery."""
+
+    def __init__(
+        self,
+        *,
+        symbol: str,
+        base_order_size: float,
+        dca_step: float = 0.01,
+        scale_factor: float = 1.4,
+        max_layers: int = 4,
+        take_profit: float = 0.01,
+        venue: str | None = None,
+        market_key: str | None = None,
+    ) -> None:
+        if dca_step <= 0:
+            raise ValueError("dca_step must be positive")
+        self.symbol = symbol
+        self._base_size = base_order_size
+        self._step = dca_step
+        self._scale = scale_factor
+        self._max_layers = max_layers
+        self._take_profit = take_profit
+        self._venue = venue
+        self._market_key = market_key or (f"{venue}:{symbol}" if venue else symbol)
+        self._position = 0.0
+        self._avg_entry: float | None = None
+        self._layers = 0
+
+    def generate_signals(self, context: StrategyContext) -> Iterable[StrategySignal]:
+        market = context.data(self._market_key)
+        price = market.price
+        signals: List[StrategySignal] = []
+
+        if self._position <= 0:
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=self.symbol,
+                    side="buy",
+                    quantity=self._base_size,
+                    price=price,
+                    venue=self._venue,
+                    tags={"type": "dca", "layer": 1},
+                )
+            )
+            self._position = self._base_size
+            self._avg_entry = price
+            self._layers = 1
+            return signals
+
+        assert self._avg_entry is not None
+
+        target_buy = self._avg_entry * (1.0 - self._step)
+        if price <= target_buy and self._layers < self._max_layers:
+            qty = self._base_size * (self._scale ** self._layers)
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=self.symbol,
+                    side="buy",
+                    quantity=qty,
+                    price=price,
+                    venue=self._venue,
+                    tags={"type": "dca", "layer": self._layers + 1},
+                )
+            )
+            total_qty = self._position + qty
+            self._avg_entry = (self._avg_entry * self._position + price * qty) / total_qty
+            self._position = total_qty
+            self._layers += 1
+            return signals
+
+        target_sell = self._avg_entry * (1.0 + self._take_profit)
+        if price >= target_sell and self._position > 0:
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=self.symbol,
+                    side="sell",
+                    quantity=self._position,
+                    price=price,
+                    venue=self._venue,
+                    tags={"type": "take_profit", "layers": self._layers},
+                )
+            )
+            self._position = 0.0
+            self._avg_entry = None
+            self._layers = 0
+
+        return signals
+
+
+__all__ = ["DCAMartingaleStrategy"]

--- a/strategies/grid.py
+++ b/strategies/grid.py
@@ -1,0 +1,88 @@
+"""Price grid based market making strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .base import Strategy, StrategyContext, StrategySignal
+
+
+@dataclass
+class GridLevelState:
+    next_buy: float
+    next_sell: float
+
+
+class GridTradingStrategy(Strategy):
+    """Simple grid strategy placing layered buy/sell orders."""
+
+    def __init__(
+        self,
+        *,
+        symbol: str,
+        lower_bound: float,
+        upper_bound: float,
+        levels: int,
+        base_order_size: float,
+        venue: str | None = None,
+        market_key: str | None = None,
+    ) -> None:
+        if lower_bound >= upper_bound:
+            raise ValueError("lower_bound must be less than upper_bound")
+        if levels < 2:
+            raise ValueError("At least two levels are required")
+        self.symbol = symbol
+        self._lower = lower_bound
+        self._upper = upper_bound
+        self._levels = levels
+        self._size = base_order_size
+        self._venue = venue
+        self._market_key = market_key or (f"{venue}:{symbol}" if venue else symbol)
+        step = (upper_bound - lower_bound) / (levels - 1)
+        self._state = GridLevelState(next_buy=lower_bound + step, next_sell=upper_bound - step)
+
+    def generate_signals(self, context: StrategyContext) -> Iterable[StrategySignal]:
+        market = context.data(self._market_key)
+        price = market.price
+        signals: List[StrategySignal] = []
+        step = (self._upper - self._lower) / (self._levels - 1)
+
+        while price <= self._state.next_buy and self._state.next_buy >= self._lower:
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=self.symbol,
+                    side="buy",
+                    quantity=self._size,
+                    price=self._state.next_buy,
+                    venue=self._venue,
+                    tags={"type": "grid", "level": self._state.next_buy},
+                )
+            )
+            self._state = GridLevelState(
+                next_buy=self._state.next_buy - step,
+                next_sell=self._state.next_sell,
+            )
+
+        while price >= self._state.next_sell and self._state.next_sell <= self._upper:
+            signals.append(
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=self.symbol,
+                    side="sell",
+                    quantity=self._size,
+                    price=self._state.next_sell,
+                    venue=self._venue,
+                    tags={"type": "grid", "level": self._state.next_sell},
+                )
+            )
+            self._state = GridLevelState(
+                next_buy=self._state.next_buy,
+                next_sell=self._state.next_sell + step,
+            )
+
+        return signals
+
+
+__all__ = ["GridTradingStrategy"]

--- a/strategies/momentum_ema.py
+++ b/strategies/momentum_ema.py
@@ -1,0 +1,99 @@
+"""Dual EMA momentum strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from .base import Strategy, StrategyContext, StrategySignal
+
+
+@dataclass
+class _EMA:
+    span: int
+    value: float | None = None
+
+    def update(self, price: float) -> float:
+        alpha = 2.0 / (self.span + 1.0)
+        if self.value is None:
+            self.value = price
+        else:
+            self.value = alpha * price + (1.0 - alpha) * self.value
+        return self.value
+
+
+class MomentumEMAStrategy(Strategy):
+    """Enter long when the fast EMA crosses above the slow EMA and vice versa."""
+
+    def __init__(
+        self,
+        *,
+        symbol: str,
+        fast_window: int = 12,
+        slow_window: int = 26,
+        threshold: float = 0.001,
+        order_size: float = 1.0,
+        venue: str | None = None,
+        market_key: str | None = None,
+    ) -> None:
+        if fast_window >= slow_window:
+            raise ValueError("fast_window must be smaller than slow_window")
+        self.symbol = symbol
+        self._fast = _EMA(fast_window)
+        self._slow = _EMA(slow_window)
+        self._threshold = threshold
+        self._size = order_size
+        self._venue = venue
+        self._market_key = market_key or (f"{venue}:{symbol}" if venue else symbol)
+        self._bias = 0
+
+    def generate_signals(self, context: StrategyContext) -> Iterable[StrategySignal]:
+        market = context.data(self._market_key)
+        closes: Sequence[float]
+        if market.ohlcv:
+            closes = [candle.close for candle in market.ohlcv]
+        else:
+            closes = [market.price]
+
+        for price in closes:
+            fast = self._fast.update(price)
+            slow = self._slow.update(price)
+
+        bias = 0
+        if fast - slow > self._threshold * market.price:
+            bias = 1
+        elif slow - fast > self._threshold * market.price:
+            bias = -1
+
+        if bias == self._bias:
+            return []
+
+        self._bias = bias
+        if bias > 0:
+            return [
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=self.symbol,
+                    side="buy",
+                    quantity=self._size,
+                    price=market.price,
+                    venue=self._venue,
+                    tags={"type": "momentum", "direction": "long"},
+                )
+            ]
+        elif bias < 0:
+            return [
+                StrategySignal(
+                    strategy=context.strategy,
+                    symbol=self.symbol,
+                    side="sell",
+                    quantity=self._size,
+                    price=market.price,
+                    venue=self._venue,
+                    tags={"type": "momentum", "direction": "short"},
+                )
+            ]
+        return []
+
+
+__all__ = ["MomentumEMAStrategy"]


### PR DESCRIPTION
## Summary
- introduce unified engine package with data feed, risk, portfolio, and orchestrator primitives for multi-strategy operation
- add reusable strategy implementations (grid, momentum EMA, DCA martingale, cross-exchange arbitrage) built on a shared protocol
- provide ccxt broker adapter plus configuration files for portfolio splits and strategy parameters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e17a1dba8c832ca6ed700bffe30f53