### PR TITLE
Add lightweight grid strategy to tradingbot_core

### DIFF
--- a/tests/test_grid_strategy_core.py
+++ b/tests/test_grid_strategy_core.py
@@ -1,0 +1,56 @@
+import math
+
+import pytest
+
+from tradingbot_core.strategy import Bar
+from tradingbot_core.strategies import GridConfig, GridStrategy
+
+
+@pytest.fixture
+def sample_bar() -> Bar:
+    return Bar(ts=0, open=0, high=0, low=0, close=150, volume=0)
+
+
+def test_arithmetic_grid_orders(sample_bar: Bar) -> None:
+    config = GridConfig(symbol="BTC/USDT", lower=100, upper=200, levels=5, quantity=0.5, geometric=False)
+    strategy = GridStrategy(config)
+
+    intents = strategy.on_bar({"BTC/USDT": sample_bar})
+    assert {intent.side for intent in intents} == {"buy", "sell"}
+
+    sells = [intent for intent in intents if intent.side == "sell"]
+    buys = [intent for intent in intents if intent.side == "buy"]
+
+    assert [intent.limit_price for intent in sells] == [100.0, 125.0]
+    assert [intent.limit_price for intent in buys] == [175.0, 200.0]
+    assert all(intent.qty == 0.5 for intent in intents)
+    assert all(intent.type == "limit" for intent in intents)
+
+
+def test_geometric_grid_prices() -> None:
+    config = GridConfig(symbol="ETH/USDT", lower=100, upper=800, levels=4, quantity=1, geometric=True)
+    strategy = GridStrategy(config)
+
+    ratio = (config.upper / config.lower) ** (1 / (config.levels - 1))
+    expected = [config.lower * ratio**i for i in range(config.levels)]
+    for actual, target in zip(strategy.prices, expected, strict=True):
+        assert math.isclose(actual, target, rel_tol=1e-9)
+
+
+def test_invalid_configuration() -> None:
+    with pytest.raises(ValueError):
+        GridStrategy(GridConfig(symbol="SOL/USDT", lower=10, upper=5, levels=3, quantity=1))
+    with pytest.raises(ValueError):
+        GridStrategy(GridConfig(symbol="SOL/USDT", lower=10, upper=20, levels=1, quantity=1))
+    with pytest.raises(ValueError):
+        GridStrategy(GridConfig(symbol="SOL/USDT", lower=-10, upper=20, levels=3, quantity=1, geometric=True))
+    with pytest.raises(ValueError):
+        GridStrategy(GridConfig(symbol="SOL/USDT", lower=10, upper=20, levels=3, quantity=0))
+
+
+def test_risk_state_contains_summary(sample_bar: Bar) -> None:
+    config = GridConfig(symbol="BTC/USDT", lower=100, upper=200, levels=5, quantity=0.5)
+    strategy = GridStrategy(config)
+
+    state = strategy.risk_state()
+    assert state == {"symbol": "BTC/USDT", "levels": 5, "quantity": 0.5}

--- a/tradingbot_core/__init__.py
+++ b/tradingbot_core/__init__.py
@@ -12,6 +12,7 @@ from .backtest_harness import BacktestHarness, BacktestContext, BacktestResult
 from .results import deps_fingerprint, save_results
 from .monitoring import AlertConfig, MonitoringHub
 from .strategy import Bar, OrderIntent, Strategy
+from .strategies import GridConfig, GridStrategy
 
 try:  # pragma: no cover - optional dependency guard
     from .reconciliation import (
@@ -43,6 +44,8 @@ __all__ = [
     "Bar",
     "OrderIntent",
     "Strategy",
+    "GridConfig",
+    "GridStrategy",
     "BacktestEvaluation",
     "BacktestProfile",
     "BacktestProfileNotFoundError",

--- a/tradingbot_core/strategies/__init__.py
+++ b/tradingbot_core/strategies/__init__.py
@@ -1,0 +1,5 @@
+"""Strategy implementations built on the lightweight core protocol."""
+
+from .grid import GridConfig, GridStrategy
+
+__all__ = ["GridConfig", "GridStrategy"]

--- a/tradingbot_core/strategies/grid.py
+++ b/tradingbot_core/strategies/grid.py
@@ -1,0 +1,99 @@
+"""Simple grid trading strategy using the lightweight strategy protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from ..strategy import Bar, OrderIntent, Strategy
+
+
+@dataclass(slots=True, frozen=True)
+class GridConfig:
+    """Configuration parameters for :class:`GridStrategy`."""
+
+    symbol: str
+    lower: float
+    upper: float
+    levels: int
+    quantity: float
+    geometric: bool = True
+
+
+class GridStrategy(Strategy):
+    """Generate limit orders along a price grid to capture mean reversion."""
+
+    name = "grid"
+
+    def __init__(self, config: GridConfig) -> None:
+        if config.levels < 2:
+            raise ValueError("GridStrategy requires at least two levels")
+        if config.lower <= 0 or config.upper <= 0:
+            if config.geometric:
+                raise ValueError("lower and upper must be positive when using geometric spacing")
+        if config.lower >= config.upper:
+            raise ValueError("lower must be strictly less than upper")
+        if config.quantity <= 0:
+            raise ValueError("quantity must be positive")
+
+        self.symbol = config.symbol
+        self.symbols: List[str] = [config.symbol]
+        self._lower = config.lower
+        self._upper = config.upper
+        self._levels = config.levels
+        self._qty = config.quantity
+        self._geometric = config.geometric
+        self._prices = self._build_price_levels()
+
+    def _build_price_levels(self) -> List[float]:
+        if self._geometric:
+            ratio = (self._upper / self._lower) ** (1 / (self._levels - 1))
+            return [self._lower * (ratio ** i) for i in range(self._levels)]
+        step = (self._upper - self._lower) / (self._levels - 1)
+        return [self._lower + i * step for i in range(self._levels)]
+
+    @property
+    def prices(self) -> List[float]:
+        """Return a copy of the current price grid."""
+
+        return list(self._prices)
+
+    def on_bar(self, bars: Dict[str, Bar]) -> List[OrderIntent]:
+        bar = bars[self.symbol]
+        price = bar.close
+        intents: List[OrderIntent] = []
+        for level in self._prices:
+            if price < level:
+                intents.append(
+                    OrderIntent(
+                        idemp_key=f"grid-b-{level}",
+                        symbol=self.symbol,
+                        side="buy",
+                        qty=self._qty,
+                        type="limit",
+                        limit_price=level,
+                    )
+                )
+            elif price > level:
+                intents.append(
+                    OrderIntent(
+                        idemp_key=f"grid-s-{level}",
+                        symbol=self.symbol,
+                        side="sell",
+                        qty=self._qty,
+                        type="limit",
+                        limit_price=level,
+                    )
+                )
+        return intents
+
+    def on_fill(self, fill: Dict[str, object] | None) -> None:  # pragma: no cover - hook for integration tests
+        """Handle fills. Left intentionally empty for the lightweight example."""
+
+    def risk_state(self) -> Dict[str, object]:
+        """Return the static risk snapshot for the strategy."""
+
+        return {"symbol": self.symbol, "levels": self._levels, "quantity": self._qty}
+
+
+__all__ = ["GridConfig", "GridStrategy"]


### PR DESCRIPTION
## Summary
- add a lightweight grid trading strategy implementation built on the core protocol
- expose the strategy from the tradingbot_core package for downstream consumers
- add unit tests covering order generation, price level spacing, and validation logic

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e180ff1b24832ca4617ce6c556ea12