### PR TITLE
Add continuous v3 research loop

### DIFF
--- a/.github/workflows/momentum-v3-research.yml
+++ b/.github/workflows/momentum-v3-research.yml
@@ -1,0 +1,61 @@
+name: Momentum v3 Research Loop
+
+on:
+  # Run after each completed calendar month so the historical dataset changes
+  # between scheduled runs. It remains research-only and has no write token.
+  schedule:
+    - cron: "30 7 2 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: momentum-v3-research-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  research:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          # --until is exclusive; the first day of the current month includes
+          # every completed month while avoiding an incomplete current month.
+          UNTIL="$(python - <<'PY'
+          from datetime import datetime, timezone
+          print(datetime.now(timezone.utc).strftime("%Y-%m"))
+          PY
+          )"
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-01 \
+            --until "$UNTIL"
+
+      - name: Run strict paper-only research controller
+        run: |
+          set -euo pipefail
+          python scripts/run_v3_research_controller.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --min-aligned-bars 26280 \
+            --output-dir artifacts/momentum-v3/research-controller
+
+      - name: Upload research state and reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: momentum-v3-research-${{ github.run_number }}
+          path: artifacts/momentum-v3/research-controller
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/momentum-v3-research.yml
+++ b/.github/workflows/momentum-v3-research.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -26,6 +27,139 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Restore latest research state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import io
+          import json
+          import os
+          import shutil
+          import tempfile
+          import urllib.request
+          import zipfile
+          from pathlib import Path, PurePosixPath
+
+          repository = os.environ["REPOSITORY"]
+          token = os.environ["GH_TOKEN"]
+          current_run_id = int(os.environ["CURRENT_RUN_ID"])
+          api_root = "https://api.github.com"
+          target_root = Path("artifacts/momentum-v3/research-controller").resolve()
+
+          def api(path):
+              request = urllib.request.Request(
+                  api_root + path,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=60) as response:
+                  return json.load(response)
+
+          def restore_archive(archive_url):
+              request = urllib.request.Request(
+                  archive_url,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=120) as response:
+                  archive_bytes = response.read()
+              target_root.parent.mkdir(parents=True, exist_ok=True)
+              restored = 0
+              with tempfile.TemporaryDirectory(
+                  dir=target_root.parent, prefix=".research-restore-"
+              ) as temporary:
+                  staging_root = Path(temporary).resolve()
+                  with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+                      for info in archive.infolist():
+                          if info.is_dir():
+                              continue
+                          mode = (info.external_attr >> 16) & 0o170000
+                          if mode == 0o120000:
+                              raise RuntimeError("refusing symlink in research artifact")
+                          raw_path = PurePosixPath(info.filename)
+                          if raw_path.is_absolute() or ".." in raw_path.parts:
+                              raise RuntimeError(f"unsafe artifact path: {info.filename!r}")
+                          parts = list(raw_path.parts)
+                          if "research-controller" in parts:
+                              parts = parts[parts.index("research-controller") + 1 :]
+                          if not parts:
+                              continue
+                          relative = Path(*parts)
+                          if not (
+                              relative.name in {"state.json", "latest.json"}
+                              or (
+                                  relative.name.startswith("report-")
+                                  and relative.suffix == ".json"
+                              )
+                          ):
+                              continue
+                          target = (staging_root / relative).resolve()
+                          if target != staging_root and staging_root not in target.parents:
+                              raise RuntimeError(f"artifact escaped target: {info.filename!r}")
+                          target.parent.mkdir(parents=True, exist_ok=True)
+                          with archive.open(info, "r") as source:
+                              target.write_bytes(source.read())
+                          restored += 1
+                  if restored:
+                      if target_root.exists():
+                          shutil.rmtree(target_root)
+                      staging_root.replace(target_root)
+              return restored
+
+          try:
+              payload = api(
+                  f"/repos/{repository}/actions/workflows/"
+                  "momentum-v3-research.yml/runs?status=success&per_page=30"
+              )
+              runs = sorted(
+                  (
+                      run
+                      for run in payload.get("workflow_runs", [])
+                      if int(run.get("id", -1)) != current_run_id
+                  ),
+                  key=lambda run: run.get("created_at", ""),
+                  reverse=True,
+              )
+              restored = 0
+              for run in runs:
+                  artifacts = api(
+                      f"/repos/{repository}/actions/runs/{int(run['id'])}/artifacts?per_page=100"
+                  ).get("artifacts", [])
+                  candidates = [
+                      artifact
+                      for artifact in artifacts
+                      if artifact.get("name", "").startswith("momentum-v3-research-")
+                      and not artifact.get("expired", False)
+                  ]
+                  for artifact in candidates:
+                      restored = restore_archive(artifact["archive_download_url"])
+                      if restored:
+                          print(
+                              f"Restored {restored} research files from run "
+                              f"{run['id']}."
+                          )
+                          break
+                  if restored:
+                      break
+              if not restored:
+                  print("No prior research artifact found; starting a fresh state.")
+          except Exception as exc:
+              # A missing/expired artifact must not turn into a trusted or
+              # partially restored state. The controller will fail closed on
+              # stale data and old state schemas.
+              print(f"Research state restore skipped: {exc}")
+          PY
 
       - name: Download completed Binance Vision history
         run: |
@@ -49,6 +183,8 @@ jobs:
             --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
             --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
             --min-aligned-bars 26280 \
+            --max-data-age-days 45 \
+            --required-consecutive-passes 3 \
             --output-dir artifacts/momentum-v3/research-controller
 
       - name: Upload research state and reports

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -26,6 +26,14 @@ jobs:
           tradingbot_ibkr/paper_lab_automation.py
           tradingbot_ibkr/rescue_runtime.py
           tradingbot_ibkr/strategy_candidates.py
+      - name: Research controller regression tests
+        run: |
+          python -m py_compile \
+            scripts/fetch_binance_vision_klines.py \
+            scripts/run_momentum_volatility_research.py \
+            scripts/run_momentum_volatility_v3.py \
+            scripts/run_v3_research_controller.py
+          pytest -q tests/test_v3_research_controller.py
       - run: bandit -r . -x tests || true
       - run: pip-audit || true
       - run: pytest --cov --cov-report=term-missing

--- a/backtest/optimization/execution_model.py
+++ b/backtest/optimization/execution_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,8 +15,9 @@ class ExecutionCostModel:
     commission_bps: float = 0.0
 
     def __post_init__(self) -> None:
-        if min(self.spread_bps, self.slippage_bps, self.commission_bps) < 0:
-            raise ValueError("execution costs cannot be negative")
+        values = (self.spread_bps, self.slippage_bps, self.commission_bps)
+        if not all(math.isfinite(float(value)) and value >= 0 for value in values):
+            raise ValueError("execution costs must be finite and non-negative")
 
     @property
     def per_fill_fraction(self) -> float:

--- a/docs/momentum_v3_research_loop.md
+++ b/docs/momentum_v3_research_loop.md
@@ -1,0 +1,60 @@
+# Continuous v3 research loop
+
+The v3 research phase now has a persistent controller:
+`scripts/run_v3_research_controller.py`.
+
+It evaluates the existing causal BTC/ETH v3 model at both `$4,000` and
+`$6,000` order notionals. It records each report and keeps a small state file
+so an unchanged dataset is not backtested repeatedly. A new historical data
+fingerprint or a change to the research implementation starts the next
+iteration.
+
+The controller marks `strategy_ready: true` only when the same candidate passes
+at both sizes and all of these conditions hold:
+
+- the v3 base-cost and higher-cost walk-forward medians are positive;
+- the full sample is profitable and has at least eight entries;
+- every base and stress walk-forward fold has at least five entries;
+- no full sample or fold has a permanent halt or repeated kill-switch events.
+
+The 1-day, 1-week, 1-month, and 1-year results remain visible in each report.
+The 1-day snapshot is evidence only; it cannot make a strategy ready by
+itself. A passing result is still a research finding requiring human review,
+paper probation, and explicit approval. The controller never changes the
+active profile, stages a finalist, enables leverage, or places orders.
+
+## Run once
+
+From the repository root, with the three-year normalized BTC/ETH files present:
+
+```bash
+python scripts/run_v3_research_controller.py \
+  --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+  --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+  --output-dir artifacts/momentum-v3/research-controller
+```
+
+The current state is written to:
+`artifacts/momentum-v3/research-controller/state.json` and
+`artifacts/momentum-v3/research-controller/latest.json`.
+
+## Keep a local process running
+
+This waits between checks and stops when the readiness gate passes:
+
+```bash
+python scripts/run_v3_research_controller.py \
+  --until-ready \
+  --interval-hours 24 \
+  --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+  --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+  --output-dir artifacts/momentum-v3/research-controller
+```
+
+Use `--force` for an intentional rerun when the files and research code are
+unchanged. For an unattended repository runner, the included
+`.github/workflows/momentum-v3-research.yml` runs after each completed month,
+downloads public Binance Vision history, uploads the state and reports, and
+uses read-only repository permissions.
+
+Do not use this loop as permission to promote a model or start live trading.

--- a/docs/momentum_v3_research_loop.md
+++ b/docs/momentum_v3_research_loop.md
@@ -1,60 +1,73 @@
 # Continuous v3 research loop
 
-The v3 research phase now has a persistent controller:
-`scripts/run_v3_research_controller.py`.
+The v3 research phase is driven by the persistent controller at
+scripts/run_v3_research_controller.py. It is a bounded research process, not a
+promotion or trading process.
 
-It evaluates the existing causal BTC/ETH v3 model at both `$4,000` and
-`$6,000` order notionals. It records each report and keeps a small state file
-so an unchanged dataset is not backtested repeatedly. A new historical data
-fingerprint or a change to the research implementation starts the next
-iteration.
+Every iteration evaluates exactly two order notionals: $4,000 and $6,000.
+Readiness requires the same candidate to pass at both sizes. Each size must
+contain:
 
-The controller marks `strategy_ready: true` only when the same candidate passes
-at both sizes and all of these conditions hold:
+- a profitable finite full-sample result at base and stress costs;
+- exactly three walk-forward folds, with finite results and at least five
+  entries in every base and stress fold;
+- a profitable finite one-year confirmation holdout at both cost levels, with
+  at least five entries and no permanent halt or repeated kill-switch event;
+- visible evidence for the 1-day, 1-week, 1-month, and 1-year snapshots.
 
-- the v3 base-cost and higher-cost walk-forward medians are positive;
-- the full sample is profitable and has at least eight entries;
-- every base and stress walk-forward fold has at least five entries;
-- no full sample or fold has a permanent halt or repeated kill-switch events.
+The four horizon snapshots are evidence only. In particular, a positive 1-day
+result cannot make a candidate ready. The full sample, stress full sample,
+walk-forward medians, and confirmation holdout are the actual gate inputs.
+Stress costs must be finite, non-negative, and strictly higher than base costs.
 
-The 1-day, 1-week, 1-month, and 1-year results remain visible in each report.
-The 1-day snapshot is evidence only; it cannot make a strategy ready by
-itself. A passing result is still a research finding requiring human review,
-paper probation, and explicit approval. The controller never changes the
-active profile, stages a finalist, enables leverage, or places orders.
+The controller uses fixed candidate definitions from the research runner. It
+does not select a winner by taking the best result from an arbitrary search
+space. A code or cost/configuration change changes the experiment signature and
+resets the readiness streak. The controller also requires the same candidate
+to pass at both sizes on three distinct data vintages before recording
+strategy_ready. These vintages are deliberately treated as repeated evidence,
+not as independent proof; a human must still review the reports and holdout
+before any promotion decision.
+
+The output state is research metadata only. The controller never changes the
+active profile, stages a finalist, enables leverage, places paper or live
+orders, changes risk limits, or merges a pull request. Any promotion remains a
+separate manual action after review and paper probation.
 
 ## Run once
 
-From the repository root, with the three-year normalized BTC/ETH files present:
+From the repository root, with normalized BTC and ETH files present:
 
-```bash
-python scripts/run_v3_research_controller.py \
-  --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
-  --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
-  --output-dir artifacts/momentum-v3/research-controller
-```
+    python scripts/run_v3_research_controller.py \
+      --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+      --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+      --output-dir artifacts/momentum-v3/research-controller
 
-The current state is written to:
-`artifacts/momentum-v3/research-controller/state.json` and
-`artifacts/momentum-v3/research-controller/latest.json`.
+The controller rejects non-finite or malformed OHLCV values, mismatched BTC/ETH
+coverage, unsynchronized gaps, gaps over six hours, and data older than 45 days
+by default. It writes state.json, latest.json, and per-iteration reports under
+artifacts/momentum-v3/research-controller. An old state schema is discarded
+rather than trusted.
 
-## Keep a local process running
+## Unchanged data and bounded polling
 
-This waits between checks and stops when the readiness gate passes:
+When the input data, source files, and research configuration have not changed,
+the controller records a skip and does not rerun the backtest. Use --force only
+for a deliberate rerun. The --until-ready mode requires --max-iterations so an
+unattended process has a finite stop bound, for example:
 
-```bash
-python scripts/run_v3_research_controller.py \
-  --until-ready \
-  --interval-hours 24 \
-  --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
-  --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
-  --output-dir artifacts/momentum-v3/research-controller
-```
+    python scripts/run_v3_research_controller.py \
+      --until-ready \
+      --max-iterations 30 \
+      --interval-hours 24 \
+      --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+      --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+      --output-dir artifacts/momentum-v3/research-controller
 
-Use `--force` for an intentional rerun when the files and research code are
-unchanged. For an unattended repository runner, the included
-`.github/workflows/momentum-v3-research.yml` runs after each completed month,
-downloads public Binance Vision history, uploads the state and reports, and
-uses read-only repository permissions.
+The monthly GitHub Actions workflow downloads completed Binance Vision months,
+restores the most recent successful research artifact when available, and
+uploads the new state and reports. Its token has only actions: read and
+contents: read permissions. Restore is optional; stale or incompatible state
+is never used as evidence.
 
 Do not use this loop as permission to promote a model or start live trading.

--- a/docs/momentum_v3_research_loop.md
+++ b/docs/momentum_v3_research_loop.md
@@ -64,6 +64,32 @@ so changing it causes a fresh research iteration rather than reusing prior
 evidence. No network sentiment feed is fetched by the runner; any context file
 must be supplied as a timestamped research input.
 
+## Matrix diagnostic on repository sample data
+
+The repository includes a 240-row synthetic OHLCV fixture for smoke testing the
+matrix only. It is not market evidence and must not be reported as strategy
+performance. Run it with a window size that produces three non-overlapping
+windows:
+
+    mkdir -p artifacts
+    python scripts/run_research_matrix.py \
+      backtest/sample_data/sample_ohlcv.csv \
+      --window-size 80 \
+      --test-fraction 0.30 \
+      --spread-bps 12 \
+      --slippage-bps 8 \
+      --commission-bps 0 \
+      --expected-move-bps 40 \
+      | tee artifacts/research-matrix-sample.json
+
+The matrix applies execution costs and reports net return, cost drag, drawdown,
+Sharpe, profit factor, and trade count. A family is not research-gate eligible
+because its best test slice is profitable: it needs at least three windows,
+at least five trades per window, positive median net return and Sharpe, a finite
+median profit factor of at least 1.05, at least two-thirds profitable windows,
+and no test drawdown above 20%. A failed gate is expected on a small synthetic
+fixture.
+
 ## Run once
 
 From the repository root, with normalized BTC and ETH files present:

--- a/docs/momentum_v3_research_loop.md
+++ b/docs/momentum_v3_research_loop.md
@@ -34,6 +34,36 @@ active profile, stages a finalist, enables leverage, places paper or live
 orders, changes risk limits, or merges a pull request. Any promotion remains a
 separate manual action after review and paper probation.
 
+## Context, liquidity, and execution gates
+
+The runner accepts an optional operator-supplied context CSV with the columns
+`timestamp,sentiment,impact`. Sentiment must be between -1 and 1; impact must
+be non-negative. Events are aligned strictly as-of each bar: future events are
+never visible, and events older than the configured lookback expire. If no
+context CSV is supplied, sentiment is neutral and event blocking is inactive;
+the causal liquidity and execution-cost gates still apply.
+
+Entries also require volume relative to the prior-bar median, an ATR-based
+expected move that covers the configured round-trip fees and slippage plus a
+minimum edge buffer, and the existing higher-timeframe/regime/leader
+conditions. Strongly adverse context reduces size; high-impact or sufficiently
+negative context blocks entries. The runner keeps one position at a time, so
+the portfolio exposure/correlation control remains explicit. These are
+research filters only and do not change live or paper risk limits.
+
+For a context-enabled run:
+
+    python scripts/run_v3_research_controller.py \
+      --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+      --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+      --context-csv data/research/context.csv \
+      --output-dir artifacts/momentum-v3/research-controller
+
+The controller fingerprints the context file as part of the experiment input,
+so changing it causes a fresh research iteration rather than reusing prior
+evidence. No network sentiment feed is fetched by the runner; any context file
+must be supplied as a timestamped research input.
+
 ## Run once
 
 From the repository root, with normalized BTC and ETH files present:

--- a/scripts/fetch_binance_vision_klines.py
+++ b/scripts/fetch_binance_vision_klines.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Download and normalize Binance Vision spot kline archives.
+
+The output is deliberately a simple CSV accepted by
+``scripts/run_historical_momentum_backtest.py``.  Binance's public archive is
+used instead of an exchange API so a backtest can be reproduced later without
+API keys or exchange pagination changes.
+
+Example:
+    python scripts/fetch_binance_vision_klines.py \
+        --symbols BTCUSDT ETHUSDT --since 2023-01 --until 2026-08
+
+``--until`` is exclusive and uses UTC calendar months.  Raw archives and their
+checksums are retained by default; do not commit either directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import re
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASE_URL = "https://data.binance.vision"
+INTERVAL = "1h"
+KLINE_COLUMNS = (
+    "open_time", "open", "high", "low", "close", "volume", "close_time",
+    "quote_volume", "trades", "taker_buy_base", "taker_buy_quote", "ignore",
+)
+
+
+def month_iter(since: str, until: str) -> list[tuple[int, int]]:
+    start = datetime.strptime(since, "%Y-%m")
+    end = datetime.strptime(until, "%Y-%m")
+    if start >= end:
+        raise ValueError("--since must be earlier than exclusive --until")
+    result: list[tuple[int, int]] = []
+    year, month = start.year, start.month
+    while (year, month) < (end.year, end.month):
+        result.append((year, month))
+        month += 1
+        if month == 13:
+            year, month = year + 1, 1
+    return result
+
+
+def _download(url: str) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": "trading-bot-historical-data/1.0"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read()
+
+
+def _checksum(zip_bytes: bytes, checksum_text: str) -> str:
+    expected = checksum_text.strip().split()[0].lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", expected):
+        raise ValueError(f"unrecognized checksum format: {checksum_text!r}")
+    actual = hashlib.sha256(zip_bytes).hexdigest()
+    if actual != expected:
+        raise ValueError(f"checksum mismatch: expected {expected}, got {actual}")
+    return actual
+
+
+def _timestamp_iso(raw: str) -> str:
+    value = int(float(raw))
+    # Binance spot archive timestamps are milliseconds before 2025 and
+    # microseconds from 2025 onward. Normalize both to UTC milliseconds.
+    if value >= 10**14:
+        value //= 1000
+    return datetime.fromtimestamp(value / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _read_archive(zip_bytes: bytes) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as archive:
+        csv_names = [name for name in archive.namelist() if name.lower().endswith(".csv")]
+        if len(csv_names) != 1:
+            raise ValueError(f"expected one CSV in archive, found {csv_names}")
+        with archive.open(csv_names[0], "r") as raw:
+            text = io.TextIOWrapper(raw, encoding="utf-8", newline="")
+            reader = csv.reader(text)
+            for values in reader:
+                if not values or values[0].lower() in {"open time", "open_time"}:
+                    continue
+                if len(values) < 6:
+                    raise ValueError("kline row has fewer than six columns")
+                rows.append({
+                    "timestamp": _timestamp_iso(values[0]),
+                    "open": values[1],
+                    "high": values[2],
+                    "low": values[3],
+                    "close": values[4],
+                    "volume": values[5],
+                })
+    return rows
+
+
+def _validate_rows(rows: list[dict[str, str]]) -> dict[str, object]:
+    if not rows:
+        raise ValueError("no kline rows found")
+    rows.sort(key=lambda row: row["timestamp"])
+    timestamps = [datetime.fromisoformat(row["timestamp"].replace("Z", "+00:00")) for row in rows]
+    duplicate_count = len(timestamps) - len(set(timestamps))
+    if duplicate_count:
+        raise ValueError(f"normalized data contains {duplicate_count} duplicate timestamps")
+    invalid = []
+    for row in rows:
+        high, low, close = float(row["high"]), float(row["low"]), float(row["close"])
+        if min(high, low, close) <= 0 or high < low:
+            invalid.append(row["timestamp"])
+    if invalid:
+        raise ValueError(f"invalid OHLC values at {invalid[:3]}")
+    gaps = []
+    for previous, current in zip(timestamps, timestamps[1:]):
+        hours = (current - previous).total_seconds() / 3600
+        if hours > 1.5:
+            gaps.append({"from": previous.isoformat(), "to": current.isoformat(), "hours": hours})
+    return {
+        "rows": len(rows),
+        "start": rows[0]["timestamp"],
+        "end": rows[-1]["timestamp"],
+        "gaps_over_1_5_hours": gaps,
+    }
+
+
+def fetch_symbol(symbol: str, since: str, until: str, raw_dir: Path, out_dir: Path) -> dict[str, object]:
+    rows_by_timestamp: dict[str, dict[str, str]] = {}
+    archives: list[dict[str, object]] = []
+    raw_symbol_dir = raw_dir / symbol
+    raw_symbol_dir.mkdir(parents=True, exist_ok=True)
+
+    for year, month in month_iter(since, until):
+        stem = f"{symbol}-{INTERVAL}-{year:04d}-{month:02d}"
+        zip_path = raw_symbol_dir / f"{stem}.zip"
+        checksum_path = raw_symbol_dir / f"{stem}.zip.CHECKSUM"
+        url = f"{BASE_URL}/data/spot/monthly/klines/{symbol}/{INTERVAL}/{stem}.zip"
+        try:
+            zip_bytes = zip_path.read_bytes() if zip_path.exists() else _download(url)
+            if not zip_path.exists():
+                zip_path.write_bytes(zip_bytes)
+            checksum_url = f"{url}.CHECKSUM"
+            checksum_text = checksum_path.read_text(encoding="utf-8") if checksum_path.exists() else _download(checksum_url).decode()
+            checksum_path.write_text(checksum_text, encoding="utf-8")
+            digest = _checksum(zip_bytes, checksum_text)
+            month_rows = _read_archive(zip_bytes)
+            for row in month_rows:
+                rows_by_timestamp[row["timestamp"]] = row
+            archives.append({"file": zip_path.name, "url": url, "sha256": digest, "rows": len(month_rows)})
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(f"archive unavailable for {symbol} {year:04d}-{month:02d}: HTTP {exc.code}; use a completed month") from exc
+
+    rows = list(rows_by_timestamp.values())
+    summary = _validate_rows(rows)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output_path = out_dir / f"{symbol}_{INTERVAL}.csv"
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["timestamp", "open", "high", "low", "close", "volume"])
+        writer.writeheader()
+        writer.writerows(sorted(rows, key=lambda row: row["timestamp"]))
+    manifest = {"source": BASE_URL, "symbol": symbol, "interval": INTERVAL, "since": since, "until_exclusive": until, "archives": archives, **summary}
+    (out_dir / f"{symbol}_{INTERVAL}.manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return {"output": str(output_path), **summary}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbols", nargs="+", default=["BTCUSDT", "ETHUSDT"])
+    parser.add_argument("--since", required=True, help="inclusive UTC month, YYYY-MM")
+    parser.add_argument("--until", required=True, help="exclusive UTC month, YYYY-MM")
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/historical/binance/raw"))
+    parser.add_argument("--out-dir", type=Path, default=Path("data/historical/binance/normalized"))
+    args = parser.parse_args()
+    print(json.dumps({symbol: fetch_symbol(symbol, args.since, args.until, args.raw_dir, args.out_dir) for symbol in args.symbols}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_binance_vision_klines.py
+++ b/scripts/fetch_binance_vision_klines.py
@@ -21,6 +21,7 @@ import csv
 import hashlib
 import io
 import json
+import math
 import re
 import urllib.error
 import urllib.request
@@ -111,8 +112,18 @@ def _validate_rows(rows: list[dict[str, str]]) -> dict[str, object]:
         raise ValueError(f"normalized data contains {duplicate_count} duplicate timestamps")
     invalid = []
     for row in rows:
-        high, low, close = float(row["high"]), float(row["low"]), float(row["close"])
-        if min(high, low, close) <= 0 or high < low:
+        open_price = float(row["open"])
+        high = float(row["high"])
+        low = float(row["low"])
+        close = float(row["close"])
+        volume = float(row["volume"])
+        if (
+            not all(math.isfinite(value) for value in (open_price, high, low, close, volume))
+            or min(open_price, high, low, close) <= 0
+            or high < max(open_price, close)
+            or low > min(open_price, close)
+            or volume < 0
+        ):
             invalid.append(row["timestamp"])
     if invalid:
         raise ValueError(f"invalid OHLC values at {invalid[:3]}")
@@ -150,7 +161,13 @@ def fetch_symbol(symbol: str, since: str, until: str, raw_dir: Path, out_dir: Pa
             digest = _checksum(zip_bytes, checksum_text)
             month_rows = _read_archive(zip_bytes)
             for row in month_rows:
-                rows_by_timestamp[row["timestamp"]] = row
+                timestamp = row["timestamp"]
+                existing = rows_by_timestamp.get(timestamp)
+                if existing is not None and existing != row:
+                    raise ValueError(
+                        f"conflicting duplicate kline at {symbol} {timestamp}"
+                    )
+                rows_by_timestamp[timestamp] = row
             archives.append({"file": zip_path.name, "url": url, "sha256": digest, "rows": len(month_rows)})
         except urllib.error.HTTPError as exc:
             raise RuntimeError(f"archive unavailable for {symbol} {year:04d}-{month:02d}: HTTP {exc.code}; use a completed month") from exc

--- a/scripts/momentum_context.py
+++ b/scripts/momentum_context.py
@@ -25,10 +25,16 @@ class ContextEvent:
     source: str = "unknown"
 
     def __post_init__(self) -> None:
-        if not -1.0 <= self.sentiment <= 1.0:
-            raise ValueError("sentiment must be between -1 and 1")
-        if self.impact < 0:
-            raise ValueError("impact cannot be negative")
+        timestamp = _utc(self.timestamp)
+        sentiment = float(self.sentiment)
+        impact = float(self.impact)
+        object.__setattr__(self, "timestamp", timestamp)
+        object.__setattr__(self, "sentiment", sentiment)
+        object.__setattr__(self, "impact", impact)
+        if not math.isfinite(sentiment) or not -1.0 <= sentiment <= 1.0:
+            raise ValueError("sentiment must be finite and between -1 and 1")
+        if not math.isfinite(impact) or impact < 0:
+            raise ValueError("impact must be finite and non-negative")
 
 
 def _utc(value: Any) -> datetime:
@@ -91,7 +97,11 @@ def align_context(
 ) -> dict[str, list[float]]:
     """Align events strictly as-of each bar timestamp."""
 
-    ordered = sorted(events, key=lambda event: event.timestamp)
+    if lookback.total_seconds() <= 0:
+        raise ValueError("lookback must be positive")
+    if not math.isfinite(risk_impact_threshold) or risk_impact_threshold < 0:
+        raise ValueError("risk_impact_threshold must be finite and non-negative")
+    ordered = sorted(list(events), key=lambda event: event.timestamp)
     output = {
         "context_sentiment": [],
         "context_impact": [],
@@ -129,6 +139,8 @@ def build_context_features(
 ) -> dict[str, list[float]]:
     """Build causal context and liquidity proxies for OHLCV bars."""
 
+    if volume_window <= 0 or lookback_hours <= 0:
+        raise ValueError("volume_window and lookback_hours must be positive")
     timestamps = [bar.timestamp for bar in bars]
     volumes = [float(bar.volume) for bar in bars]
     context = align_context(

--- a/scripts/momentum_context.py
+++ b/scripts/momentum_context.py
@@ -1,0 +1,148 @@
+"""Causal sentiment, event-risk, and liquidity features for research.
+
+This module is intentionally offline and research-only.  It accepts a timestamped
+CSV supplied by the operator; it never fetches news, places orders, or changes
+paper/live configuration.  Every event is used only at or after its timestamp.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from statistics import median
+from typing import Any, Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class ContextEvent:
+    timestamp: datetime
+    sentiment: float
+    impact: float
+    category: str = "unknown"
+    source: str = "unknown"
+
+    def __post_init__(self) -> None:
+        if not -1.0 <= self.sentiment <= 1.0:
+            raise ValueError("sentiment must be between -1 and 1")
+        if self.impact < 0:
+            raise ValueError("impact cannot be negative")
+
+
+def _utc(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        timestamp = value
+    else:
+        timestamp = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
+
+
+def load_context_events(path: Path) -> list[ContextEvent]:
+    """Load an operator-supplied timestamped context CSV.
+
+    Required columns are timestamp,sentiment,impact.  Events are sorted and
+    validated before use.  This function does not infer sentiment from future
+    prices and does not permit malformed timestamps.
+    """
+
+    events: list[ContextEvent] = []
+    with Path(path).open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        required = {"timestamp", "sentiment", "impact"}
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            raise ValueError(f"context CSV missing columns: {sorted(missing)}")
+        for row in reader:
+            events.append(
+                ContextEvent(
+                    timestamp=_utc(row["timestamp"]),
+                    sentiment=float(row["sentiment"]),
+                    impact=float(row["impact"]),
+                    category=str(row.get("category", "unknown")),
+                    source=str(row.get("source", "unknown")),
+                )
+            )
+    return sorted(events, key=lambda event: event.timestamp)
+
+
+def _prior_median(values: Sequence[float], index: int, window: int) -> float:
+    prior = [float(value) for value in values[max(0, index - window):index] if float(value) > 0]
+    return median(prior) if prior else math.nan
+
+
+def _volume_ratios(volumes: Sequence[float], window: int) -> list[float]:
+    ratios: list[float] = []
+    for index, volume in enumerate(volumes):
+        baseline = _prior_median(volumes, index, window)
+        ratios.append(float(volume) / baseline if baseline > 0 else math.nan)
+    return ratios
+
+
+def align_context(
+    timestamps: Iterable[Any],
+    events: Sequence[ContextEvent],
+    *,
+    lookback: timedelta = timedelta(hours=24),
+    risk_impact_threshold: float = 0.75,
+) -> dict[str, list[float]]:
+    """Align events strictly as-of each bar timestamp."""
+
+    ordered = sorted(events, key=lambda event: event.timestamp)
+    output = {
+        "context_sentiment": [],
+        "context_impact": [],
+        "context_event_count": [],
+        "context_risk_event": [],
+    }
+    for raw_timestamp in timestamps:
+        timestamp = _utc(raw_timestamp)
+        recent = [
+            event
+            for event in ordered
+            if timestamp - lookback <= event.timestamp <= timestamp
+        ]
+        total_impact = sum(event.impact for event in recent)
+        sentiment = (
+            sum(event.sentiment * event.impact for event in recent) / total_impact
+            if total_impact > 0
+            else 0.0
+        )
+        output["context_sentiment"].append(float(sentiment))
+        output["context_impact"].append(float(max((event.impact for event in recent), default=0.0)))
+        output["context_event_count"].append(float(len(recent)))
+        output["context_risk_event"].append(
+            1.0 if any(event.impact >= risk_impact_threshold for event in recent) else 0.0
+        )
+    return output
+
+
+def build_context_features(
+    bars: Sequence[Any],
+    events: Sequence[ContextEvent] | None = None,
+    *,
+    volume_window: int = 20,
+    lookback_hours: int = 24,
+) -> dict[str, list[float]]:
+    """Build causal context and liquidity proxies for OHLCV bars."""
+
+    timestamps = [bar.timestamp for bar in bars]
+    volumes = [float(bar.volume) for bar in bars]
+    context = align_context(
+        timestamps,
+        list(events or []),
+        lookback=timedelta(hours=lookback_hours),
+    )
+    context["volume_ratio"] = _volume_ratios(volumes, volume_window)
+    return context
+
+
+__all__ = [
+    "ContextEvent",
+    "align_context",
+    "build_context_features",
+    "load_context_events",
+]

--- a/scripts/run_momentum_volatility_research.py
+++ b/scripts/run_momentum_volatility_research.py
@@ -46,14 +46,38 @@ def load_bars(path: Path) -> list[Bar]:
                 ts = datetime.fromtimestamp(value / 1000, tz=timezone.utc)
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=timezone.utc)
-            bars.append(Bar(ts, float(row["open"]), float(row["high"]), float(row["low"]), float(row["close"]), float(row.get("volume", 0))))
+            values = {
+                "open": float(row["open"]),
+                "high": float(row["high"]),
+                "low": float(row["low"]),
+                "close": float(row["close"]),
+                "volume": float(row.get("volume", 0)),
+            }
+            if not all(math.isfinite(value) for value in values.values()):
+                raise ValueError("historical CSV contains non-finite numeric values")
+            bars.append(
+                Bar(
+                    ts,
+                    values["open"],
+                    values["high"],
+                    values["low"],
+                    values["close"],
+                    values["volume"],
+                )
+            )
     bars.sort(key=lambda item: item.timestamp)
     if not bars:
         raise ValueError("historical CSV is empty")
     if any(a.timestamp == b.timestamp for a, b in zip(bars, bars[1:])):
         raise ValueError("historical CSV contains duplicate timestamps")
-    if any(min(b.open, b.high, b.low, b.close) <= 0 or b.high < b.low for b in bars):
-        raise ValueError("historical CSV contains invalid OHLC values")
+    for bar in bars:
+        if (
+            min(bar.open, bar.high, bar.low, bar.close) <= 0
+            or bar.high < max(bar.open, bar.close)
+            or bar.low > min(bar.open, bar.close)
+            or bar.volume < 0
+        ):
+            raise ValueError("historical CSV contains invalid OHLC or volume values")
     return bars
 
 
@@ -95,11 +119,18 @@ def _higher_timeframe_flags(
     slow_value: float | None = None
     previous_slow: float | None = None
     current_flag = 0.0
+    previous_timestamp = None
     for index, bar in enumerate(bars):
         bucket = int(bar.timestamp.timestamp()) // (group_size * 3600)
-        if bucket != current_bucket:
+        gap = (
+            previous_timestamp is not None
+            and (bar.timestamp - previous_timestamp).total_seconds() != 3600
+        )
+        if gap or bucket != current_bucket:
             current_bucket = bucket
             current_count = 0
+            if gap:
+                current_flag = 0.0
         current_count += 1
         if current_count == group_size:
             completed_closes.append(bar.close)
@@ -128,6 +159,7 @@ def _higher_timeframe_flags(
                     and slow_value > previous_slow
                 )
         flags[index] = current_flag
+        previous_timestamp = bar.timestamp
     return flags
 
 
@@ -581,8 +613,8 @@ def main() -> None:
         bearish_exit_requires_breakdown=v2,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
-    print(json.dumps(report, indent=2))
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(json.dumps(report, indent=2, allow_nan=False))
 
 
 if __name__ == "__main__":

--- a/scripts/run_momentum_volatility_research.py
+++ b/scripts/run_momentum_volatility_research.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""Research a causal momentum-plus-volatility breakout strategy.
+
+This runner intentionally uses only the Python standard library. Signals are
+formed at a bar close and orders fill at the next bar open, with an ATR trail,
+fees, slippage, and the 2% kill switch. It is research-only and does not touch
+the paper operator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Bar:
+    timestamp: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+def load_bars(path: Path) -> list[Bar]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = csv.DictReader(handle)
+        bars = []
+        for row in rows:
+            raw = row.get("timestamp") or row.get("ts") or row.get("date")
+            if raw is None:
+                raise ValueError("CSV requires timestamp, ts, or date")
+            try:
+                ts = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except ValueError:
+                value = int(float(raw))
+                if value >= 10**14:
+                    value //= 1000
+                ts = datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            bars.append(Bar(ts, float(row["open"]), float(row["high"]), float(row["low"]), float(row["close"]), float(row.get("volume", 0))))
+    bars.sort(key=lambda item: item.timestamp)
+    if not bars:
+        raise ValueError("historical CSV is empty")
+    if any(a.timestamp == b.timestamp for a, b in zip(bars, bars[1:])):
+        raise ValueError("historical CSV contains duplicate timestamps")
+    if any(min(b.open, b.high, b.low, b.close) <= 0 or b.high < b.low for b in bars):
+        raise ValueError("historical CSV contains invalid OHLC values")
+    return bars
+
+
+def _ema(values: list[float], span: int) -> list[float]:
+    alpha = 2 / (span + 1)
+    result: list[float] = []
+    value = values[0]
+    for item in values:
+        value = alpha * item + (1 - alpha) * value
+        result.append(value)
+    return result
+
+
+def _percentile(value: float, prior: list[float]) -> float:
+    if not prior:
+        return math.nan
+    return sum(item <= value for item in prior) / len(prior)
+
+
+def _higher_timeframe_flags(
+    bars: list[Bar],
+    *,
+    group_size: int,
+    fast_window: int,
+    slow_window: int,
+) -> list[float]:
+    """Return a causal higher-timeframe trend flag for every source bar.
+
+    A higher-timeframe candle is only added after its final source candle has
+    closed. Incomplete buckets are discarded when a timestamp gap or bucket
+    boundary is encountered, so the flag never uses future candles.
+    """
+
+    flags = [0.0] * len(bars)
+    completed_closes: list[float] = []
+    current_bucket: int | None = None
+    current_count = 0
+    fast_value: float | None = None
+    slow_value: float | None = None
+    previous_slow: float | None = None
+    current_flag = 0.0
+    for index, bar in enumerate(bars):
+        bucket = int(bar.timestamp.timestamp()) // (group_size * 3600)
+        if bucket != current_bucket:
+            current_bucket = bucket
+            current_count = 0
+        current_count += 1
+        if current_count == group_size:
+            completed_closes.append(bar.close)
+            alpha_fast = 2.0 / (fast_window + 1.0)
+            alpha_slow = 2.0 / (slow_window + 1.0)
+            previous_slow = slow_value
+            fast_value = (
+                bar.close
+                if fast_value is None
+                else alpha_fast * bar.close + (1.0 - alpha_fast) * fast_value
+            )
+            slow_value = (
+                bar.close
+                if slow_value is None
+                else alpha_slow * bar.close + (1.0 - alpha_slow) * slow_value
+            )
+            if (
+                len(completed_closes) >= slow_window
+                and fast_value is not None
+                and slow_value is not None
+                and previous_slow is not None
+            ):
+                current_flag = float(
+                    fast_value > slow_value
+                    and bar.close > slow_value
+                    and slow_value > previous_slow
+                )
+        flags[index] = current_flag
+    return flags
+
+
+def features(
+    bars: list[Bar],
+    *,
+    atr_period: int = 14,
+    regime_window: int = 720,
+    volume_lookback: int = 20,
+    higher_timeframe_bars: int = 4,
+    higher_timeframe_fast_window: int = 5,
+    higher_timeframe_slow_window: int = 20,
+) -> dict[str, list[float]]:
+    closes = [bar.close for bar in bars]
+    true_ranges: list[float] = []
+    returns: list[float] = [math.nan]
+    for i, bar in enumerate(bars):
+        previous = closes[i - 1] if i else bar.close
+        true_ranges.append(max(bar.high - bar.low, abs(bar.high - previous), abs(bar.low - previous)))
+        returns.append(math.log(bar.close / previous) if i and previous > 0 else math.nan)
+    atr: list[float] = [math.nan] * len(bars)
+    atr_pct: list[float] = [math.nan] * len(bars)
+    realized: list[float] = [math.nan] * len(bars)
+    atr_rank: list[float] = [math.nan] * len(bars)
+    realized_rank: list[float] = [math.nan] * len(bars)
+    volume_median: list[float] = [math.nan] * len(bars)
+    for i in range(len(bars)):
+        if i + 1 >= atr_period:
+            atr[i] = sum(true_ranges[i - atr_period + 1 : i + 1]) / atr_period
+            atr_pct[i] = atr[i] / closes[i]
+        if i >= 23:
+            sample = [x for x in returns[i - 23 : i + 1] if not math.isnan(x)]
+            realized[i] = statistics.pstdev(sample) if len(sample) > 1 else math.nan
+        prior_atr = [x for x in atr_pct[max(0, i - regime_window) : i] if not math.isnan(x)]
+        prior_realized = [x for x in realized[max(0, i - regime_window) : i] if not math.isnan(x)]
+        prior_volumes = [
+            bar.volume
+            for bar in bars[max(0, i - volume_lookback) : i]
+            if bar.volume > 0
+        ]
+        if prior_volumes:
+            volume_median[i] = statistics.median(prior_volumes)
+        if atr_pct[i] == atr_pct[i] and len(prior_atr) >= 100:
+            atr_rank[i] = _percentile(atr_pct[i], prior_atr)
+        if realized[i] == realized[i] and len(prior_realized) >= 100:
+            realized_rank[i] = _percentile(realized[i], prior_realized)
+    return {
+        "ema_fast": _ema(closes, 8),
+        "ema_slow": _ema(closes, 21),
+        "ema_regime_100": _ema(closes, 100),
+        "ema_regime_200": _ema(closes, 200),
+        "atr": atr,
+        "atr_pct": atr_pct,
+        "atr_rank": atr_rank,
+        "realized": realized,
+        "realized_rank": realized_rank,
+        "volume_median": volume_median,
+        "higher_timeframe_trend": _higher_timeframe_flags(
+            bars,
+            group_size=higher_timeframe_bars,
+            fast_window=higher_timeframe_fast_window,
+            slow_window=higher_timeframe_slow_window,
+        ),
+    }
+
+
+def _summary(values: list[float]) -> dict[str, float]:
+    clean = sorted(x for x in values if x == x)
+    if not clean:
+        return {}
+    return {f"p{p}": clean[min(len(clean) - 1, int((len(clean) - 1) * p / 100))] for p in (10, 25, 50, 75, 90, 95)}
+
+
+def run(
+    bars: list[Bar],
+    *,
+    initial_balance: float,
+    order_notional: float,
+    fees_bps: float,
+    slippage_bps: float,
+    lower_vol_rank: float = 0.25,
+    upper_vol_rank: float = 0.90,
+    expansion_ratio: float = 1.05,
+    trail_atr: float = 2.5,
+    regime_span: int = 100,
+    cooldown_bars: int = 12,
+    stable_bars: int = 12,
+    require_two_bullish_candles: bool = True,
+    exit_on_bearish_candle: bool = True,
+    entry_min_body_atr: float = 0.5,
+    breakout_lookback: int = 20,
+    entry_volume_multiplier: float = 1.0,
+    require_higher_timeframe_trend: bool = True,
+    higher_timeframe_bars: int = 4,
+    higher_timeframe_fast_window: int = 5,
+    higher_timeframe_slow_window: int = 20,
+    bearish_exit_min_body_atr: float = 0.75,
+    bearish_exit_requires_breakdown: bool = True,
+    hard_stop_atr: float = 2.0,
+) -> dict[str, object]:
+    if initial_balance <= 0 or order_notional <= 0:
+        raise ValueError("initial_balance and order_notional must be positive")
+    if entry_min_body_atr < 0 or bearish_exit_min_body_atr < 0:
+        raise ValueError("candle body ATR thresholds must be non-negative")
+    if breakout_lookback <= 0:
+        raise ValueError("breakout_lookback must be positive")
+    if entry_volume_multiplier < 0:
+        raise ValueError("entry_volume_multiplier must be non-negative")
+    if (
+        higher_timeframe_bars <= 0
+        or higher_timeframe_fast_window <= 0
+        or higher_timeframe_slow_window <= 0
+        or higher_timeframe_fast_window >= higher_timeframe_slow_window
+    ):
+        raise ValueError("invalid higher timeframe parameters")
+    if hard_stop_atr <= 0 or trail_atr <= 0:
+        raise ValueError("hard_stop_atr and trail_atr must be positive")
+    f = features(
+        bars,
+        higher_timeframe_bars=higher_timeframe_bars,
+        higher_timeframe_fast_window=higher_timeframe_fast_window,
+        higher_timeframe_slow_window=higher_timeframe_slow_window,
+    )
+    fee = fees_bps / 10_000
+    slip = slippage_bps / 10_000
+    cash, qty = initial_balance, 0.0
+    entry, hard_stop, stop, highest = 0.0, 0.0, 0.0, 0.0
+    peak, risk_peak, max_dd = initial_balance, initial_balance, 0.0
+    trades, killed, pending_entry, pending_exit = 0, False, False, False
+    entry_points, expansion_points, tradable_points = 0, 0, 0
+    bullish_confirmation_points, bearish_exit_points = 0, 0
+    kill_events, recovery_events = 0, 0
+    halted, blocked_until, stable_count = False, -1, 0
+    for i, bar in enumerate(bars):
+        if pending_exit and qty:
+            fill = bar.open * (1 - slip)
+            cash += qty * fill * (1 - fee)
+            qty, trades, pending_exit = 0.0, trades + 1, False
+        if pending_entry and not qty and cash > 0:
+            fill = bar.open * (1 + slip)
+            notional = min(order_notional, cash)
+            qty = notional / fill * (1 - fee)
+            cash -= notional
+            entry, highest = fill, bar.open
+            stop_atr = (
+                f["atr"][i - 1]
+                if i and f["atr"][i - 1] == f["atr"][i - 1]
+                else entry * 0.02
+            )
+            hard_stop = entry - hard_stop_atr * stop_atr
+            stop = entry - trail_atr * stop_atr
+            trades, pending_entry = trades + 1, False
+        stop_triggered = False
+        if qty:
+            active_stop = max(hard_stop, stop)
+            if bar.low <= active_stop:
+                fill = active_stop * (1 - slip)
+                cash += qty * fill * (1 - fee)
+                qty, trades, pending_exit = 0.0, trades + 1, False
+                stop_triggered = True
+            else:
+                highest = max(highest, bar.high)
+                atr = f["atr"][i]
+                if atr == atr:
+                    stop = max(stop, highest - trail_atr * atr)
+        equity = cash + qty * bar.close
+        peak = max(peak, equity)
+        max_dd = max(max_dd, (peak - equity) / peak if peak else 0.0)
+        risk_peak = max(risk_peak, equity)
+        risk_dd = (risk_peak - equity) / risk_peak if risk_peak else 0.0
+        if risk_dd >= 0.02 and not halted:
+            if qty:
+                fill = bar.close * (1 - slip)
+                cash += qty * fill * (1 - fee)
+                qty, trades = 0.0, trades + 1
+            killed = True
+            kill_events += 1
+            blocked_until = i + cooldown_bars
+            stable_count = 0
+            halted = True
+            risk_peak = cash
+            pending_entry = pending_exit = False
+            continue
+        if i < 2 or i + 1 >= len(bars):
+            continue
+        atr_rank = f["atr_rank"][i]
+        rv_rank = f["realized_rank"][i]
+        atr_now, atr_prior = f["atr_pct"][i], f["atr_pct"][i - 24] if i >= 24 else math.nan
+        prior_start = i - breakout_lookback - 1
+        prior_end = i - 1
+        prior_bars = bars[max(0, prior_start) : prior_end]
+        prior_high = max((x.high for x in prior_bars), default=math.nan)
+        tradable = (
+            atr_rank == atr_rank and rv_rank == rv_rank and lower_vol_rank <= atr_rank <= upper_vol_rank
+            and 0.005 <= atr_now <= 0.05 and atr_prior == atr_prior and atr_now / atr_prior >= expansion_ratio
+        )
+        regime = f[f"ema_regime_{regime_span}"][i]
+        regime_prior = f[f"ema_regime_{regime_span}"][i - 24] if i >= 24 else math.nan
+        trend = (
+            f["ema_fast"][i] > f["ema_slow"][i]
+            and bars[i].close > f["ema_slow"][i]
+            and regime == regime
+            and bars[i].close > regime
+            and regime_prior == regime_prior
+            and regime > regime_prior
+        )
+        breakout = prior_high == prior_high and bars[i].close > prior_high
+        if tradable:
+            tradable_points += 1
+        if atr_now == atr_now and atr_prior == atr_prior and atr_now / atr_prior >= expansion_ratio:
+            expansion_points += 1
+        if trend and breakout:
+            entry_points += 1
+        bullish_confirmation = (
+            bars[i - 1].close > bars[i - 1].open
+            and bars[i].close > bars[i].open
+        )
+        if bullish_confirmation:
+            bullish_confirmation_points += 1
+        atr_value = f["atr"][i]
+        volume_confirmation = (
+            f["volume_median"][i] == f["volume_median"][i]
+            and bars[i].volume > 0
+            and bars[i].volume >= entry_volume_multiplier * f["volume_median"][i]
+        )
+        body_confirmation = (
+            atr_value == atr_value
+            and bars[i].close - bars[i].open >= entry_min_body_atr * atr_value
+        )
+        higher_timeframe_confirmation = bool(f["higher_timeframe_trend"][i])
+        bearish_exit = (
+            exit_on_bearish_candle
+            and bars[i].close < bars[i].open
+            and atr_value == atr_value
+            and (bars[i].open - bars[i].close) >= bearish_exit_min_body_atr * atr_value
+            and (
+                not bearish_exit_requires_breakdown
+                or (
+                    i > 0
+                    and bars[i].close < bars[i - 1].low
+                    and bars[i].close < f["ema_fast"][i]
+                )
+            )
+        )
+        if bearish_exit:
+            bearish_exit_points += 1
+        if halted and i < blocked_until:
+            stable_count = 0
+            continue
+        if halted and stable_count < stable_bars:
+            if trend and tradable:
+                stable_count += 1
+            else:
+                stable_count = 0
+            if stable_count >= stable_bars:
+                recovery_events += 1
+                halted = False
+                risk_peak = cash
+        if stop_triggered:
+            continue
+        entry_confirmation_ok = (
+            not require_two_bullish_candles
+            or (
+                bullish_confirmation
+                and body_confirmation
+                and breakout
+                and volume_confirmation
+                and (
+                    not require_higher_timeframe_trend
+                    or higher_timeframe_confirmation
+                )
+            )
+        )
+        if not qty and not halted and trend and breakout and tradable and entry_confirmation_ok:
+            pending_entry = True
+        if qty and (
+            f["ema_fast"][i] <= f["ema_slow"][i]
+            or bars[i].close < f["ema_slow"][i]
+            or bearish_exit
+        ):
+            pending_exit = True
+    if qty:
+        cash += qty * bars[-1].close * (1 - slip) * (1 - fee)
+        trades += 1
+    return {
+        "start": bars[0].timestamp.isoformat(), "end": bars[min(len(bars) - 1, i)].timestamp.isoformat(),
+        "bars": min(len(bars), i + 1), "ending_balance": cash, "pnl": cash - initial_balance,
+        "return_pct": (cash / initial_balance - 1) * 100, "max_drawdown_pct": max_dd * 100,
+        "trades": trades, "kill_switch": killed, "kill_events": kill_events, "recovery_events": recovery_events, "entry_points": entry_points,
+        "expansion_points": expansion_points, "tradable_points": tradable_points,
+        "bullish_confirmation_points": bullish_confirmation_points,
+        "body_confirmation_points": sum(
+            1
+            for i in range(len(bars))
+            if f["atr"][i] == f["atr"][i]
+            and bars[i].close - bars[i].open >= entry_min_body_atr * f["atr"][i]
+        ),
+        "volume_confirmation_points": sum(
+            1
+            for i in range(len(bars))
+            if f["volume_median"][i] == f["volume_median"][i]
+            and bars[i].volume > 0
+            and bars[i].volume >= entry_volume_multiplier * f["volume_median"][i]
+        ),
+        "higher_timeframe_points": sum(1 for value in f["higher_timeframe_trend"] if value),
+        "bearish_exit_points": bearish_exit_points,
+        "params": {
+            "lower_vol_rank": lower_vol_rank,
+            "upper_vol_rank": upper_vol_rank,
+            "expansion_ratio": expansion_ratio,
+            "trail_atr": trail_atr,
+            "regime_span": regime_span,
+            "cooldown_bars": cooldown_bars,
+            "stable_bars": stable_bars,
+            "order_notional": order_notional,
+            "require_two_bullish_candles": require_two_bullish_candles,
+            "exit_on_bearish_candle": exit_on_bearish_candle,
+            "entry_min_body_atr": entry_min_body_atr,
+            "breakout_lookback": breakout_lookback,
+            "entry_volume_multiplier": entry_volume_multiplier,
+            "require_higher_timeframe_trend": require_higher_timeframe_trend,
+            "higher_timeframe_bars": higher_timeframe_bars,
+            "higher_timeframe_fast_window": higher_timeframe_fast_window,
+            "higher_timeframe_slow_window": higher_timeframe_slow_window,
+            "bearish_exit_min_body_atr": bearish_exit_min_body_atr,
+            "bearish_exit_requires_breakdown": bearish_exit_requires_breakdown,
+            "hard_stop_atr": hard_stop_atr,
+        },
+    }
+
+
+def research(
+    path: Path,
+    initial_balance: float,
+    order_notional: float,
+    *,
+    require_two_bullish_candles: bool = True,
+    exit_on_bearish_candle: bool = True,
+    entry_min_body_atr: float = 0.5,
+    breakout_lookback: int = 20,
+    entry_volume_multiplier: float = 1.0,
+    require_higher_timeframe_trend: bool = True,
+    higher_timeframe_bars: int = 4,
+    higher_timeframe_fast_window: int = 5,
+    higher_timeframe_slow_window: int = 20,
+    bearish_exit_min_body_atr: float = 0.75,
+    bearish_exit_requires_breakdown: bool = True,
+    hard_stop_atr: float = 2.0,
+) -> dict[str, object]:
+    bars = load_bars(path)
+    f = features(bars)
+    report: dict[str, object] = {
+        "dataset": str(path), "bars": len(bars), "start": bars[0].timestamp.isoformat(), "end": bars[-1].timestamp.isoformat(),
+        "data_points": {"atr_pct": _summary(f["atr_pct"]), "realized_hourly_vol": _summary(f["realized"]), "atr_rank": _summary(f["atr_rank"]), "realized_rank": _summary(f["realized_rank"])},
+    }
+    candidates = {
+        "balanced": {"lower_vol_rank": 0.25, "upper_vol_rank": 0.90, "expansion_ratio": 1.05, "trail_atr": 2.5, "regime_span": 100},
+        "strict": {"lower_vol_rank": 0.35, "upper_vol_rank": 0.85, "expansion_ratio": 1.10, "trail_atr": 2.5, "regime_span": 200},
+        "wide": {"lower_vol_rank": 0.15, "upper_vol_rank": 0.95, "expansion_ratio": 1.00, "trail_atr": 3.0, "regime_span": 100},
+    }
+    report["candle_rule"] = {
+        "require_two_bullish_candles": require_two_bullish_candles,
+        "exit_on_bearish_candle": exit_on_bearish_candle,
+        "entry_min_body_atr": entry_min_body_atr,
+        "breakout_lookback": breakout_lookback,
+        "entry_volume_multiplier": entry_volume_multiplier,
+        "require_higher_timeframe_trend": require_higher_timeframe_trend,
+        "higher_timeframe_bars": higher_timeframe_bars,
+        "higher_timeframe_fast_window": higher_timeframe_fast_window,
+        "higher_timeframe_slow_window": higher_timeframe_slow_window,
+        "bearish_exit_min_body_atr": bearish_exit_min_body_atr,
+        "bearish_exit_requires_breakdown": bearish_exit_requires_breakdown,
+        "hard_stop_atr": hard_stop_atr,
+    }
+    report["candidates"] = {
+        name: run(
+            bars,
+            initial_balance=initial_balance,
+            order_notional=order_notional,
+            fees_bps=10,
+            slippage_bps=5,
+            require_two_bullish_candles=require_two_bullish_candles,
+            exit_on_bearish_candle=exit_on_bearish_candle,
+            entry_min_body_atr=entry_min_body_atr,
+            breakout_lookback=breakout_lookback,
+            entry_volume_multiplier=entry_volume_multiplier,
+            require_higher_timeframe_trend=require_higher_timeframe_trend,
+            higher_timeframe_bars=higher_timeframe_bars,
+            higher_timeframe_fast_window=higher_timeframe_fast_window,
+            higher_timeframe_slow_window=higher_timeframe_slow_window,
+            bearish_exit_min_body_atr=bearish_exit_min_body_atr,
+            bearish_exit_requires_breakdown=bearish_exit_requires_breakdown,
+            hard_stop_atr=hard_stop_atr,
+            **params,
+        )
+        for name, params in candidates.items()
+    }
+    folds = [(0, int(len(bars) * 0.5), int(len(bars) * 0.5), int(len(bars) * 0.625)), (0, int(len(bars) * 0.625), int(len(bars) * 0.625), int(len(bars) * 0.75)), (0, int(len(bars) * 0.75), int(len(bars) * 0.75), len(bars))]
+    report["walk_forward"] = {
+        name: [
+            run(
+                bars[test_start:test_end],
+                initial_balance=initial_balance,
+                order_notional=order_notional,
+                fees_bps=10,
+                slippage_bps=5,
+                require_two_bullish_candles=require_two_bullish_candles,
+                exit_on_bearish_candle=exit_on_bearish_candle,
+                entry_min_body_atr=entry_min_body_atr,
+                breakout_lookback=breakout_lookback,
+                entry_volume_multiplier=entry_volume_multiplier,
+                require_higher_timeframe_trend=require_higher_timeframe_trend,
+                higher_timeframe_bars=higher_timeframe_bars,
+                higher_timeframe_fast_window=higher_timeframe_fast_window,
+                higher_timeframe_slow_window=higher_timeframe_slow_window,
+                bearish_exit_min_body_atr=bearish_exit_min_body_atr,
+                bearish_exit_requires_breakdown=bearish_exit_requires_breakdown,
+                hard_stop_atr=hard_stop_atr,
+                **params,
+            )
+            for _, _, test_start, test_end in folds
+        ]
+        for name, params in candidates.items()
+    }
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", type=Path, required=True)
+    parser.add_argument("--initial-balance", type=float, default=75_000)
+    parser.add_argument("--order-notional", type=float, default=6_000)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--disable-candle-confirmation",
+        action="store_true",
+        help="Research-only comparison run without the v2 candle/volume/HTF confirmation layer",
+    )
+    args = parser.parse_args()
+    v2 = not args.disable_candle_confirmation
+    report = research(
+        args.path,
+        args.initial_balance,
+        args.order_notional,
+        require_two_bullish_candles=v2,
+        exit_on_bearish_candle=v2,
+        entry_min_body_atr=0.5 if v2 else 0.0,
+        entry_volume_multiplier=1.0 if v2 else 0.0,
+        require_higher_timeframe_trend=v2,
+        bearish_exit_min_body_atr=0.75 if v2 else 0.0,
+        bearish_exit_requires_breakdown=v2,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_momentum_volatility_v3.py
+++ b/scripts/run_momentum_volatility_v3.py
@@ -314,6 +314,11 @@ def run_pair(
 
     if initial_balance <= 0 or order_notional <= 0:
         raise ValueError("initial_balance and order_notional must be positive")
+    if not all(
+        math.isfinite(value) and value >= 0
+        for value in (fees_bps, slippage_bps)
+    ):
+        raise ValueError("fees_bps and slippage_bps must be finite and non-negative")
     if not pair:
         raise ValueError("pair data must not be empty")
     if not 0 < config.reduced_size_multiplier <= 1:
@@ -644,45 +649,148 @@ def run_pair(
     }
 
 
+CONFIRMATION_HOLDOUT_BARS = 365 * 24
+MIN_CONFIRMATION_ENTRIES = 5
+MIN_FULL_ENTRIES = 8
+
+
 def _folds(length: int) -> list[tuple[int, int]]:
-    first = int(length * 0.50)
-    second = int(length * 0.625)
-    third = int(length * 0.75)
-    return [(first, second), (second, third), (third, length)]
+    holdout_start = length - CONFIRMATION_HOLDOUT_BARS
+    if holdout_start <= 0:
+        raise ValueError("data must include a positive one-year confirmation holdout")
+    first = int(holdout_start * 0.50)
+    second = int(holdout_start * 0.625)
+    third = int(holdout_start * 0.75)
+    return [(first, second), (second, third), (third, holdout_start)]
+
+
+def _confirmation_holdout(length: int) -> tuple[int, int]:
+    start = length - CONFIRMATION_HOLDOUT_BARS
+    if start <= 0:
+        raise ValueError("data must include a positive one-year confirmation holdout")
+    return start, length
+
+
+def _result_number(result: Mapping[str, object], key: str) -> float:
+    try:
+        value = float(result.get(key, math.nan))
+    except (TypeError, ValueError):
+        return math.nan
+    return value
+
+
+def _result_integer(result: Mapping[str, object], key: str) -> int:
+    try:
+        value = int(result.get(key, -1))
+    except (TypeError, ValueError):
+        return -1
+    return value
 
 
 def _median_return(results: Sequence[Mapping[str, object]]) -> float:
-    return statistics.median(float(result["return_pct"]) for result in results)
+    values = [_result_number(result, "return_pct") for result in results]
+    if not values or not all(_valid(value) for value in values):
+        return math.nan
+    return statistics.median(values)
 
 
 def _promotion_gate(
     full: Mapping[str, object],
+    stress_full: Mapping[str, object],
     walk_forward: Sequence[Mapping[str, object]],
     stress_walk_forward: Sequence[Mapping[str, object]],
+    confirmation_base: Mapping[str, object],
+    confirmation_stress: Mapping[str, object],
 ) -> dict[str, object]:
     base_median = _median_return(walk_forward)
     stress_median = _median_return(stress_walk_forward)
     reasons: list[str] = []
-    if base_median <= 0:
-        reasons.append("base walk-forward median return is not positive")
-    if stress_median <= 0:
-        reasons.append("higher-cost walk-forward median return is not positive")
-    if bool(full["permanent_halt"]):
-        reasons.append("full sample hit the permanent cumulative drawdown limit")
-    if int(full["kill_events"]) > 1 or any(int(item["kill_events"]) > 1 for item in stress_walk_forward):
-        reasons.append("repeated 2% kill-switch events occurred")
-    if int(full["entries"]) < 4:
-        reasons.append("fewer than four full-sample entries")
+    if not _valid(base_median) or base_median <= 0:
+        reasons.append("base walk-forward median return is not positive and finite")
+    if not _valid(stress_median) or stress_median <= 0:
+        reasons.append("higher-cost walk-forward median return is not positive and finite")
+
+    required_results = (
+        ("full sample", full),
+        ("stress full sample", stress_full),
+        ("confirmation holdout base", confirmation_base),
+        ("confirmation holdout stress", confirmation_stress),
+    )
+    for label, result in required_results:
+        if not isinstance(result, Mapping):
+            reasons.append(f"missing {label} result")
+            continue
+        return_pct = _result_number(result, "return_pct")
+        if not _valid(return_pct):
+            reasons.append(f"{label} return is not finite")
+        elif return_pct <= 0:
+            reasons.append(f"{label} return is not positive")
+        minimum_entries = (
+            MIN_FULL_ENTRIES
+            if label in {"full sample", "stress full sample"}
+            else MIN_CONFIRMATION_ENTRIES
+        )
+        if _result_integer(result, "entries") < minimum_entries:
+            reasons.append(f"{label} has fewer than {minimum_entries} entries")
+        permanent_halt = result.get("permanent_halt")
+        if not isinstance(permanent_halt, bool):
+            reasons.append(f"{label} permanent_halt flag is invalid")
+        elif permanent_halt:
+            reasons.append(f"{label} hit a permanent halt")
+        kill_events = _result_integer(result, "kill_events")
+        if kill_events < 0:
+            reasons.append(f"{label} kill_events field is invalid")
+        elif kill_events > 1:
+            reasons.append(f"{label} has repeated kill-switch events")
+
+    for label, folds in (
+        ("base walk-forward", walk_forward),
+        ("stress walk-forward", stress_walk_forward),
+    ):
+        if len(folds) != 3:
+            reasons.append(f"{label} must contain exactly three folds")
+            continue
+        for index, fold in enumerate(folds, start=1):
+            if not isinstance(fold, Mapping):
+                reasons.append(f"{label} fold {index} is invalid")
+                continue
+            if not _valid(_result_number(fold, "return_pct")):
+                reasons.append(f"{label} fold {index} return is not finite")
+            if _result_integer(fold, "entries") < MIN_CONFIRMATION_ENTRIES:
+                reasons.append(
+                    f"{label} fold {index} has fewer than {MIN_CONFIRMATION_ENTRIES} entries"
+                )
+            permanent_halt = fold.get("permanent_halt")
+            if not isinstance(permanent_halt, bool):
+                reasons.append(f"{label} fold {index} permanent_halt flag is invalid")
+            elif permanent_halt:
+                reasons.append(f"{label} fold {index} hit a permanent halt")
+            kill_events = _result_integer(fold, "kill_events")
+            if kill_events < 0:
+                reasons.append(f"{label} fold {index} kill_events field is invalid")
+            elif kill_events > 1:
+                reasons.append(f"{label} fold {index} has repeated kill-switch events")
+
     return {
         "pass": not reasons,
         "base_walk_forward_median_return_pct": base_median,
         "stress_walk_forward_median_return_pct": stress_median,
+        "confirmation_holdout_base_return_pct": _result_number(
+            confirmation_base, "return_pct"
+        ),
+        "confirmation_holdout_stress_return_pct": _result_number(
+            confirmation_stress, "return_pct"
+        ),
         "requirements": {
             "positive_base_median_walk_forward": True,
             "positive_stress_median_walk_forward": True,
+            "positive_full_sample_base_and_stress": True,
+            "positive_confirmation_holdout_base_and_stress": True,
+            "minimum_full_sample_entries": MIN_FULL_ENTRIES,
+            "minimum_entries_per_walk_forward_fold": MIN_CONFIRMATION_ENTRIES,
+            "minimum_confirmation_holdout_entries": MIN_CONFIRMATION_ENTRIES,
             "no_permanent_halt": True,
             "no_repeated_kill_switch": True,
-            "minimum_full_sample_entries": 4,
         },
         "failure_reasons": reasons,
     }
@@ -706,6 +814,22 @@ def research(
     pair = align_pair(btc, eth)
     if horizon_order_notional is None:
         horizon_order_notional = order_notional
+    cost_values = (
+        fees_bps,
+        slippage_bps,
+        stress_fees_bps,
+        stress_slippage_bps,
+    )
+    if not all(math.isfinite(value) and value >= 0 for value in cost_values):
+        raise ValueError("all cost assumptions must be finite and non-negative")
+    if (
+        stress_fees_bps < fees_bps
+        or stress_slippage_bps < slippage_bps
+        or (stress_fees_bps == fees_bps and stress_slippage_bps == slippage_bps)
+    ):
+        raise ValueError(
+            "stress costs must be no lower in either component and higher in at least one"
+        )
 
     candidates: dict[str, V3Config] = {
         "balanced": V3Config(
@@ -755,6 +879,7 @@ def research(
         "candidate_definitions": {name: config.as_dict() for name, config in candidates.items()},
     }
     folds = _folds(len(pair))
+    confirmation_start, confirmation_end = _confirmation_holdout(len(pair))
     candidates_report: dict[str, object] = {}
     for name, config in candidates.items():
         feature_map = build_pair_features(pair, config)
@@ -764,6 +889,15 @@ def research(
             order_notional=order_notional,
             fees_bps=fees_bps,
             slippage_bps=slippage_bps,
+            config=config,
+            feature_map=feature_map,
+        )
+        stress_full = run_pair(
+            pair,
+            initial_balance=initial_balance,
+            order_notional=order_notional,
+            fees_bps=stress_fees_bps,
+            slippage_bps=stress_slippage_bps,
             config=config,
             feature_map=feature_map,
         )
@@ -795,6 +929,28 @@ def research(
             )
             for start, end in folds
         ]
+        confirmation_base = run_pair(
+            pair,
+            initial_balance=initial_balance,
+            order_notional=horizon_order_notional,
+            fees_bps=fees_bps,
+            slippage_bps=slippage_bps,
+            config=config,
+            start_index=confirmation_start,
+            end_index=confirmation_end,
+            feature_map=feature_map,
+        )
+        confirmation_stress = run_pair(
+            pair,
+            initial_balance=initial_balance,
+            order_notional=horizon_order_notional,
+            fees_bps=stress_fees_bps,
+            slippage_bps=stress_slippage_bps,
+            config=config,
+            start_index=confirmation_start,
+            end_index=confirmation_end,
+            feature_map=feature_map,
+        )
         horizon_sizes = {
             "1d": 24,
             "1w": 24 * 7,
@@ -816,16 +972,40 @@ def research(
             )
         candidates_report[name] = {
             "full_sample": full,
+            "full_sample_stress": stress_full,
             "walk_forward": wf,
             "stress_walk_forward": stress_wf,
+            "confirmation_holdout": {
+                "base": confirmation_base,
+                "stress": confirmation_stress,
+                "start_index": confirmation_start,
+                "end_index": confirmation_end,
+                "bars": confirmation_end - confirmation_start,
+            },
             "walk_forward_medians": {
                 "base_return_pct": _median_return(wf),
                 "stress_return_pct": _median_return(stress_wf),
             },
             "horizons": horizons,
-            "promotion_gate": _promotion_gate(full, wf, stress_wf),
+            "promotion_gate": _promotion_gate(
+                full,
+                stress_full,
+                wf,
+                stress_wf,
+                confirmation_base,
+                confirmation_stress,
+            ),
         }
-    report["walk_forward_folds"] = [{"start_index": start, "end_index": end} for start, end in folds]
+    report["walk_forward_folds"] = [
+        {"start_index": start, "end_index": end}
+        for start, end in folds
+    ]
+    report["confirmation_holdout"] = {
+        "start_index": confirmation_start,
+        "end_index": confirmation_end,
+        "bars": confirmation_end - confirmation_start,
+        "one_year": True,
+    }
     report["candidates"] = candidates_report
     report["paper_promotion"] = {
         "passed_candidates": [
@@ -865,8 +1045,8 @@ def main() -> None:
         horizon_order_notional=args.horizon_order_notional,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
-    print(json.dumps(report, indent=2))
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(json.dumps(report, indent=2, allow_nan=False))
 
 
 if __name__ == "__main__":

--- a/scripts/run_momentum_volatility_v3.py
+++ b/scripts/run_momentum_volatility_v3.py
@@ -22,8 +22,10 @@ from pathlib import Path
 from typing import Mapping, Sequence
 
 try:  # Works both as ``python scripts/...`` and when imported by pytest.
+    from scripts.momentum_context import ContextEvent, build_context_features, load_context_events
     from scripts.run_momentum_volatility_research import Bar, features, load_bars
 except ModuleNotFoundError:  # pragma: no cover - direct script fallback
+    from momentum_context import ContextEvent, build_context_features, load_context_events
     from run_momentum_volatility_research import Bar, features, load_bars
 
 
@@ -79,6 +81,14 @@ class V3Config:
     recovery_size_bars: int = 24
     recovery_abort_drawdown: float = 0.01
     lifetime_drawdown_limit: float = 0.06
+    # Optional causal context gates. Neutral context is permitted when no
+    # timestamped context CSV is supplied; supplied events are never forward-filled.
+    context_lookback_hours: int = 24
+    min_context_volume_ratio: float = 0.65
+    negative_sentiment_block: float = -0.40
+    risk_event_blocks: bool = True
+    expected_move_atr_multiple: float = 1.00
+    min_expected_edge_bps: float = 5.0
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -135,6 +145,7 @@ def _prior_highs(bars: Sequence[Bar], lookback: int) -> list[float]:
 def build_pair_features(
     pair: Sequence[PairBar],
     config: V3Config,
+    context_events: Sequence[ContextEvent] | None = None,
 ) -> dict[str, dict[str, list[float]]]:
     """Build causal features for both assets over the common time axis."""
 
@@ -150,6 +161,13 @@ def build_pair_features(
             higher_timeframe_fast_window=config.higher_timeframe_fast_window,
             higher_timeframe_slow_window=config.higher_timeframe_slow_window,
         )
+        context = build_context_features(
+            bars,
+            context_events,
+            volume_window=config.volume_lookback,
+            lookback_hours=config.context_lookback_hours,
+        )
+        base.update(context)
         closes = [bar.close for bar in bars]
         score = [math.nan] * len(bars)
         for index in range(config.leader_lookback, len(bars)):
@@ -228,11 +246,24 @@ def _setup(
     f: Mapping[str, list[float]],
     index: int,
     config: V3Config,
+    *,
+    fees_bps: float = 0.0,
+    slippage_bps: float = 0.0,
 ) -> tuple[bool, float, str]:
     """Evaluate one asset without using the next bar."""
 
     if index < max(2, config.breakout_lookback + 1) or index + 1 >= len(bars):
         return False, 0.0, "warmup"
+    context_sentiment = f.get("context_sentiment", [0.0] * len(bars))[index]
+    context_impact = f.get("context_impact", [0.0] * len(bars))[index]
+    context_risk = f.get("context_risk_event", [0.0] * len(bars))[index]
+    volume_ratio = f.get("volume_ratio", [math.nan] * len(bars))[index]
+    if config.risk_event_blocks and context_risk >= 1.0:
+        return False, 0.0, "risk_event"
+    if _valid(context_sentiment) and context_sentiment < config.negative_sentiment_block:
+        return False, 0.0, "sentiment"
+    if not _valid(volume_ratio) or volume_ratio < config.min_context_volume_ratio:
+        return False, 0.0, "liquidity"
     state, size_multiplier, _ = _volatility_state(f, index, config)
     if state not in {"normal", "reduced"}:
         return False, 0.0, state
@@ -243,6 +274,14 @@ def _setup(
         return False, 0.0, "breakout"
     first, second = bars[index - 1], bars[index]
     atr = f["atr"][index]
+    expected_edge_bps = (
+        atr / second.close * 10_000.0 * config.expected_move_atr_multiple
+        if _valid(atr) and second.close > 0
+        else math.nan
+    )
+    round_trip_cost_bps = 2.0 * (float(fees_bps) + float(slippage_bps))
+    if not _valid(expected_edge_bps) or expected_edge_bps < round_trip_cost_bps + config.min_expected_edge_bps:
+        return False, 0.0, "edge"
     bullish = first.close > first.open and second.close > second.open
     body = second.close - second.open
     body_ok = _valid(atr) and body >= config.entry_min_body_atr * atr
@@ -261,6 +300,10 @@ def _setup(
     )
     if not bullish or not body_ok or not volume_ok or not higher_timeframe_ok:
         return False, 0.0, "confirmation"
+    # A mildly adverse but non-blocking context signal reduces exposure. A
+    # high-impact event or strongly negative sentiment was already blocked.
+    if context_impact > 0 and context_sentiment < 0.15:
+        size_multiplier *= 0.75
     return True, size_multiplier, state
 
 
@@ -377,6 +420,7 @@ def run_pair(
     trend_exits = 0
     size_reductions = 0
     extreme_blocked_entries = 0
+    context_blocked_entries = 0
     leader_counts = {"BTC": 0, "ETH": 0}
     leader_scores_seen = 0
     entry_reasons: dict[str, int] = {}
@@ -517,7 +561,12 @@ def run_pair(
         # the pending entry/exit is therefore filled no earlier than index+1.
         setups: dict[str, tuple[bool, float, str]] = {
             symbol: _setup(
-                bars_by_symbol[symbol], feature_map[symbol], index, config
+                bars_by_symbol[symbol],
+                feature_map[symbol],
+                index,
+                config,
+                fees_bps=fees_bps,
+                slippage_bps=slippage_bps,
             )
             for symbol in ("BTC", "ETH")
         }
@@ -528,6 +577,8 @@ def run_pair(
         for symbol, (_, _, reason) in setups.items():
             if reason == "extreme":
                 extreme_blocked_entries += 1
+            if reason in {"risk_event", "sentiment", "liquidity", "edge"}:
+                context_blocked_entries += 1
 
         healthy = any(
             _trend_ok(bars_by_symbol[symbol], feature_map[symbol], index, config)
@@ -634,6 +685,12 @@ def run_pair(
         "profit_lock_exits": profit_lock_exits,
         "size_reductions": size_reductions,
         "extreme_blocked_entries": extreme_blocked_entries,
+        "context_blocked_entries": context_blocked_entries,
+        "context_mode": "timestamped_events" if any(
+            any(value > 0 for value in feature_map[symbol].get("context_event_count", []))
+            for symbol in ("BTC", "ETH")
+        ) else "neutral_without_events",
+        "max_concurrent_positions": 1,
         "leader_counts": leader_counts,
         "leader_scores_seen": leader_scores_seen,
         "entry_reasons": entry_reasons,
@@ -808,10 +865,12 @@ def research(
     stress_slippage_bps: float = 10.0,
     horizon_initial_balance: float = 5_000.0,
     horizon_order_notional: float | None = None,
+    context_path: Path | None = None,
 ) -> dict[str, object]:
     btc = load_bars(btc_path)
     eth = load_bars(eth_path)
     pair = align_pair(btc, eth)
+    context_events = load_context_events(context_path) if context_path else []
     if horizon_order_notional is None:
         horizon_order_notional = order_notional
     cost_values = (
@@ -859,8 +918,14 @@ def research(
         ),
     }
     report: dict[str, object] = {
-        "model": "adaptive_momentum_volatility_v3",
+        "model": "adaptive_momentum_volatility_v3_context_gated",
         "research_only": True,
+        "context": {
+            "path": str(context_path) if context_path else None,
+            "events": len(context_events),
+            "neutral_when_missing": True,
+            "as_of_only": True,
+        },
         "paper_promotion_required": True,
         "data": {
             "btc_path": str(btc_path),
@@ -882,7 +947,7 @@ def research(
     confirmation_start, confirmation_end = _confirmation_holdout(len(pair))
     candidates_report: dict[str, object] = {}
     for name, config in candidates.items():
-        feature_map = build_pair_features(pair, config)
+        feature_map = build_pair_features(pair, config, context_events)
         full = run_pair(
             pair,
             initial_balance=initial_balance,
@@ -1030,6 +1095,7 @@ def main() -> None:
     parser.add_argument("--stress-slippage-bps", type=float, default=10.0)
     parser.add_argument("--horizon-initial-balance", type=float, default=5_000.0)
     parser.add_argument("--horizon-order-notional", type=float)
+    parser.add_argument("--context-csv", type=Path, help="optional timestamp,sentiment,impact CSV")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
     report = research(
@@ -1043,6 +1109,7 @@ def main() -> None:
         stress_slippage_bps=args.stress_slippage_bps,
         horizon_initial_balance=args.horizon_initial_balance,
         horizon_order_notional=args.horizon_order_notional,
+        context_path=args.context_csv,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")

--- a/scripts/run_momentum_volatility_v3.py
+++ b/scripts/run_momentum_volatility_v3.py
@@ -1,0 +1,873 @@
+#!/usr/bin/env python3
+"""Research-only adaptive BTC/ETH volatility-regime momentum model.
+
+Version 3 is deliberately separate from the v2 runner and active paper
+configuration.  It uses closed hourly candles, schedules fills for the next
+bar open, and keeps the two-asset decision in one portfolio so BTC and ETH
+cannot both be entered as identical independent strategies.
+
+The executable is a backtest/research tool only.  A candidate is paper-ready
+only when its walk-forward promotion gate is true; this script never changes
+the active portfolio configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Mapping, Sequence
+
+try:  # Works both as ``python scripts/...`` and when imported by pytest.
+    from scripts.run_momentum_volatility_research import Bar, features, load_bars
+except ModuleNotFoundError:  # pragma: no cover - direct script fallback
+    from run_momentum_volatility_research import Bar, features, load_bars
+
+
+def _valid(value: float) -> bool:
+    return math.isfinite(value)
+
+
+@dataclass(frozen=True)
+class PairBar:
+    timestamp: object
+    btc: Bar
+    eth: Bar
+
+
+@dataclass(frozen=True)
+class V3Config:
+    """Frozen research parameters for one v3 candidate."""
+
+    atr_period: int = 14
+    regime_window: int = 720
+    volume_lookback: int = 20
+    fast_window: int = 8
+    slow_window: int = 21
+    regime_span: int = 200
+    breakout_lookback: int = 20
+    expansion_lookback: int = 24
+    expansion_ratio: float = 1.05
+    min_vol_rank: float = 0.35
+    reduce_size_rank: float = 0.75
+    extreme_vol_rank: float = 0.90
+    max_atr_pct: float = 0.06
+    extreme_realized_rank: float = 0.95
+    reduced_size_multiplier: float = 0.50
+    leader_lookback: int = 24
+    leader_min_score: float = 0.05
+    leader_margin: float = 0.05
+    entry_min_body_atr: float = 0.50
+    entry_volume_multiplier: float = 1.00
+    require_higher_timeframe_trend: bool = True
+    higher_timeframe_bars: int = 4
+    higher_timeframe_fast_window: int = 5
+    higher_timeframe_slow_window: int = 20
+    hard_stop_atr: float = 2.0
+    trailing_stop_atr: float = 2.5
+    time_stop_bars: int = 72
+    time_stop_min_return: float = 0.005
+    profit_lock_activation_atr: float = 1.00
+    profit_lock_floor_atr: float = 0.25
+    kill_switch_drawdown: float = 0.02
+    cooldown_bars: int = 12
+    stable_bars: int = 12
+    recovery_size_multiplier: float = 0.50
+    recovery_size_bars: int = 24
+    recovery_abort_drawdown: float = 0.01
+    lifetime_drawdown_limit: float = 0.06
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            key: getattr(self, key)
+            for key in self.__dataclass_fields__
+        }
+
+
+@dataclass(frozen=True)
+class _PendingEntry:
+    symbol: str
+    size_multiplier: float
+    atr: float
+    signal_index: int
+
+
+@dataclass(frozen=True)
+class _PendingExit:
+    reason: str
+
+
+def align_pair(btc: Sequence[Bar], eth: Sequence[Bar]) -> list[PairBar]:
+    """Align BTC and ETH by timestamp and reject ambiguous input."""
+
+    btc_by_time = {bar.timestamp: bar for bar in btc}
+    eth_by_time = {bar.timestamp: bar for bar in eth}
+    if len(btc_by_time) != len(btc) or len(eth_by_time) != len(eth):
+        raise ValueError("pair data contains duplicate timestamps")
+    timestamps = sorted(set(btc_by_time).intersection(eth_by_time))
+    if len(timestamps) < 2:
+        raise ValueError("BTC and ETH have fewer than two common timestamps")
+    return [PairBar(timestamp, btc_by_time[timestamp], eth_by_time[timestamp]) for timestamp in timestamps]
+
+
+def _asset_bars(pair: Sequence[PairBar], symbol: str) -> list[Bar]:
+    if symbol == "BTC":
+        return [item.btc for item in pair]
+    if symbol == "ETH":
+        return [item.eth for item in pair]
+    raise ValueError(f"unsupported pair symbol: {symbol}")
+
+
+def _prior_highs(bars: Sequence[Bar], lookback: int) -> list[float]:
+    result = [math.nan] * len(bars)
+    for index in range(lookback + 1, len(bars)):
+        # The previous two candles are confirmation candles.  They are not
+        # allowed to become part of the breakout reference range.
+        prior = bars[index - lookback - 1 : index - 1]
+        if len(prior) == lookback:
+            result[index] = max(bar.high for bar in prior)
+    return result
+
+
+def build_pair_features(
+    pair: Sequence[PairBar],
+    config: V3Config,
+) -> dict[str, dict[str, list[float]]]:
+    """Build causal features for both assets over the common time axis."""
+
+    result: dict[str, dict[str, list[float]]] = {}
+    for symbol in ("BTC", "ETH"):
+        bars = _asset_bars(pair, symbol)
+        base = features(
+            bars,
+            atr_period=config.atr_period,
+            regime_window=config.regime_window,
+            volume_lookback=config.volume_lookback,
+            higher_timeframe_bars=config.higher_timeframe_bars,
+            higher_timeframe_fast_window=config.higher_timeframe_fast_window,
+            higher_timeframe_slow_window=config.higher_timeframe_slow_window,
+        )
+        closes = [bar.close for bar in bars]
+        score = [math.nan] * len(bars)
+        for index in range(config.leader_lookback, len(bars)):
+            realized = base["realized"][index]
+            if not _valid(realized) or realized <= 0:
+                continue
+            change = math.log(closes[index] / closes[index - config.leader_lookback])
+            # Risk-adjusted return, using only data available at the signal
+            # close.  A positive score is required before selecting a leader.
+            score[index] = change / max(realized, base["atr_pct"][index], 1e-9)
+        base["prior_high"] = _prior_highs(bars, config.breakout_lookback)
+        base["leader_score"] = score
+        result[symbol] = base
+    return result
+
+
+def _trend_ok(
+    bars: Sequence[Bar],
+    f: Mapping[str, list[float]],
+    index: int,
+    config: V3Config,
+) -> bool:
+    regime_key = f"ema_regime_{config.regime_span}"
+    if regime_key not in f or index < config.expansion_lookback:
+        return False
+    regime = f[regime_key][index]
+    prior_regime = f[regime_key][index - config.expansion_lookback]
+    return (
+        _valid(f["ema_fast"][index])
+        and _valid(f["ema_slow"][index])
+        and _valid(regime)
+        and _valid(prior_regime)
+        and f["ema_fast"][index] > f["ema_slow"][index]
+        and bars[index].close > f["ema_slow"][index]
+        and bars[index].close > regime
+        and regime > prior_regime
+    )
+
+
+def _volatility_state(
+    f: Mapping[str, list[float]],
+    index: int,
+    config: V3Config,
+) -> tuple[str, float, float]:
+    """Return (state, size multiplier, expansion ratio) at a signal close."""
+
+    atr_pct = f["atr_pct"][index]
+    prior_index = index - config.expansion_lookback
+    prior_atr_pct = f["atr_pct"][prior_index] if prior_index >= 0 else math.nan
+    atr_rank = f["atr_rank"][index]
+    realized_rank = f["realized_rank"][index]
+    if not all(_valid(value) for value in (atr_pct, prior_atr_pct, atr_rank, realized_rank)):
+        return "unknown", 0.0, math.nan
+    expansion_ratio = atr_pct / prior_atr_pct if prior_atr_pct > 0 else math.inf
+    extreme = (
+        atr_rank >= config.extreme_vol_rank
+        or realized_rank >= config.extreme_realized_rank
+        or atr_pct > config.max_atr_pct
+    )
+    if extreme:
+        return "extreme", 0.0, expansion_ratio
+    if atr_rank < config.min_vol_rank:
+        return "quiet", 0.0, expansion_ratio
+    if expansion_ratio < config.expansion_ratio:
+        return "not_expanded", 0.0, expansion_ratio
+    multiplier = (
+        config.reduced_size_multiplier
+        if atr_rank >= config.reduce_size_rank
+        else 1.0
+    )
+    return ("reduced" if multiplier < 1.0 else "normal"), multiplier, expansion_ratio
+
+
+def _setup(
+    bars: Sequence[Bar],
+    f: Mapping[str, list[float]],
+    index: int,
+    config: V3Config,
+) -> tuple[bool, float, str]:
+    """Evaluate one asset without using the next bar."""
+
+    if index < max(2, config.breakout_lookback + 1) or index + 1 >= len(bars):
+        return False, 0.0, "warmup"
+    state, size_multiplier, _ = _volatility_state(f, index, config)
+    if state not in {"normal", "reduced"}:
+        return False, 0.0, state
+    if not _trend_ok(bars, f, index, config):
+        return False, 0.0, "trend"
+    prior_high = f["prior_high"][index]
+    if not _valid(prior_high) or bars[index].close <= prior_high:
+        return False, 0.0, "breakout"
+    first, second = bars[index - 1], bars[index]
+    atr = f["atr"][index]
+    bullish = first.close > first.open and second.close > second.open
+    body = second.close - second.open
+    body_ok = _valid(atr) and body >= config.entry_min_body_atr * atr
+    median_volume = f["volume_median"][index]
+    volume_ok = (
+        config.entry_volume_multiplier <= 0
+        or (
+            _valid(median_volume)
+            and second.volume > 0
+            and second.volume >= config.entry_volume_multiplier * median_volume
+        )
+    )
+    higher_timeframe_ok = (
+        not config.require_higher_timeframe_trend
+        or bool(f["higher_timeframe_trend"][index])
+    )
+    if not bullish or not body_ok or not volume_ok or not higher_timeframe_ok:
+        return False, 0.0, "confirmation"
+    return True, size_multiplier, state
+
+
+def _leader(
+    feature_map: Mapping[str, Mapping[str, list[float]]],
+    index: int,
+    config: V3Config,
+) -> tuple[str | None, dict[str, float]]:
+    scores = {
+        symbol: feature_map[symbol]["leader_score"][index]
+        for symbol in ("BTC", "ETH")
+    }
+    valid_scores = {symbol: value for symbol, value in scores.items() if _valid(value)}
+    if not valid_scores:
+        return None, scores
+    ordered = sorted(valid_scores.items(), key=lambda item: item[1], reverse=True)
+    winner, winner_score = ordered[0]
+    runner_up = ordered[1][1] if len(ordered) > 1 else -math.inf
+    if winner_score < config.leader_min_score:
+        return None, scores
+    if len(ordered) > 1 and winner_score - runner_up < config.leader_margin:
+        return None, scores
+    return winner, scores
+
+
+def _sell(cash: float, qty: float, price: float, fee: float, slip: float) -> float:
+    return cash + qty * price * (1.0 - slip) * (1.0 - fee)
+
+
+def _buy_fill(cash: float, price: float, desired_notional: float, fee: float, slip: float) -> tuple[float, float, float]:
+    notional = min(max(desired_notional, 0.0), cash)
+    fill = price * (1.0 + slip)
+    if notional <= 0 or fill <= 0:
+        return cash, 0.0, fill
+    return cash - notional, notional / fill * (1.0 - fee), fill
+
+
+def run_pair(
+    pair: Sequence[PairBar],
+    *,
+    initial_balance: float,
+    order_notional: float,
+    fees_bps: float,
+    slippage_bps: float,
+    config: V3Config = V3Config(),
+    start_index: int = 0,
+    end_index: int | None = None,
+    feature_map: Mapping[str, Mapping[str, list[float]]] | None = None,
+) -> dict[str, object]:
+    """Run one causal pair portfolio over an inclusive/exclusive slice."""
+
+    if initial_balance <= 0 or order_notional <= 0:
+        raise ValueError("initial_balance and order_notional must be positive")
+    if not pair:
+        raise ValueError("pair data must not be empty")
+    if not 0 < config.reduced_size_multiplier <= 1:
+        raise ValueError("reduced_size_multiplier must be in (0, 1]")
+    if not 0 < config.recovery_size_multiplier <= 1:
+        raise ValueError("recovery_size_multiplier must be in (0, 1]")
+    if not 0 < config.kill_switch_drawdown < config.lifetime_drawdown_limit:
+        raise ValueError("kill switch must be below lifetime drawdown limit")
+    if config.time_stop_bars <= 0 or config.recovery_size_bars <= 0:
+        raise ValueError("time and recovery windows must be positive")
+    if end_index is None:
+        end_index = len(pair)
+    if not 0 <= start_index < end_index <= len(pair):
+        raise ValueError("invalid backtest slice")
+
+    feature_map = feature_map or build_pair_features(pair, config)
+    btc = _asset_bars(pair, "BTC")
+    eth = _asset_bars(pair, "ETH")
+    bars_by_symbol = {"BTC": btc, "ETH": eth}
+    fee = fees_bps / 10_000.0
+    slip = slippage_bps / 10_000.0
+    cash = float(initial_balance)
+    position_symbol: str | None = None
+    qty = 0.0
+    entry_price = 0.0
+    entry_atr = 0.0
+    entry_index = -1
+    highest = 0.0
+    hard_stop = 0.0
+    trailing_stop = 0.0
+    profit_stop = 0.0
+    profit_lock_active = False
+    pending_entry: _PendingEntry | None = None
+    pending_exit: _PendingExit | None = None
+
+    lifetime_peak = initial_balance
+    risk_peak = initial_balance
+    max_drawdown = 0.0
+    recovery_baseline = initial_balance
+    recovery_until = -1
+    halted = False
+    blocked_until = -1
+    stable_count = 0
+    recovery_mode = False
+    permanent_halt = False
+    permanent_halt_reason: str | None = None
+
+    entries = 0
+    exits = 0
+    kill_events = 0
+    recovery_events = 0
+    time_stop_exits = 0
+    profit_lock_activations = 0
+    profit_lock_exits = 0
+    stop_exits = 0
+    trend_exits = 0
+    size_reductions = 0
+    extreme_blocked_entries = 0
+    leader_counts = {"BTC": 0, "ETH": 0}
+    leader_scores_seen = 0
+    entry_reasons: dict[str, int] = {}
+
+    last_index = end_index - 1
+
+    def current_equity(index: int) -> float:
+        if position_symbol is None:
+            return cash
+        return cash + qty * bars_by_symbol[position_symbol][index].close
+
+    def flatten(index: int, *, price: float | None = None) -> None:
+        nonlocal cash, qty, position_symbol, pending_entry, pending_exit, exits
+        if position_symbol is None or qty <= 0:
+            pending_entry = pending_exit = None
+            return
+        mark = price if price is not None else bars_by_symbol[position_symbol][index].close
+        cash = _sell(cash, qty, mark, fee, slip)
+        qty = 0.0
+        position_symbol = None
+        pending_entry = pending_exit = None
+        exits += 1
+
+    for index in range(start_index, end_index):
+        # Pending signals are formed from the prior close and fill at the next
+        # bar open.  A pending order is cancelled by a halt before it can fill.
+        if pending_exit is not None and position_symbol is not None:
+            bar = bars_by_symbol[position_symbol][index]
+            cash = _sell(cash, qty, bar.open, fee, slip)
+            reason = pending_exit.reason
+            exits += 1
+            if reason == "time_stop":
+                time_stop_exits += 1
+            elif reason == "profit_lock":
+                profit_lock_exits += 1
+            elif reason == "trend":
+                trend_exits += 1
+            pending_exit = None
+            position_symbol = None
+            qty = 0.0
+
+        if pending_entry is not None and position_symbol is None and not halted and not permanent_halt:
+            selected = pending_entry
+            bar = bars_by_symbol[selected.symbol][index]
+            desired = order_notional * selected.size_multiplier
+            cash, qty, fill = _buy_fill(cash, bar.open, desired, fee, slip)
+            if qty > 0:
+                position_symbol = selected.symbol
+                entry_price = fill
+                entry_atr = selected.atr if _valid(selected.atr) and selected.atr > 0 else fill * 0.02
+                entry_index = selected.signal_index
+                highest = fill
+                hard_stop = fill - config.hard_stop_atr * entry_atr
+                trailing_stop = fill - config.trailing_stop_atr * entry_atr
+                profit_stop = 0.0
+                profit_lock_active = False
+                entries += 1
+                entry_reasons[selected.symbol] = entry_reasons.get(selected.symbol, 0) + 1
+            pending_entry = None
+
+        # Manage an existing position with the current bar.  A newly raised
+        # trailing/profit stop applies to the next bar, avoiding a same-bar
+        # high-then-low assumption.
+        stop_triggered = False
+        if position_symbol is not None:
+            bars = bars_by_symbol[position_symbol]
+            f = feature_map[position_symbol]
+            bar = bars[index]
+            active_stop = max(hard_stop, trailing_stop, profit_stop)
+            if bar.low <= active_stop:
+                cash = _sell(cash, qty, active_stop, fee, slip)
+                exits += 1
+                stop_exits += 1
+                if profit_lock_active and active_stop >= profit_stop > 0:
+                    profit_lock_exits += 1
+                position_symbol = None
+                qty = 0.0
+                pending_exit = None
+                stop_triggered = True
+            else:
+                highest = max(highest, bar.high)
+                atr = f["atr"][index]
+                if _valid(atr) and atr > 0:
+                    trailing_stop = max(trailing_stop, highest - config.trailing_stop_atr * atr)
+                if not profit_lock_active and highest >= entry_price + config.profit_lock_activation_atr * entry_atr:
+                    profit_lock_active = True
+                    profit_lock_activations += 1
+                    profit_stop = entry_price + config.profit_lock_floor_atr * entry_atr
+                elif profit_lock_active:
+                    profit_stop = max(
+                        profit_stop,
+                        entry_price + config.profit_lock_floor_atr * entry_atr,
+                    )
+
+        equity = current_equity(index)
+        lifetime_peak = max(lifetime_peak, equity)
+        max_drawdown = max(
+            max_drawdown,
+            (lifetime_peak - equity) / lifetime_peak if lifetime_peak else 0.0,
+        )
+        lifetime_dd = (
+            (lifetime_peak - equity) / lifetime_peak if lifetime_peak else 0.0
+        )
+
+        # The lifetime limit is not reset by the ordinary 2% recovery cycle.
+        if lifetime_dd >= config.lifetime_drawdown_limit and not permanent_halt:
+            flatten(index)
+            permanent_halt = True
+            permanent_halt_reason = "lifetime_drawdown_limit"
+            halted = True
+            recovery_mode = False
+            continue
+
+        if recovery_mode and equity <= recovery_baseline * (1.0 - config.recovery_abort_drawdown):
+            flatten(index)
+            permanent_halt = True
+            permanent_halt_reason = "recovery_abort_drawdown"
+            halted = True
+            recovery_mode = False
+            continue
+
+        risk_peak = max(risk_peak, equity)
+        risk_dd = (risk_peak - equity) / risk_peak if risk_peak else 0.0
+        if risk_dd >= config.kill_switch_drawdown and not halted and not permanent_halt:
+            flatten(index)
+            kill_events += 1
+            halted = True
+            recovery_mode = False
+            blocked_until = index + config.cooldown_bars
+            stable_count = 0
+            risk_peak = cash
+            continue
+
+        if permanent_halt or index + 1 >= end_index:
+            continue
+
+        # Evaluate both assets at the current close.  All arrays are causal;
+        # the pending entry/exit is therefore filled no earlier than index+1.
+        setups: dict[str, tuple[bool, float, str]] = {
+            symbol: _setup(
+                bars_by_symbol[symbol], feature_map[symbol], index, config
+            )
+            for symbol in ("BTC", "ETH")
+        }
+        leader, scores = _leader(feature_map, index, config)
+        if leader is not None:
+            leader_counts[leader] += 1
+            leader_scores_seen += 1
+        for symbol, (_, _, reason) in setups.items():
+            if reason == "extreme":
+                extreme_blocked_entries += 1
+
+        healthy = any(
+            _trend_ok(bars_by_symbol[symbol], feature_map[symbol], index, config)
+            and _volatility_state(feature_map[symbol], index, config)[0] in {"normal", "reduced"}
+            for symbol in ("BTC", "ETH")
+        )
+        if halted:
+            if index < blocked_until:
+                stable_count = 0
+                continue
+            if healthy:
+                stable_count += 1
+            else:
+                stable_count = 0
+            if stable_count >= config.stable_bars:
+                halted = False
+                recovery_mode = True
+                recovery_events += 1
+                recovery_baseline = current_equity(index)
+                recovery_until = index + config.recovery_size_bars
+                risk_peak = recovery_baseline
+            else:
+                continue
+
+        if recovery_mode and index >= recovery_until:
+            recovery_mode = False
+
+        if stop_triggered:
+            continue
+
+        if position_symbol is not None:
+            f = feature_map[position_symbol]
+            bars = bars_by_symbol[position_symbol]
+            bearish = (
+                bars[index].close < bars[index].open
+                and _valid(f["atr"][index])
+                and bars[index].open - bars[index].close >= config.entry_min_body_atr * f["atr"][index]
+                and index > 0
+                and bars[index].close < bars[index - 1].low
+                and bars[index].close < f["ema_fast"][index]
+            )
+            age = index - entry_index
+            weak_trend = not _trend_ok(bars, f, index, config)
+            time_stop = age >= config.time_stop_bars and (
+                bars[index].close / entry_price - 1.0 < config.time_stop_min_return
+            )
+            if pending_exit is None and (weak_trend or bearish or time_stop):
+                reason = "time_stop" if time_stop else "trend"
+                pending_exit = _PendingExit(reason)
+            continue
+
+        if halted or permanent_halt or pending_entry is not None:
+            continue
+        if leader is None:
+            continue
+        setup_ok, volatility_size, setup_reason = setups[leader]
+        if not setup_ok:
+            continue
+        if volatility_size < 1.0:
+            size_reductions += 1
+        recovery_size = (
+            config.recovery_size_multiplier if recovery_mode else 1.0
+        )
+        if _valid(feature_map[leader]["atr"][index]) and feature_map[leader]["atr"][index] > 0:
+            pending_entry = _PendingEntry(
+                symbol=leader,
+                size_multiplier=volatility_size * recovery_size,
+                atr=feature_map[leader]["atr"][index],
+                signal_index=index,
+            )
+            entry_reasons[setup_reason] = entry_reasons.get(setup_reason, 0) + 1
+
+    if position_symbol is not None:
+        flatten(last_index)
+    ending_balance = cash
+    final_equity = ending_balance
+    lifetime_peak = max(lifetime_peak, final_equity)
+    max_drawdown = max(
+        max_drawdown,
+        (lifetime_peak - final_equity) / lifetime_peak if lifetime_peak else 0.0,
+    )
+    return {
+        "start": pair[start_index].timestamp.isoformat(),
+        "end": pair[last_index].timestamp.isoformat(),
+        "bars": end_index - start_index,
+        "initial_balance": initial_balance,
+        "ending_balance": ending_balance,
+        "pnl": ending_balance - initial_balance,
+        "return_pct": (ending_balance / initial_balance - 1.0) * 100.0,
+        "max_drawdown_pct": max_drawdown * 100.0,
+        "lifetime_drawdown_pct": ((lifetime_peak - ending_balance) / lifetime_peak * 100.0) if lifetime_peak else 0.0,
+        "entries": entries,
+        "exits": exits,
+        "trades": entries + exits,
+        "kill_switch": kill_events > 0,
+        "kill_events": kill_events,
+        "recovery_events": recovery_events,
+        "permanent_halt": permanent_halt,
+        "permanent_halt_reason": permanent_halt_reason,
+        "time_stop_exits": time_stop_exits,
+        "stop_exits": stop_exits,
+        "trend_exits": trend_exits,
+        "profit_lock_activations": profit_lock_activations,
+        "profit_lock_exits": profit_lock_exits,
+        "size_reductions": size_reductions,
+        "extreme_blocked_entries": extreme_blocked_entries,
+        "leader_counts": leader_counts,
+        "leader_scores_seen": leader_scores_seen,
+        "entry_reasons": entry_reasons,
+        "params": {
+            **config.as_dict(),
+            "initial_balance": initial_balance,
+            "order_notional": order_notional,
+            "fees_bps": fees_bps,
+            "slippage_bps": slippage_bps,
+            "start_index": start_index,
+            "end_index": end_index,
+        },
+    }
+
+
+def _folds(length: int) -> list[tuple[int, int]]:
+    first = int(length * 0.50)
+    second = int(length * 0.625)
+    third = int(length * 0.75)
+    return [(first, second), (second, third), (third, length)]
+
+
+def _median_return(results: Sequence[Mapping[str, object]]) -> float:
+    return statistics.median(float(result["return_pct"]) for result in results)
+
+
+def _promotion_gate(
+    full: Mapping[str, object],
+    walk_forward: Sequence[Mapping[str, object]],
+    stress_walk_forward: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    base_median = _median_return(walk_forward)
+    stress_median = _median_return(stress_walk_forward)
+    reasons: list[str] = []
+    if base_median <= 0:
+        reasons.append("base walk-forward median return is not positive")
+    if stress_median <= 0:
+        reasons.append("higher-cost walk-forward median return is not positive")
+    if bool(full["permanent_halt"]):
+        reasons.append("full sample hit the permanent cumulative drawdown limit")
+    if int(full["kill_events"]) > 1 or any(int(item["kill_events"]) > 1 for item in stress_walk_forward):
+        reasons.append("repeated 2% kill-switch events occurred")
+    if int(full["entries"]) < 4:
+        reasons.append("fewer than four full-sample entries")
+    return {
+        "pass": not reasons,
+        "base_walk_forward_median_return_pct": base_median,
+        "stress_walk_forward_median_return_pct": stress_median,
+        "requirements": {
+            "positive_base_median_walk_forward": True,
+            "positive_stress_median_walk_forward": True,
+            "no_permanent_halt": True,
+            "no_repeated_kill_switch": True,
+            "minimum_full_sample_entries": 4,
+        },
+        "failure_reasons": reasons,
+    }
+
+
+def research(
+    btc_path: Path,
+    eth_path: Path,
+    *,
+    initial_balance: float = 75_000.0,
+    order_notional: float = 6_000.0,
+    fees_bps: float = 10.0,
+    slippage_bps: float = 5.0,
+    stress_fees_bps: float = 20.0,
+    stress_slippage_bps: float = 10.0,
+    horizon_initial_balance: float = 5_000.0,
+    horizon_order_notional: float | None = None,
+) -> dict[str, object]:
+    btc = load_bars(btc_path)
+    eth = load_bars(eth_path)
+    pair = align_pair(btc, eth)
+    if horizon_order_notional is None:
+        horizon_order_notional = order_notional
+
+    candidates: dict[str, V3Config] = {
+        "balanced": V3Config(
+            expansion_ratio=1.05,
+            min_vol_rank=0.25,
+            reduce_size_rank=0.75,
+            extreme_vol_rank=0.90,
+            trailing_stop_atr=2.5,
+            time_stop_bars=72,
+        ),
+        "selective": V3Config(
+            expansion_ratio=1.10,
+            min_vol_rank=0.35,
+            reduce_size_rank=0.75,
+            extreme_vol_rank=0.90,
+            trailing_stop_atr=2.5,
+            time_stop_bars=72,
+        ),
+        "conservative": V3Config(
+            expansion_ratio=1.10,
+            min_vol_rank=0.35,
+            reduce_size_rank=0.70,
+            extreme_vol_rank=0.85,
+            trailing_stop_atr=3.0,
+            time_stop_bars=96,
+            profit_lock_activation_atr=1.25,
+        ),
+    }
+    report: dict[str, object] = {
+        "model": "adaptive_momentum_volatility_v3",
+        "research_only": True,
+        "paper_promotion_required": True,
+        "data": {
+            "btc_path": str(btc_path),
+            "eth_path": str(eth_path),
+            "btc_bars": len(btc),
+            "eth_bars": len(eth),
+            "aligned_bars": len(pair),
+            "start": pair[0].timestamp.isoformat(),
+            "end": pair[-1].timestamp.isoformat(),
+        },
+        "costs": {
+            "base": {"fees_bps": fees_bps, "slippage_bps": slippage_bps},
+            "stress": {"fees_bps": stress_fees_bps, "slippage_bps": stress_slippage_bps},
+        },
+        "portfolio": {"initial_balance": initial_balance, "order_notional": order_notional},
+        "candidate_definitions": {name: config.as_dict() for name, config in candidates.items()},
+    }
+    folds = _folds(len(pair))
+    candidates_report: dict[str, object] = {}
+    for name, config in candidates.items():
+        feature_map = build_pair_features(pair, config)
+        full = run_pair(
+            pair,
+            initial_balance=initial_balance,
+            order_notional=order_notional,
+            fees_bps=fees_bps,
+            slippage_bps=slippage_bps,
+            config=config,
+            feature_map=feature_map,
+        )
+        wf = [
+            run_pair(
+                pair,
+                initial_balance=initial_balance,
+                order_notional=order_notional,
+                fees_bps=fees_bps,
+                slippage_bps=slippage_bps,
+                config=config,
+                start_index=start,
+                end_index=end,
+                feature_map=feature_map,
+            )
+            for start, end in folds
+        ]
+        stress_wf = [
+            run_pair(
+                pair,
+                initial_balance=initial_balance,
+                order_notional=order_notional,
+                fees_bps=stress_fees_bps,
+                slippage_bps=stress_slippage_bps,
+                config=config,
+                start_index=start,
+                end_index=end,
+                feature_map=feature_map,
+            )
+            for start, end in folds
+        ]
+        horizon_sizes = {
+            "1d": 24,
+            "1w": 24 * 7,
+            "1m": 24 * 30,
+            "1y": 24 * 365,
+        }
+        horizons: dict[str, object] = {}
+        for label, bars_count in horizon_sizes.items():
+            start = max(0, len(pair) - bars_count)
+            horizons[label] = run_pair(
+                pair,
+                initial_balance=horizon_initial_balance,
+                order_notional=horizon_order_notional,
+                fees_bps=fees_bps,
+                slippage_bps=slippage_bps,
+                config=config,
+                start_index=start,
+                feature_map=feature_map,
+            )
+        candidates_report[name] = {
+            "full_sample": full,
+            "walk_forward": wf,
+            "stress_walk_forward": stress_wf,
+            "walk_forward_medians": {
+                "base_return_pct": _median_return(wf),
+                "stress_return_pct": _median_return(stress_wf),
+            },
+            "horizons": horizons,
+            "promotion_gate": _promotion_gate(full, wf, stress_wf),
+        }
+    report["walk_forward_folds"] = [{"start_index": start, "end_index": end} for start, end in folds]
+    report["candidates"] = candidates_report
+    report["paper_promotion"] = {
+        "passed_candidates": [
+            name
+            for name, value in candidates_report.items()
+            if bool(value["promotion_gate"]["pass"])
+        ],
+        "active_profile_changed": False,
+    }
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--initial-balance", type=float, default=75_000.0)
+    parser.add_argument("--order-notional", type=float, default=6_000.0)
+    parser.add_argument("--fees-bps", type=float, default=10.0)
+    parser.add_argument("--slippage-bps", type=float, default=5.0)
+    parser.add_argument("--stress-fees-bps", type=float, default=20.0)
+    parser.add_argument("--stress-slippage-bps", type=float, default=10.0)
+    parser.add_argument("--horizon-initial-balance", type=float, default=5_000.0)
+    parser.add_argument("--horizon-order-notional", type=float)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    report = research(
+        args.btc_path,
+        args.eth_path,
+        initial_balance=args.initial_balance,
+        order_notional=args.order_notional,
+        fees_bps=args.fees_bps,
+        slippage_bps=args.slippage_bps,
+        stress_fees_bps=args.stress_fees_bps,
+        stress_slippage_bps=args.stress_slippage_bps,
+        horizon_initial_balance=args.horizon_initial_balance,
+        horizon_order_notional=args.horizon_order_notional,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_research_matrix.py
+++ b/scripts/run_research_matrix.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import math
 from pathlib import Path
+import statistics
 from typing import Any
 
 import pandas as pd
@@ -19,6 +20,12 @@ import pandas as pd
 from backtest.optimization.execution_model import ExecutionCostModel
 from backtest.strategies.regime_momentum import generate_signals as regime_momentum_signals
 from tradingbot_ibkr.research_context import NewsEvent, gate_signal_series
+MIN_TEST_TRADES_PER_WINDOW = 5
+MIN_MATRIX_WINDOWS = 3
+MIN_POSITIVE_WINDOW_FRACTION = 2.0 / 3.0
+MAX_FAMILY_DRAWDOWN = 0.20
+
+
 from backtest.optimization.research_loop import (
     NightlyResearchLoop,
     _simulate_arbitrage,
@@ -35,19 +42,33 @@ def _evaluation(
     trades: int,
     costs: ExecutionCostModel,
 ) -> dict[str, Any]:
-    gross_return = float(summary.get("total_return", 0.0))
+    gross_return = float(summary.get("total_return", math.nan))
+    sharpe = float(summary.get("sharpe", math.nan))
+    drawdown = abs(float(summary.get("max_drawdown", math.nan)))
+    raw_profit_factor = float(summary.get("profit_factor", math.nan))
+    profit_factor = raw_profit_factor if math.isfinite(raw_profit_factor) else None
+    finite_metrics = all(
+        math.isfinite(value)
+        for value in (gross_return, sharpe, drawdown)
+    )
+    net_return = (
+        costs.net_return(gross_return, trades)
+        if finite_metrics
+        else math.nan
+    )
     return {
         "strategy": name,
         "gross_return": gross_return,
-        "net_return": costs.net_return(gross_return, trades),
-        "test_sharpe": float(summary.get("sharpe", 0.0)),
-        "test_drawdown": float(summary.get("max_drawdown", 0.0)),
-        "profit_factor": (
-            None
-            if math.isinf(float(summary.get("profit_factor", 0.0)))
-            else float(summary.get("profit_factor", 0.0))
-        ),
+        "net_return": net_return,
+        "cost_drag": gross_return - net_return if finite_metrics else math.nan,
+        "execution_cost_bps": costs.round_trip_fraction * 10_000.0,
+        "test_sharpe": sharpe,
+        "test_drawdown": drawdown,
+        # An infinite PF is retained as null: a no-loss sample is not treated
+        # as robust evidence by the family gate.
+        "profit_factor": profit_factor,
         "trades": int(trades),
+        "finite_metrics": finite_metrics and math.isfinite(net_return),
     }
 
 
@@ -59,10 +80,31 @@ def run_matrix(
     costs: ExecutionCostModel | None = None,
     news_events: list[NewsEvent] | None = None,
     expected_move_bps: float = 40.0,
+    minimum_test_trades: int = MIN_TEST_TRADES_PER_WINDOW,
+    minimum_windows: int = MIN_MATRIX_WINDOWS,
 ) -> dict[str, Any]:
+    if window_size < 2:
+        raise ValueError("window_size must be at least two rows")
+    if not 0.0 < test_fraction < 1.0:
+        raise ValueError("test_fraction must be between zero and one")
+    if minimum_test_trades < 1 or minimum_windows < 1:
+        raise ValueError("matrix research minimums must be positive")
+    if not math.isfinite(expected_move_bps) or expected_move_bps < 0:
+        raise ValueError("expected_move_bps must be finite and non-negative")
+    required_columns = {"timestamp", "close"}
+    missing = required_columns - set(data.columns)
+    if missing:
+        raise ValueError(f"dataset missing columns: {sorted(missing)}")
+    frame = data.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+    frame["close"] = pd.to_numeric(frame["close"], errors="coerce")
+    if frame["timestamp"].isna().any() or not frame["close"].map(math.isfinite).all() or (frame["close"] <= 0).any():
+        raise ValueError("dataset contains invalid timestamps or close prices")
+    frame = frame.sort_values("timestamp").drop_duplicates("timestamp").reset_index(drop=True)
     costs = costs or ExecutionCostModel()
     windows = create_non_overlapping_windows(
-        data.sort_values("timestamp").reset_index(drop=True),
+        frame,
+        window_size=window_size,
         window_size=window_size,
         test_fraction=test_fraction,
     )
@@ -130,12 +172,80 @@ def run_matrix(
     families: dict[str, dict[str, Any]] = {}
     for family in sorted({item["strategy"] for item in results}):
         entries = [item for item in results if item["strategy"] == family]
+        family_windows = sorted({item["window"] for item in entries})
+        eligible = [
+            item
+            for item in entries
+            if item["finite_metrics"] and item["trades"] >= minimum_test_trades
+        ]
+        net_returns = [float(item["net_return"]) for item in eligible]
+        sharpes = [float(item["test_sharpe"]) for item in eligible]
+        profit_factors = [
+            float(item["profit_factor"])
+            for item in eligible
+            if item["profit_factor"] is not None
+            and math.isfinite(float(item["profit_factor"]))
+        ]
+        positive_tests = sum(value > 0 for value in net_returns)
+        gate_reasons: list[str] = []
+        if len(family_windows) < minimum_windows:
+            gate_reasons.append(
+                f"only {len(family_windows)} test windows; {minimum_windows} required"
+            )
+        if len(eligible) != len(entries):
+            gate_reasons.append(
+                f"{len(entries) - len(eligible)} window results fail finite/sample gates"
+            )
+        if not net_returns or statistics.median(net_returns) <= 0:
+            gate_reasons.append("median net return is not positive")
+        if (
+            not net_returns
+            or positive_tests / len(net_returns) < MIN_POSITIVE_WINDOW_FRACTION
+        ):
+            gate_reasons.append("fewer than two thirds of eligible windows are profitable")
+        if not sharpes or statistics.median(sharpes) <= 0:
+            gate_reasons.append("median test Sharpe is not positive")
+        if not profit_factors or statistics.median(profit_factors) < 1.05:
+            gate_reasons.append("median finite profit factor is below 1.05")
+        if eligible and max(float(item["test_drawdown"]) for item in eligible) > MAX_FAMILY_DRAWDOWN:
+            gate_reasons.append(f"test drawdown exceeds {MAX_FAMILY_DRAWDOWN:.0%}")
         families[family] = {
-            "windows": len({item["window"] for item in entries}),
-            "positive_tests": sum(item["net_return"] > 0 for item in entries),
+            "windows": len(family_windows),
+            "positive_tests": positive_tests,
             "total_tests": len(entries),
-            "best_net_return": max(item["net_return"] for item in entries),
-            "best": max(entries, key=lambda item: (item["net_return"], item["test_sharpe"])),
+            "best_net_return": max(
+                (float(item["net_return"]) for item in entries if item["finite_metrics"]),
+                default=None,
+            ),
+            # This is intentionally descriptive only. It is never used by the
+            # family gate because selecting the best test slice is test leakage.
+            "best_test_result_descriptive_only": max(
+                entries,
+                key=lambda item: (
+                    float(item["net_return"])
+                    if item["finite_metrics"]
+                    else -math.inf,
+                    float(item["test_sharpe"])
+                    if math.isfinite(float(item["test_sharpe"]))
+                    else -math.inf,
+                ),
+            ),
+            "median_net_return": statistics.median(net_returns) if net_returns else None,
+            "median_test_sharpe": statistics.median(sharpes) if sharpes else None,
+            "median_test_drawdown": statistics.median(
+                [float(item["test_drawdown"]) for item in eligible]
+            ) if eligible else None,
+            "median_profit_factor": statistics.median(profit_factors) if profit_factors else None,
+            "eligible_windows": len(eligible),
+            "research_gate": {
+                "pass": not gate_reasons,
+                "failure_reasons": gate_reasons,
+                "minimum_test_trades_per_window": minimum_test_trades,
+                "minimum_windows": minimum_windows,
+                "minimum_positive_window_fraction": MIN_POSITIVE_WINDOW_FRACTION,
+                "maximum_test_drawdown": MAX_FAMILY_DRAWDOWN,
+                "best_test_result_is_not_evidence": True,
+            },
         }
     return {
         "cost_model": {
@@ -147,6 +257,12 @@ def run_matrix(
         "families": families,
         "results": results,
         "news_mode": "enabled" if news_events else "price_only",
+        "research_gates": {
+            "best_test_slice_is_descriptive_only": True,
+            "minimum_test_trades_per_window": minimum_test_trades,
+            "minimum_windows": minimum_windows,
+            "execution_costs_applied": True,
+        },
     }
 
 

--- a/scripts/run_research_matrix.py
+++ b/scripts/run_research_matrix.py
@@ -105,7 +105,6 @@ def run_matrix(
     windows = create_non_overlapping_windows(
         frame,
         window_size=window_size,
-        window_size=window_size,
         test_fraction=test_fraction,
     )
     loop = NightlyResearchLoop(windows, Path("/tmp/research-matrix-registry.json"), trials_range=(1, 1))

--- a/scripts/run_research_matrix.py
+++ b/scripts/run_research_matrix.py
@@ -107,6 +107,8 @@ def run_matrix(
         window_size=window_size,
         test_fraction=test_fraction,
     )
+    if not windows:
+        raise ValueError("dataset/window settings produced no evaluable test windows")
     loop = NightlyResearchLoop(windows, Path("/tmp/research-matrix-registry.json"), trials_range=(1, 1))
     results: list[dict[str, Any]] = []
     def news_wrap(builder):

--- a/scripts/run_v3_research_controller.py
+++ b/scripts/run_v3_research_controller.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
+import statistics
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -31,7 +33,10 @@ except ModuleNotFoundError:  # pragma: no cover - direct import fallback
     from run_momentum_volatility_v3 import align_pair, research
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+DEFAULT_MIN_CONFIRMATION_ENTRIES = 5
+DEFAULT_MAX_DATA_AGE_DAYS = 45.0
+REQUIRED_ORDER_SIZE_KEYS = frozenset({"4000", "6000"})
 DEFAULT_BTC_PATH = Path("data/historical/binance/normalized/BTCUSDT_1h.csv")
 DEFAULT_ETH_PATH = Path("data/historical/binance/normalized/ETHUSDT_1h.csv")
 DEFAULT_OUTPUT_DIR = Path("artifacts/momentum-v3/research-controller")
@@ -50,7 +55,10 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
 
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.tmp")
-    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False),
+        encoding="utf-8",
+    )
     temporary.replace(path)
 
 
@@ -61,16 +69,71 @@ def _read_state(path: Path) -> dict[str, Any]:
             "status": "researching",
             "strategy_ready": False,
             "iterations_completed": 0,
+            "consecutive_ready_passes": 0,
             "history": [],
         }
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"research state must be a JSON object: {path}")
     if payload.get("schema_version") != SCHEMA_VERSION:
-        raise ValueError(
-            f"unsupported research state schema: {payload.get('schema_version')!r}"
-        )
-    payload.setdefault("history", [])
+        # Never trust readiness from an older state format. Reset to a clean
+        # research state so an optional artifact restore cannot block the
+        # monthly job or carry an old winner across changed gate semantics.
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "researching",
+            "strategy_ready": False,
+            "iterations_completed": 0,
+            "consecutive_ready_passes": 0,
+            "history": [],
+            "migration_notice": (
+                f"discarded unsupported research state schema "
+                f"{payload.get('schema_version')!r}"
+            ),
+        }
+    if not isinstance(payload.get("strategy_ready", False), bool):
+        raise ValueError("research state strategy_ready must be boolean")
+    if (
+        not isinstance(payload.get("iterations_completed", 0), int)
+        or isinstance(payload.get("iterations_completed", 0), bool)
+        or payload.get("iterations_completed", 0) < 0
+    ):
+        raise ValueError("research state iterations_completed must be a non-negative integer")
+    history = payload.get("history", [])
+    if not isinstance(history, list):
+        raise ValueError("research state history must be a list")
+    payload.setdefault("consecutive_ready_passes", 0)
+    payload.setdefault("last_ready_signature", None)
+    payload.setdefault("last_ready_experiment", None)
+    payload.setdefault("last_ready_candidates", [])
+    consecutive = payload["consecutive_ready_passes"]
+    if not isinstance(consecutive, int) or isinstance(consecutive, bool) or consecutive < 0:
+        raise ValueError("research state consecutive_ready_passes must be non-negative")
+    for field in ("last_ready_signature", "last_ready_experiment"):
+        if payload[field] is not None and not isinstance(payload[field], Mapping):
+            raise ValueError(f"research state {field} must be an object or null")
+    if (
+        not isinstance(payload["last_ready_candidates"], list)
+        or not all(isinstance(item, str) for item in payload["last_ready_candidates"])
+    ):
+        raise ValueError("research state last_ready_candidates must be a string list")
+    if payload.get("strategy_ready"):
+        last_run = payload.get("last_run")
+        readiness = last_run.get("readiness") if isinstance(last_run, Mapping) else None
+        if (
+            not isinstance(last_run, Mapping)
+            or last_run.get("strategy_ready") is not True
+            or not isinstance(readiness, Mapping)
+            or readiness.get("strategy_ready") is not True
+        ):
+            # A cached flag without the complete evidence record is not
+            # sufficient to report readiness after an artifact restore.
+            payload["strategy_ready"] = False
+            payload["status"] = "researching"
+            payload["consecutive_ready_passes"] = 0
+            payload["last_ready_signature"] = None
+            payload["last_ready_experiment"] = None
+            payload["last_ready_candidates"] = []
     return payload
 
 
@@ -83,14 +146,20 @@ def _sha256(path: Path) -> str:
 
 
 def _source_fingerprint() -> dict[str, str]:
-    """Invalidate a cached iteration when the research implementation changes."""
+    """Invalidate cached research when code or workflow inputs change."""
 
-    files = (
+    files = [
         Path(__file__),
         Path(__file__).with_name("run_momentum_volatility_v3.py"),
         Path(__file__).with_name("run_momentum_volatility_research.py"),
-    )
-    return {str(path): _sha256(path) for path in files}
+        Path(__file__).with_name("fetch_binance_vision_klines.py"),
+        Path(__file__).parents[1] / ".github" / "workflows" / "momentum-v3-research.yml",
+    ]
+    return {
+        str(path): _sha256(path)
+        for path in files
+        if path.is_file()
+    }
 
 
 def _data_fingerprint(paths: Sequence[Path]) -> dict[str, Any]:
@@ -124,13 +193,9 @@ def validate_data(
     eth_path: Path,
     *,
     minimum_aligned_bars: int = DEFAULT_MIN_ALIGNED_BARS,
+    max_data_age_days: float | None = None,
 ) -> tuple[list[Any], dict[str, Any]]:
-    """Load both markets and fail closed on short or unsafe research data.
-
-    A synchronized exchange-wide outage can be retained without inventing
-    candles.  Asymmetric or very large gaps are rejected because they can
-    change the leader and volatility calculations differently by asset.
-    """
+    """Load both markets and fail closed on unsafe or stale research data."""
 
     btc = load_bars(btc_path)
     eth = load_bars(eth_path)
@@ -138,6 +203,16 @@ def validate_data(
     if len(pair) < minimum_aligned_bars:
         raise ValueError(
             f"aligned data has {len(pair)} bars; at least {minimum_aligned_bars} are required"
+        )
+    if (
+        btc[0].timestamp != eth[0].timestamp
+        or btc[-1].timestamp != eth[-1].timestamp
+        or len(pair) != len(btc)
+        or len(pair) != len(eth)
+    ):
+        raise ValueError(
+            "BTC and ETH must have identical timestamp coverage; "
+            "refusing silently truncated pair data"
         )
     btc_gaps = _gap_details(btc)
     eth_gaps = _gap_details(eth)
@@ -157,12 +232,24 @@ def validate_data(
             f"historical data contains a synchronized gap of {largest_gap:.2f} hours; "
             "gaps over six hours require a separately reviewed dataset"
         )
+    data_age_days = None
+    if max_data_age_days is not None:
+        if not math.isfinite(max_data_age_days) or max_data_age_days <= 0:
+            raise ValueError("max_data_age_days must be finite and positive")
+        now = datetime.now(timezone.utc)
+        data_age_days = (now - pair[-1].timestamp).total_seconds() / 86400.0
+        if data_age_days < 0 or data_age_days > max_data_age_days:
+            raise ValueError(
+                f"historical data ends {data_age_days:.2f} days from the current UTC time; "
+                f"maximum allowed age is {max_data_age_days:.2f} days"
+            )
     return pair, {
         "btc_bars": len(btc),
         "eth_bars": len(eth),
         "aligned_bars": len(pair),
         "start": pair[0].timestamp.isoformat(),
         "end": pair[-1].timestamp.isoformat(),
+        "data_age_days": data_age_days,
         "btc_gaps_over_1_5_hours": btc_gaps,
         "eth_gaps_over_1_5_hours": eth_gaps,
         "synchronized_gap_warning": bool(btc_gaps),
@@ -170,20 +257,91 @@ def validate_data(
     }
 
 
-def _number(payload: Mapping[str, Any], key: str) -> float:
-    value = payload.get(key)
+def _result_number(payload: Mapping[str, Any], key: str) -> float:
     try:
-        return float(value)
+        value = float(payload.get(key, math.nan))
     except (TypeError, ValueError):
-        return float("nan")
+        return math.nan
+    return value
 
 
-def _integer(payload: Mapping[str, Any], key: str) -> int:
-    value = payload.get(key)
+def _result_integer(payload: Mapping[str, Any], key: str) -> int:
     try:
-        return int(value)
+        value = int(payload.get(key, -1))
     except (TypeError, ValueError):
         return -1
+    return value
+
+
+def _median_result_return(results: Sequence[Any]) -> float:
+    values: list[float] = []
+    for result in results:
+        if not isinstance(result, Mapping):
+            return math.nan
+        value = _result_number(result, "return_pct")
+        if not math.isfinite(value):
+            return math.nan
+        values.append(value)
+    return statistics.median(values) if values else math.nan
+
+
+def _result_reasons(
+    label: str,
+    result: Any,
+    *,
+    minimum_entries: int,
+    require_positive: bool,
+) -> list[str]:
+    reasons: list[str] = []
+    if not isinstance(result, Mapping):
+        return [f"missing {label} result"]
+    entries = _result_integer(result, "entries")
+    if entries < minimum_entries:
+        reasons.append(
+            f"{label} has {entries} entries; {minimum_entries} required"
+        )
+    return_pct = _result_number(result, "return_pct")
+    if not math.isfinite(return_pct):
+        reasons.append(f"{label} return is not finite")
+    elif require_positive and return_pct <= 0:
+        reasons.append(f"{label} return is not positive")
+    permanent_halt = result.get("permanent_halt")
+    if not isinstance(permanent_halt, bool):
+        reasons.append(f"{label} permanent_halt flag is invalid")
+    elif permanent_halt:
+        reasons.append(f"{label} hit a permanent halt")
+    kill_events = _result_integer(result, "kill_events")
+    if kill_events < 0:
+        reasons.append(f"{label} kill_events field is invalid")
+    elif kill_events > 1:
+        reasons.append(f"{label} has repeated kill-switch events")
+    return reasons
+
+
+def _validate_report_costs(report: Mapping[str, Any]) -> list[str]:
+    costs = report.get("costs")
+    if not isinstance(costs, Mapping):
+        return ["missing cost assumptions"]
+    base = costs.get("base")
+    stress = costs.get("stress")
+    if not isinstance(base, Mapping) or not isinstance(stress, Mapping):
+        return ["base and stress cost assumptions are required"]
+    base_fees = _result_number(base, "fees_bps")
+    base_slippage = _result_number(base, "slippage_bps")
+    stress_fees = _result_number(stress, "fees_bps")
+    stress_slippage = _result_number(stress, "slippage_bps")
+    values = (base_fees, base_slippage, stress_fees, stress_slippage)
+    if not all(math.isfinite(value) and value >= 0 for value in values):
+        return ["cost assumptions must be finite and non-negative"]
+    if (
+        stress_fees < base_fees
+        or stress_slippage < base_slippage
+        or (stress_fees == base_fees and stress_slippage == base_slippage)
+    ):
+        return [
+            "stress costs must be no lower in either component and higher in at least one"
+        ]
+    return []
 
 
 def evaluate_candidate(
@@ -192,94 +350,131 @@ def evaluate_candidate(
     *,
     minimum_full_entries: int = DEFAULT_MIN_FULL_ENTRIES,
     minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
+    minimum_confirmation_entries: int = DEFAULT_MIN_CONFIRMATION_ENTRIES,
 ) -> dict[str, Any]:
-    """Apply the stricter controller gate to one v3 candidate report.
-
-    The v3 runner's gate is necessary but intentionally broad.  The
-    controller additionally requires enough entries in every chronological
-    walk-forward fold and a positive full-sample result.  A one-day snapshot
-    is reported as evidence, not treated as proof of robustness.
-    """
+    """Apply independent, fail-closed readiness checks to one candidate."""
 
     reasons: list[str] = []
     gate = candidate.get("promotion_gate")
-    if not isinstance(gate, Mapping):
-        reasons.append("missing v3 promotion gate")
-    elif not bool(gate.get("pass")):
-        gate_reasons = gate.get("failure_reasons")
+    if not isinstance(gate, Mapping) or gate.get("pass") is not True:
+        gate_reasons = gate.get("failure_reasons") if isinstance(gate, Mapping) else None
         if isinstance(gate_reasons, list) and gate_reasons:
             reasons.extend(str(item) for item in gate_reasons)
         else:
-            reasons.append("v3 promotion gate did not pass")
+            reasons.append("v3 promotion gate did not pass a strict boolean check")
 
     full = candidate.get("full_sample")
-    if not isinstance(full, Mapping):
-        reasons.append("missing full-sample result")
-        full = {}
-    if _integer(full, "entries") < minimum_full_entries:
-        reasons.append(f"fewer than {minimum_full_entries} full-sample entries")
-    if _number(full, "return_pct") <= 0:
-        reasons.append("full-sample return is not positive")
-    if bool(full.get("permanent_halt")):
-        reasons.append("full sample hit a permanent halt")
-    if _integer(full, "kill_events") > 1:
-        reasons.append("full sample has repeated kill-switch events")
+    stress_full = candidate.get("full_sample_stress")
+    reasons.extend(_result_reasons(
+        "full sample", full, minimum_entries=minimum_full_entries, require_positive=True
+    ))
+    reasons.extend(_result_reasons(
+        "stress full sample", stress_full, minimum_entries=minimum_full_entries, require_positive=True
+    ))
 
     fold_checks: dict[str, list[dict[str, Any]]] = {}
+    fold_medians: dict[str, float] = {}
     for label in ("walk_forward", "stress_walk_forward"):
         raw_folds = candidate.get(label)
-        if not isinstance(raw_folds, Sequence) or isinstance(raw_folds, (str, bytes)):
-            reasons.append(f"missing {label} results")
+        if (
+            not isinstance(raw_folds, Sequence)
+            or isinstance(raw_folds, (str, bytes))
+            or len(raw_folds) != 3
+        ):
+            reasons.append(f"{label} must contain exactly three folds")
             fold_checks[label] = []
+            fold_medians[label] = math.nan
             continue
         checks: list[dict[str, Any]] = []
         for index, raw_fold in enumerate(raw_folds, start=1):
-            fold = raw_fold if isinstance(raw_fold, Mapping) else {}
-            entries = _integer(fold, "entries")
-            fold_reasons: list[str] = []
-            if entries < minimum_fold_entries:
-                fold_reasons.append(
-                    f"fold {index} has {entries} entries; {minimum_fold_entries} required"
-                )
-            if bool(fold.get("permanent_halt")):
-                fold_reasons.append(f"fold {index} hit a permanent halt")
-            if _integer(fold, "kill_events") > 1:
-                fold_reasons.append(f"fold {index} has repeated kill-switch events")
-            reasons.extend(f"{label}: {item}" for item in fold_reasons)
-            checks.append(
-                {
-                    "fold": index,
-                    "entries": entries,
-                    "return_pct": _number(fold, "return_pct"),
-                    "pass": not fold_reasons,
-                    "failure_reasons": fold_reasons,
-                }
+            fold_reasons = _result_reasons(
+                f"{label} fold {index}",
+                raw_fold,
+                minimum_entries=minimum_fold_entries,
+                require_positive=False,
             )
+            reasons.extend(fold_reasons)
+            fold = raw_fold if isinstance(raw_fold, Mapping) else {}
+            checks.append({
+                "fold": index,
+                "entries": _result_integer(fold, "entries"),
+                "return_pct": _result_number(fold, "return_pct"),
+                "pass": not fold_reasons,
+                "failure_reasons": fold_reasons,
+            })
         fold_checks[label] = checks
+        fold_medians[label] = _median_result_return(raw_folds)
+
+    base_median = fold_medians["walk_forward"]
+    stress_median = fold_medians["stress_walk_forward"]
+    if not math.isfinite(base_median) or base_median <= 0:
+        reasons.append("base walk-forward median return is not positive and finite")
+    if not math.isfinite(stress_median) or stress_median <= 0:
+        reasons.append("stress walk-forward median return is not positive and finite")
+    if isinstance(gate, Mapping):
+        for field, computed in (
+            ("base_walk_forward_median_return_pct", base_median),
+            ("stress_walk_forward_median_return_pct", stress_median),
+        ):
+            reported = _result_number(gate, field)
+            if not math.isfinite(reported) or not math.isfinite(computed):
+                reasons.append(f"promotion gate field {field} is not finite")
+            elif not math.isclose(reported, computed, rel_tol=1e-9, abs_tol=1e-9):
+                reasons.append(f"promotion gate field {field} disagrees with raw folds")
+
+    holdout = candidate.get("confirmation_holdout")
+    holdout_checks: dict[str, Any] = {}
+    if not isinstance(holdout, Mapping):
+        reasons.append("missing confirmation holdout")
+    else:
+        for label in ("base", "stress"):
+            holdout_checks[label] = _result_reasons(
+                f"confirmation holdout {label}",
+                holdout.get(label),
+                minimum_entries=minimum_confirmation_entries,
+                require_positive=True,
+            )
+            reasons.extend(holdout_checks[label])
 
     horizons = candidate.get("horizons")
     horizon_observations: dict[str, Any] = {}
-    if isinstance(horizons, Mapping):
+    if not isinstance(horizons, Mapping):
+        reasons.append("missing 1d/1w/1m/1y horizon evidence")
+    else:
         for label in ("1d", "1w", "1m", "1y"):
             value = horizons.get(label)
-            if isinstance(value, Mapping):
-                horizon_observations[label] = {
-                    "return_pct": _number(value, "return_pct"),
-                    "entries": _integer(value, "entries"),
-                    "pnl": _number(value, "pnl"),
-                }
+            if not isinstance(value, Mapping):
+                reasons.append(f"missing {label} horizon evidence")
+                continue
+            return_pct = _result_number(value, "return_pct")
+            pnl = _result_number(value, "pnl")
+            entries = _result_integer(value, "entries")
+            if not math.isfinite(return_pct) or not math.isfinite(pnl) or entries < 0:
+                reasons.append(f"{label} horizon evidence is invalid")
+            horizon_observations[label] = {
+                "return_pct": return_pct,
+                "entries": entries,
+                "pnl": pnl,
+            }
 
     return {
         "candidate": candidate_name,
         "pass": not reasons,
         "failure_reasons": reasons,
         "fold_checks": fold_checks,
+        "walk_forward_medians": {
+            "base_return_pct": base_median,
+            "stress_return_pct": stress_median,
+        },
+        "confirmation_holdout_checks": holdout_checks,
         "horizon_observations": horizon_observations,
         "rules": {
             "minimum_full_sample_entries": minimum_full_entries,
             "minimum_entries_per_walk_forward_fold": minimum_fold_entries,
-            "positive_full_sample_return": True,
+            "minimum_confirmation_holdout_entries": minimum_confirmation_entries,
+            "positive_full_sample_base_and_stress": True,
             "positive_base_and_stress_walk_forward_medians": True,
+            "positive_confirmation_holdout_base_and_stress": True,
             "one_day_snapshot_is_not_sufficient_proof": True,
         },
     }
@@ -290,14 +485,28 @@ def evaluate_readiness(
     *,
     minimum_full_entries: int = DEFAULT_MIN_FULL_ENTRIES,
     minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
+    minimum_confirmation_entries: int = DEFAULT_MIN_CONFIRMATION_ENTRIES,
 ) -> dict[str, Any]:
-    """Require the same candidate to pass at both $4k and $6k sizing."""
+    """Require one candidate to pass the complete gate at exactly both sizes."""
+
+    normalized_reports = {str(size): report for size, report in reports.items()}
+    global_reasons: list[str] = []
+    if set(normalized_reports) != set(REQUIRED_ORDER_SIZE_KEYS):
+        global_reasons.append("readiness requires exactly $4,000 and $6,000 reports")
 
     checks_by_size: dict[str, dict[str, Any]] = {}
     candidate_sets: list[set[str]] = []
-    for size, report in reports.items():
+    for size in sorted(REQUIRED_ORDER_SIZE_KEYS):
+        report = normalized_reports.get(size)
+        if not isinstance(report, Mapping):
+            global_reasons.append(f"missing report for order size {size}")
+            report = {}
+        global_reasons.extend(
+            f"${size}: {reason}" for reason in _validate_report_costs(report)
+        )
         raw_candidates = report.get("candidates", {})
         if not isinstance(raw_candidates, Mapping):
+            global_reasons.append(f"${size}: missing candidates mapping")
             raw_candidates = {}
         checks = {
             str(name): evaluate_candidate(
@@ -305,37 +514,51 @@ def evaluate_readiness(
                 candidate,
                 minimum_full_entries=minimum_full_entries,
                 minimum_fold_entries=minimum_fold_entries,
+                minimum_confirmation_entries=minimum_confirmation_entries,
             )
             for name, candidate in raw_candidates.items()
             if isinstance(candidate, Mapping)
         }
-        checks_by_size[str(size)] = checks
+        checks_by_size[size] = checks
         candidate_sets.append(set(checks))
 
-    common_candidates = sorted(set.intersection(*candidate_sets)) if candidate_sets else []
-    ready_candidates = [
+    common_candidates = set.intersection(*candidate_sets) if len(candidate_sets) == 2 else set()
+    ready_candidates = sorted(
         name
         for name in common_candidates
-        if all(bool(checks_by_size[size][name]["pass"]) for size in checks_by_size)
-    ]
+        if all(bool(checks_by_size[size][name]["pass"]) for size in REQUIRED_ORDER_SIZE_KEYS)
+    )
+    if global_reasons:
+        ready_candidates = []
     return {
         "pass": bool(ready_candidates),
         "strategy_ready": bool(ready_candidates),
         "ready_candidates": ready_candidates,
-        "required_sizes": sorted(checks_by_size),
-        "common_candidates": common_candidates,
+        "required_sizes": sorted(REQUIRED_ORDER_SIZE_KEYS),
+        "common_candidates": sorted(common_candidates),
         "checks_by_size": checks_by_size,
+        "failure_reasons": global_reasons,
         "rules": {
             "same_candidate_must_pass_all_required_sizes": True,
             "required_order_notionals": [4_000.0, 6_000.0],
+            "required_confirmation_holdout": True,
+            "required_distinct_data_vintages": 3,
             "leverage_allowed": False,
             "paper_promotion_is_not_automatic": True,
         },
     }
 
 
-def _signature(data: Mapping[str, Any], source: Mapping[str, str]) -> dict[str, Any]:
-    return {"data": dict(data), "source": dict(source)}
+def _signature(
+    data: Mapping[str, Any],
+    source: Mapping[str, str],
+    config: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "data": dict(data),
+        "source": dict(source),
+        "config": dict(config),
+    }
 
 
 def _save_status(state_path: Path, state: Mapping[str, Any]) -> None:
@@ -359,6 +582,9 @@ def _run_iteration(
     horizon_initial_balance: float,
     minimum_full_entries: int,
     minimum_fold_entries: int,
+    minimum_confirmation_entries: int,
+    max_data_age_days: float | None,
+    research_config: Mapping[str, Any],
     data_fingerprint: Mapping[str, Any],
     source_fingerprint: Mapping[str, str],
 ) -> dict[str, Any]:
@@ -367,6 +593,7 @@ def _run_iteration(
         btc_path,
         eth_path,
         minimum_aligned_bars=minimum_aligned_bars,
+        max_data_age_days=max_data_age_days,
     )
     del pair  # validation above deliberately reloads inside the v3 runner.
 
@@ -395,6 +622,7 @@ def _run_iteration(
             "data_quality": quality,
             "data_fingerprint": dict(data_fingerprint),
             "source_fingerprint": dict(source_fingerprint),
+            "research_config": dict(research_config),
         }
         reports[size_key] = report
         report_path = iteration_dir / f"report-{size_key}.json"
@@ -405,6 +633,7 @@ def _run_iteration(
         reports,
         minimum_full_entries=minimum_full_entries,
         minimum_fold_entries=minimum_fold_entries,
+        minimum_confirmation_entries=minimum_confirmation_entries,
     )
     finished_at = _utc_now()
     return {
@@ -431,7 +660,7 @@ def _append_history(state: dict[str, Any], entry: Mapping[str, Any]) -> None:
         history = []
         state["history"] = history
     history.append(dict(entry))
-    del history[:-100]
+    del history[:-1000]
 
 
 def run_controller(
@@ -450,23 +679,46 @@ def run_controller(
     horizon_initial_balance: float = 5_000.0,
     minimum_full_entries: int = DEFAULT_MIN_FULL_ENTRIES,
     minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
+    minimum_confirmation_entries: int = DEFAULT_MIN_CONFIRMATION_ENTRIES,
+    max_data_age_days: float | None = DEFAULT_MAX_DATA_AGE_DAYS,
+    required_consecutive_passes: int = 3,
     until_ready: bool = False,
     interval_hours: float = 24.0,
     max_iterations: int = 0,
     force: bool = False,
 ) -> dict[str, Any]:
-    if len(order_notionals) != 2 or set(order_notionals) != set(DEFAULT_ORDER_NOTIONALS):
+    if len(order_notionals) != 2 or set(order_notionals) != {4_000.0, 6_000.0}:
         raise ValueError("the controller requires exactly $4,000 and $6,000 order notionals")
-    if any(value <= 0 for value in order_notionals):
-        raise ValueError("order notionals must be positive")
-    if minimum_aligned_bars < 1 or minimum_full_entries < 1 or minimum_fold_entries < 1:
+    if any(not math.isfinite(value) or value <= 0 for value in order_notionals):
+        raise ValueError("order notionals must be finite and positive")
+    if (
+        minimum_aligned_bars < 1
+        or minimum_full_entries < 1
+        or minimum_fold_entries < 1
+        or minimum_confirmation_entries < 1
+    ):
         raise ValueError("research minimums must be positive")
-    if until_ready and interval_hours < 0:
-        raise ValueError("interval_hours cannot be negative")
-    if until_ready and interval_hours == 0 and max_iterations == 0:
+    if required_consecutive_passes < 1:
+        raise ValueError("required_consecutive_passes must be positive")
+    cost_values = (fees_bps, slippage_bps, stress_fees_bps, stress_slippage_bps)
+    if not all(math.isfinite(value) and value >= 0 for value in cost_values):
+        raise ValueError("cost assumptions must be finite and non-negative")
+    if (
+        stress_fees_bps < fees_bps
+        or stress_slippage_bps < slippage_bps
+        or (stress_fees_bps == fees_bps and stress_slippage_bps == slippage_bps)
+    ):
         raise ValueError(
-            "an unlimited --until-ready loop needs a positive interval_hours"
+            "stress costs must be no lower in either component and higher in at least one"
         )
+    if max_data_age_days is not None and (
+        not math.isfinite(max_data_age_days) or max_data_age_days <= 0
+    ):
+        raise ValueError("max_data_age_days must be finite and positive")
+    if until_ready and max_iterations == 0:
+        raise ValueError("--until-ready requires a finite --max-iterations safety bound")
+    if until_ready and (not math.isfinite(interval_hours) or interval_hours < 0):
+        raise ValueError("interval_hours must be finite and non-negative")
     if max_iterations < 0:
         raise ValueError("max_iterations cannot be negative")
 
@@ -477,25 +729,40 @@ def run_controller(
     if not btc_path.is_file() or not eth_path.is_file():
         raise FileNotFoundError(f"both BTC and ETH CSVs are required: {btc_path}, {eth_path}")
 
+    research_config = {
+        "schema_version": SCHEMA_VERSION,
+        "minimum_aligned_bars": minimum_aligned_bars,
+        "order_notionals": [float(value) for value in order_notionals],
+        "research_initial_balance": research_initial_balance,
+        "fees_bps": fees_bps,
+        "slippage_bps": slippage_bps,
+        "stress_fees_bps": stress_fees_bps,
+        "stress_slippage_bps": stress_slippage_bps,
+        "horizon_initial_balance": horizon_initial_balance,
+        "minimum_full_entries": minimum_full_entries,
+        "minimum_fold_entries": minimum_fold_entries,
+        "minimum_confirmation_entries": minimum_confirmation_entries,
+        "max_data_age_days": max_data_age_days,
+        "required_consecutive_passes": required_consecutive_passes,
+    }
+
     state = _read_state(state_path)
     source_fingerprint = _source_fingerprint()
     iterations_this_call = 0
     while True:
         data_fingerprint = _data_fingerprint((btc_path, eth_path))
-        signature = _signature(data_fingerprint, source_fingerprint)
-        last_signature = state.get("last_signature")
-        if not force and last_signature == signature:
-            state.update(
-                {
-                    "schema_version": SCHEMA_VERSION,
-                    "status": "ready" if state.get("strategy_ready") else "waiting_for_new_data",
-                    "last_checked_at": _utc_now(),
-                    "active_profile_changed": False,
-                }
-            )
+        signature = _signature(data_fingerprint, source_fingerprint, research_config)
+        if not force and state.get("last_signature") == signature:
+            state.update({
+                "schema_version": SCHEMA_VERSION,
+                "status": "ready" if state.get("strategy_ready") else "waiting_for_new_data",
+                "last_checked_at": _utc_now(),
+                "active_profile_changed": False,
+            })
             _save_status(state_path, state)
             if not until_ready:
                 return state
+            iterations_this_call += 1
             if max_iterations and iterations_this_call >= max_iterations:
                 return state
             time.sleep(interval_hours * 3600.0)
@@ -517,39 +784,68 @@ def run_controller(
             horizon_initial_balance=horizon_initial_balance,
             minimum_full_entries=minimum_full_entries,
             minimum_fold_entries=minimum_fold_entries,
+            minimum_confirmation_entries=minimum_confirmation_entries,
+            max_data_age_days=max_data_age_days,
+            research_config=research_config,
             data_fingerprint=data_fingerprint,
             source_fingerprint=source_fingerprint,
         )
-        state.update(
-            {
-                "schema_version": SCHEMA_VERSION,
-                "status": result["status"],
-                "strategy_ready": result["strategy_ready"],
-                "iterations_completed": iteration,
-                "last_checked_at": _utc_now(),
-                "last_run": result,
-                "last_signature": signature,
-                "active_profile_changed": False,
-                "paper_orders_placed": False,
-                "leverage_enabled": False,
-            }
-        )
-        _append_history(
-            state,
-            {
-                "iteration": iteration,
-                "finished_at": result["finished_at"],
-                "data_end": result["data_quality"]["end"],
-                "strategy_ready": result["strategy_ready"],
-                "ready_candidates": result["readiness"]["ready_candidates"],
-                "report_paths": result["report_paths"],
-            },
-        )
+        candidate_ready = bool(result["strategy_ready"])
+        ready_candidates = list(result["readiness"]["ready_candidates"])
+        experiment_signature = {"source": dict(source_fingerprint), "config": dict(research_config)}
+        previous_ready_signature = state.get("last_ready_signature")
+        same_data = previous_ready_signature == signature
+        same_experiment = state.get("last_ready_experiment") == experiment_signature
+        same_candidates = state.get("last_ready_candidates") == ready_candidates
+        if candidate_ready:
+            previous_count = int(state.get("consecutive_ready_passes", 0))
+            consecutive_ready_passes = (
+                previous_count + 1
+                if same_experiment and same_candidates and not same_data
+                else 1
+            )
+            state["last_ready_signature"] = signature
+            state["last_ready_experiment"] = experiment_signature
+            state["last_ready_candidates"] = ready_candidates
+        else:
+            consecutive_ready_passes = 0
+            state["last_ready_signature"] = None
+            state["last_ready_experiment"] = None
+            state["last_ready_candidates"] = []
+        strategy_ready = candidate_ready and consecutive_ready_passes >= required_consecutive_passes
+        result["candidate_ready"] = candidate_ready
+        result["strategy_ready"] = strategy_ready
+        result["consecutive_ready_passes"] = consecutive_ready_passes
+        result["required_consecutive_passes"] = required_consecutive_passes
+
+        state.update({
+            "schema_version": SCHEMA_VERSION,
+            "status": "ready" if strategy_ready else "candidate_for_review" if candidate_ready else "researching",
+            "strategy_ready": strategy_ready,
+            "iterations_completed": iteration,
+            "last_checked_at": _utc_now(),
+            "last_run": result,
+            "last_signature": signature,
+            "active_profile_changed": False,
+            "paper_orders_placed": False,
+            "leverage_enabled": False,
+            "consecutive_ready_passes": consecutive_ready_passes,
+        })
+        _append_history(state, {
+            "iteration": iteration,
+            "finished_at": result["finished_at"],
+            "data_end": result["data_quality"]["end"],
+            "data_signature": signature,
+            "candidate_ready": candidate_ready,
+            "strategy_ready": strategy_ready,
+            "consecutive_ready_passes": consecutive_ready_passes,
+            "ready_candidates": result["readiness"]["ready_candidates"],
+            "report_paths": result["report_paths"],
+        })
         _save_status(state_path, state)
         iterations_this_call += 1
         force = False
-
-        if result["strategy_ready"] or not until_ready:
+        if strategy_ready or not until_ready:
             return state
         if max_iterations and iterations_this_call >= max_iterations:
             return state
@@ -571,10 +867,18 @@ def main() -> int:
     parser.add_argument("--horizon-initial-balance", type=float, default=5_000.0)
     parser.add_argument("--min-full-entries", type=int, default=DEFAULT_MIN_FULL_ENTRIES)
     parser.add_argument("--min-fold-entries", type=int, default=DEFAULT_MIN_FOLD_ENTRIES)
+    parser.add_argument("--min-confirmation-entries", type=int, default=DEFAULT_MIN_CONFIRMATION_ENTRIES)
+    parser.add_argument("--max-data-age-days", type=float, default=DEFAULT_MAX_DATA_AGE_DAYS)
+    parser.add_argument(
+        "--required-consecutive-passes",
+        type=int,
+        default=3,
+        help="distinct data vintages required before strategy_ready becomes true",
+    )
     parser.add_argument(
         "--until-ready",
         action="store_true",
-        help="continue polling until a candidate passes the controller gate",
+        help="continue polling until the same candidate passes the required data vintages",
     )
     parser.add_argument(
         "--interval-hours",
@@ -608,6 +912,9 @@ def main() -> int:
         horizon_initial_balance=args.horizon_initial_balance,
         minimum_full_entries=args.min_full_entries,
         minimum_fold_entries=args.min_fold_entries,
+        minimum_confirmation_entries=args.min_confirmation_entries,
+        max_data_age_days=args.max_data_age_days,
+        required_consecutive_passes=args.required_consecutive_passes,
         until_ready=args.until_ready,
         interval_hours=args.interval_hours,
         max_iterations=args.max_iterations,

--- a/scripts/run_v3_research_controller.py
+++ b/scripts/run_v3_research_controller.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+"""Keep the v3 historical research loop running until it is ready.
+
+This controller is deliberately research-only.  It runs the existing causal
+v3 backtest at the two requested order sizes, persists a small state file, and
+returns to a waiting state when the data and code have not changed.  It never
+changes an active portfolio, stages a candidate, enables leverage, contacts a
+broker, or places an order.
+
+For a long-running local process use ``--until-ready``.  For a scheduler such
+as GitHub Actions, invoke the controller once per scheduled run; a new data
+fingerprint causes a fresh research iteration.  ``--force`` is available for
+deliberate reruns against unchanged inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+try:  # Works as ``python scripts/...`` and when imported by pytest.
+    from scripts.run_momentum_volatility_research import Bar, load_bars
+    from scripts.run_momentum_volatility_v3 import align_pair, research
+except ModuleNotFoundError:  # pragma: no cover - direct import fallback
+    from run_momentum_volatility_research import Bar, load_bars
+    from run_momentum_volatility_v3 import align_pair, research
+
+
+SCHEMA_VERSION = 1
+DEFAULT_BTC_PATH = Path("data/historical/binance/normalized/BTCUSDT_1h.csv")
+DEFAULT_ETH_PATH = Path("data/historical/binance/normalized/ETHUSDT_1h.csv")
+DEFAULT_OUTPUT_DIR = Path("artifacts/momentum-v3/research-controller")
+DEFAULT_MIN_ALIGNED_BARS = 3 * 365 * 24
+DEFAULT_ORDER_NOTIONALS = (4_000.0, 6_000.0)
+DEFAULT_MIN_FULL_ENTRIES = 8
+DEFAULT_MIN_FOLD_ENTRIES = 5
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Write JSON without leaving a half-written state file behind."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    temporary.replace(path)
+
+
+def _read_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "researching",
+            "strategy_ready": False,
+            "iterations_completed": 0,
+            "history": [],
+        }
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"research state must be a JSON object: {path}")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported research state schema: {payload.get('schema_version')!r}"
+        )
+    payload.setdefault("history", [])
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_fingerprint() -> dict[str, str]:
+    """Invalidate a cached iteration when the research implementation changes."""
+
+    files = (
+        Path(__file__),
+        Path(__file__).with_name("run_momentum_volatility_v3.py"),
+        Path(__file__).with_name("run_momentum_volatility_research.py"),
+    )
+    return {str(path): _sha256(path) for path in files}
+
+
+def _data_fingerprint(paths: Sequence[Path]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for path in paths:
+        stat = path.stat()
+        result[str(path)] = {
+            "sha256": _sha256(path),
+            "bytes": stat.st_size,
+        }
+    return result
+
+
+def _gap_details(bars: Sequence[Bar]) -> list[dict[str, Any]]:
+    details: list[dict[str, Any]] = []
+    for previous, current in zip(bars, bars[1:]):
+        hours = (current.timestamp - previous.timestamp).total_seconds() / 3600.0
+        if hours > 1.5:
+            details.append(
+                {
+                    "from": previous.timestamp.isoformat(),
+                    "to": current.timestamp.isoformat(),
+                    "hours": hours,
+                }
+            )
+    return details
+
+
+def validate_data(
+    btc_path: Path,
+    eth_path: Path,
+    *,
+    minimum_aligned_bars: int = DEFAULT_MIN_ALIGNED_BARS,
+) -> tuple[list[Any], dict[str, Any]]:
+    """Load both markets and fail closed on short or unsafe research data.
+
+    A synchronized exchange-wide outage can be retained without inventing
+    candles.  Asymmetric or very large gaps are rejected because they can
+    change the leader and volatility calculations differently by asset.
+    """
+
+    btc = load_bars(btc_path)
+    eth = load_bars(eth_path)
+    pair = align_pair(btc, eth)
+    if len(pair) < minimum_aligned_bars:
+        raise ValueError(
+            f"aligned data has {len(pair)} bars; at least {minimum_aligned_bars} are required"
+        )
+    btc_gaps = _gap_details(btc)
+    eth_gaps = _gap_details(eth)
+    if [(item["from"], item["to"]) for item in btc_gaps] != [
+        (item["from"], item["to"]) for item in eth_gaps
+    ]:
+        raise ValueError(
+            "historical data contains unsynchronized gaps; refusing to compare "
+            f"BTC={btc_gaps} with ETH={eth_gaps}"
+        )
+    largest_gap = max(
+        (float(item["hours"]) for item in (*btc_gaps, *eth_gaps)),
+        default=0.0,
+    )
+    if largest_gap > 6.0:
+        raise ValueError(
+            f"historical data contains a synchronized gap of {largest_gap:.2f} hours; "
+            "gaps over six hours require a separately reviewed dataset"
+        )
+    return pair, {
+        "btc_bars": len(btc),
+        "eth_bars": len(eth),
+        "aligned_bars": len(pair),
+        "start": pair[0].timestamp.isoformat(),
+        "end": pair[-1].timestamp.isoformat(),
+        "btc_gaps_over_1_5_hours": btc_gaps,
+        "eth_gaps_over_1_5_hours": eth_gaps,
+        "synchronized_gap_warning": bool(btc_gaps),
+        "largest_gap_hours": largest_gap,
+    }
+
+
+def _number(payload: Mapping[str, Any], key: str) -> float:
+    value = payload.get(key)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _integer(payload: Mapping[str, Any], key: str) -> int:
+    value = payload.get(key)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return -1
+
+
+def evaluate_candidate(
+    candidate_name: str,
+    candidate: Mapping[str, Any],
+    *,
+    minimum_full_entries: int = DEFAULT_MIN_FULL_ENTRIES,
+    minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
+) -> dict[str, Any]:
+    """Apply the stricter controller gate to one v3 candidate report.
+
+    The v3 runner's gate is necessary but intentionally broad.  The
+    controller additionally requires enough entries in every chronological
+    walk-forward fold and a positive full-sample result.  A one-day snapshot
+    is reported as evidence, not treated as proof of robustness.
+    """
+
+    reasons: list[str] = []
+    gate = candidate.get("promotion_gate")
+    if not isinstance(gate, Mapping):
+        reasons.append("missing v3 promotion gate")
+    elif not bool(gate.get("pass")):
+        gate_reasons = gate.get("failure_reasons")
+        if isinstance(gate_reasons, list) and gate_reasons:
+            reasons.extend(str(item) for item in gate_reasons)
+        else:
+            reasons.append("v3 promotion gate did not pass")
+
+    full = candidate.get("full_sample")
+    if not isinstance(full, Mapping):
+        reasons.append("missing full-sample result")
+        full = {}
+    if _integer(full, "entries") < minimum_full_entries:
+        reasons.append(f"fewer than {minimum_full_entries} full-sample entries")
+    if _number(full, "return_pct") <= 0:
+        reasons.append("full-sample return is not positive")
+    if bool(full.get("permanent_halt")):
+        reasons.append("full sample hit a permanent halt")
+    if _integer(full, "kill_events") > 1:
+        reasons.append("full sample has repeated kill-switch events")
+
+    fold_checks: dict[str, list[dict[str, Any]]] = {}
+    for label in ("walk_forward", "stress_walk_forward"):
+        raw_folds = candidate.get(label)
+        if not isinstance(raw_folds, Sequence) or isinstance(raw_folds, (str, bytes)):
+            reasons.append(f"missing {label} results")
+            fold_checks[label] = []
+            continue
+        checks: list[dict[str, Any]] = []
+        for index, raw_fold in enumerate(raw_folds, start=1):
+            fold = raw_fold if isinstance(raw_fold, Mapping) else {}
+            entries = _integer(fold, "entries")
+            fold_reasons: list[str] = []
+            if entries < minimum_fold_entries:
+                fold_reasons.append(
+                    f"fold {index} has {entries} entries; {minimum_fold_entries} required"
+                )
+            if bool(fold.get("permanent_halt")):
+                fold_reasons.append(f"fold {index} hit a permanent halt")
+            if _integer(fold, "kill_events") > 1:
+                fold_reasons.append(f"fold {index} has repeated kill-switch events")
+            reasons.extend(f"{label}: {item}" for item in fold_reasons)
+            checks.append(
+                {
+                    "fold": index,
+                    "entries": entries,
+                    "return_pct": _number(fold, "return_pct"),
+                    "pass": not fold_reasons,
+                    "failure_reasons": fold_reasons,
+                }
+            )
+        fold_checks[label] = checks
+
+    horizons = candidate.get("horizons")
+    horizon_observations: dict[str, Any] = {}
+    if isinstance(horizons, Mapping):
+        for label in ("1d", "1w", "1m", "1y"):
+            value = horizons.get(label)
+            if isinstance(value, Mapping):
+                horizon_observations[label] = {
+                    "return_pct": _number(value, "return_pct"),
+                    "entries": _integer(value, "entries"),
+                    "pnl": _number(value, "pnl"),
+                }
+
+    return {
+        "candidate": candidate_name,
+        "pass": not reasons,
+        "failure_reasons": reasons,
+        "fold_checks": fold_checks,
+        "horizon_observations": horizon_observations,
+        "rules": {
+            "minimum_full_sample_entries": minimum_full_entries,
+            "minimum_entries_per_walk_forward_fold": minimum_fold_entries,
+            "positive_full_sample_return": True,
+            "positive_base_and_stress_walk_forward_medians": True,
+            "one_day_snapshot_is_not_sufficient_proof": True,
+        },
+    }
+
+
+def evaluate_readiness(
+    reports: Mapping[str, Mapping[str, Any]],
+    *,
+    minimum_full_entries: int = DEFAULT_MIN_FULL_ENTRIES,
+    minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
+) -> dict[str, Any]:
+    """Require the same candidate to pass at both $4k and $6k sizing."""
+
+    checks_by_size: dict[str, dict[str, Any]] = {}
+    candidate_sets: list[set[str]] = []
+    for size, report in reports.items():
+        raw_candidates = report.get("candidates", {})
+        if not isinstance(raw_candidates, Mapping):
+            raw_candidates = {}
+        checks = {
+            str(name): evaluate_candidate(
+                str(name),
+                candidate,
+                minimum_full_entries=minimum_full_entries,
+                minimum_fold_entries=minimum_fold_entries,
+            )
+            for name, candidate in raw_candidates.items()
+            if isinstance(candidate, Mapping)
+        }
+        checks_by_size[str(size)] = checks
+        candidate_sets.append(set(checks))
+
+    common_candidates = sorted(set.intersection(*candidate_sets)) if candidate_sets else []
+    ready_candidates = [
+        name
+        for name in common_candidates
+        if all(bool(checks_by_size[size][name]["pass"]) for size in checks_by_size)
+    ]
+    return {
+        "pass": bool(ready_candidates),
+        "strategy_ready": bool(ready_candidates),
+        "ready_candidates": ready_candidates,
+        "required_sizes": sorted(checks_by_size),
+        "common_candidates": common_candidates,
+        "checks_by_size": checks_by_size,
+        "rules": {
+            "same_candidate_must_pass_all_required_sizes": True,
+            "required_order_notionals": [4_000.0, 6_000.0],
+            "leverage_allowed": False,
+            "paper_promotion_is_not_automatic": True,
+        },
+    }
+
+
+def _signature(data: Mapping[str, Any], source: Mapping[str, str]) -> dict[str, Any]:
+    return {"data": dict(data), "source": dict(source)}
+
+
+def _save_status(state_path: Path, state: Mapping[str, Any]) -> None:
+    _atomic_write_json(state_path, state)
+    _atomic_write_json(state_path.with_name("latest.json"), state)
+
+
+def _run_iteration(
+    *,
+    iteration: int,
+    btc_path: Path,
+    eth_path: Path,
+    output_dir: Path,
+    minimum_aligned_bars: int,
+    order_notionals: Sequence[float],
+    research_initial_balance: float,
+    fees_bps: float,
+    slippage_bps: float,
+    stress_fees_bps: float,
+    stress_slippage_bps: float,
+    horizon_initial_balance: float,
+    minimum_full_entries: int,
+    minimum_fold_entries: int,
+    data_fingerprint: Mapping[str, Any],
+    source_fingerprint: Mapping[str, str],
+) -> dict[str, Any]:
+    started_at = _utc_now()
+    pair, quality = validate_data(
+        btc_path,
+        eth_path,
+        minimum_aligned_bars=minimum_aligned_bars,
+    )
+    del pair  # validation above deliberately reloads inside the v3 runner.
+
+    iteration_dir = output_dir / f"iteration-{iteration:04d}"
+    reports: dict[str, Mapping[str, Any]] = {}
+    report_paths: dict[str, str] = {}
+    for order_notional in order_notionals:
+        size_key = str(int(order_notional))
+        report = research(
+            btc_path,
+            eth_path,
+            initial_balance=research_initial_balance,
+            order_notional=order_notional,
+            fees_bps=fees_bps,
+            slippage_bps=slippage_bps,
+            stress_fees_bps=stress_fees_bps,
+            stress_slippage_bps=stress_slippage_bps,
+            horizon_initial_balance=horizon_initial_balance,
+            horizon_order_notional=order_notional,
+        )
+        report["controller"] = {
+            "schema_version": SCHEMA_VERSION,
+            "iteration": iteration,
+            "research_only": True,
+            "active_profile_changed": False,
+            "data_quality": quality,
+            "data_fingerprint": dict(data_fingerprint),
+            "source_fingerprint": dict(source_fingerprint),
+        }
+        reports[size_key] = report
+        report_path = iteration_dir / f"report-{size_key}.json"
+        _atomic_write_json(report_path, report)
+        report_paths[size_key] = str(report_path)
+
+    readiness = evaluate_readiness(
+        reports,
+        minimum_full_entries=minimum_full_entries,
+        minimum_fold_entries=minimum_fold_entries,
+    )
+    finished_at = _utc_now()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ready" if readiness["strategy_ready"] else "researching",
+        "strategy_ready": bool(readiness["strategy_ready"]),
+        "iteration": iteration,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "data_quality": quality,
+        "data_fingerprint": dict(data_fingerprint),
+        "source_fingerprint": dict(source_fingerprint),
+        "readiness": readiness,
+        "report_paths": report_paths,
+        "active_profile_changed": False,
+        "paper_orders_placed": False,
+        "leverage_enabled": False,
+    }
+
+
+def _append_history(state: dict[str, Any], entry: Mapping[str, Any]) -> None:
+    history = state.setdefault("history", [])
+    if not isinstance(history, list):
+        history = []
+        state["history"] = history
+    history.append(dict(entry))
+    del history[:-100]
+
+
+def run_controller(
+    *,
+    btc_path: Path = DEFAULT_BTC_PATH,
+    eth_path: Path = DEFAULT_ETH_PATH,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    state_path: Path | None = None,
+    minimum_aligned_bars: int = DEFAULT_MIN_ALIGNED_BARS,
+    order_notionals: Sequence[float] = DEFAULT_ORDER_NOTIONALS,
+    research_initial_balance: float = 75_000.0,
+    fees_bps: float = 10.0,
+    slippage_bps: float = 5.0,
+    stress_fees_bps: float = 20.0,
+    stress_slippage_bps: float = 10.0,
+    horizon_initial_balance: float = 5_000.0,
+    minimum_full_entries: int = DEFAULT_MIN_FULL_ENTRIES,
+    minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
+    until_ready: bool = False,
+    interval_hours: float = 24.0,
+    max_iterations: int = 0,
+    force: bool = False,
+) -> dict[str, Any]:
+    if len(order_notionals) != 2 or set(order_notionals) != set(DEFAULT_ORDER_NOTIONALS):
+        raise ValueError("the controller requires exactly $4,000 and $6,000 order notionals")
+    if any(value <= 0 for value in order_notionals):
+        raise ValueError("order notionals must be positive")
+    if minimum_aligned_bars < 1 or minimum_full_entries < 1 or minimum_fold_entries < 1:
+        raise ValueError("research minimums must be positive")
+    if until_ready and interval_hours < 0:
+        raise ValueError("interval_hours cannot be negative")
+    if until_ready and interval_hours == 0 and max_iterations == 0:
+        raise ValueError(
+            "an unlimited --until-ready loop needs a positive interval_hours"
+        )
+    if max_iterations < 0:
+        raise ValueError("max_iterations cannot be negative")
+
+    btc_path = btc_path.resolve()
+    eth_path = eth_path.resolve()
+    output_dir = output_dir.resolve()
+    state_path = (state_path or output_dir / "state.json").resolve()
+    if not btc_path.is_file() or not eth_path.is_file():
+        raise FileNotFoundError(f"both BTC and ETH CSVs are required: {btc_path}, {eth_path}")
+
+    state = _read_state(state_path)
+    source_fingerprint = _source_fingerprint()
+    iterations_this_call = 0
+    while True:
+        data_fingerprint = _data_fingerprint((btc_path, eth_path))
+        signature = _signature(data_fingerprint, source_fingerprint)
+        last_signature = state.get("last_signature")
+        if not force and last_signature == signature:
+            state.update(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "ready" if state.get("strategy_ready") else "waiting_for_new_data",
+                    "last_checked_at": _utc_now(),
+                    "active_profile_changed": False,
+                }
+            )
+            _save_status(state_path, state)
+            if not until_ready:
+                return state
+            if max_iterations and iterations_this_call >= max_iterations:
+                return state
+            time.sleep(interval_hours * 3600.0)
+            continue
+
+        iteration = int(state.get("iterations_completed", 0)) + 1
+        result = _run_iteration(
+            iteration=iteration,
+            btc_path=btc_path,
+            eth_path=eth_path,
+            output_dir=output_dir,
+            minimum_aligned_bars=minimum_aligned_bars,
+            order_notionals=order_notionals,
+            research_initial_balance=research_initial_balance,
+            fees_bps=fees_bps,
+            slippage_bps=slippage_bps,
+            stress_fees_bps=stress_fees_bps,
+            stress_slippage_bps=stress_slippage_bps,
+            horizon_initial_balance=horizon_initial_balance,
+            minimum_full_entries=minimum_full_entries,
+            minimum_fold_entries=minimum_fold_entries,
+            data_fingerprint=data_fingerprint,
+            source_fingerprint=source_fingerprint,
+        )
+        state.update(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "status": result["status"],
+                "strategy_ready": result["strategy_ready"],
+                "iterations_completed": iteration,
+                "last_checked_at": _utc_now(),
+                "last_run": result,
+                "last_signature": signature,
+                "active_profile_changed": False,
+                "paper_orders_placed": False,
+                "leverage_enabled": False,
+            }
+        )
+        _append_history(
+            state,
+            {
+                "iteration": iteration,
+                "finished_at": result["finished_at"],
+                "data_end": result["data_quality"]["end"],
+                "strategy_ready": result["strategy_ready"],
+                "ready_candidates": result["readiness"]["ready_candidates"],
+                "report_paths": result["report_paths"],
+            },
+        )
+        _save_status(state_path, state)
+        iterations_this_call += 1
+        force = False
+
+        if result["strategy_ready"] or not until_ready:
+            return state
+        if max_iterations and iterations_this_call >= max_iterations:
+            return state
+        time.sleep(interval_hours * 3600.0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, default=DEFAULT_BTC_PATH)
+    parser.add_argument("--eth-path", type=Path, default=DEFAULT_ETH_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--state", type=Path, help="state JSON; defaults to <output-dir>/state.json")
+    parser.add_argument("--min-aligned-bars", type=int, default=DEFAULT_MIN_ALIGNED_BARS)
+    parser.add_argument("--research-initial-balance", type=float, default=75_000.0)
+    parser.add_argument("--fees-bps", type=float, default=10.0)
+    parser.add_argument("--slippage-bps", type=float, default=5.0)
+    parser.add_argument("--stress-fees-bps", type=float, default=20.0)
+    parser.add_argument("--stress-slippage-bps", type=float, default=10.0)
+    parser.add_argument("--horizon-initial-balance", type=float, default=5_000.0)
+    parser.add_argument("--min-full-entries", type=int, default=DEFAULT_MIN_FULL_ENTRIES)
+    parser.add_argument("--min-fold-entries", type=int, default=DEFAULT_MIN_FOLD_ENTRIES)
+    parser.add_argument(
+        "--until-ready",
+        action="store_true",
+        help="continue polling until a candidate passes the controller gate",
+    )
+    parser.add_argument(
+        "--interval-hours",
+        type=float,
+        default=24.0,
+        help="sleep between checks while --until-ready is active",
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=0,
+        help="optional safety bound for one invocation; 0 means no bound",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="rerun even when the data and research code are unchanged",
+    )
+    args = parser.parse_args()
+    state = run_controller(
+        btc_path=args.btc_path,
+        eth_path=args.eth_path,
+        output_dir=args.output_dir,
+        state_path=args.state,
+        minimum_aligned_bars=args.min_aligned_bars,
+        research_initial_balance=args.research_initial_balance,
+        fees_bps=args.fees_bps,
+        slippage_bps=args.slippage_bps,
+        stress_fees_bps=args.stress_fees_bps,
+        stress_slippage_bps=args.stress_slippage_bps,
+        horizon_initial_balance=args.horizon_initial_balance,
+        minimum_full_entries=args.min_full_entries,
+        minimum_fold_entries=args.min_fold_entries,
+        until_ready=args.until_ready,
+        interval_hours=args.interval_hours,
+        max_iterations=args.max_iterations,
+        force=args.force,
+    )
+    print(
+        json.dumps(
+            {
+                "status": state.get("status"),
+                "strategy_ready": state.get("strategy_ready", False),
+                "iterations_completed": state.get("iterations_completed", 0),
+                "ready_candidates": state.get("last_run", {})
+                .get("readiness", {})
+                .get("ready_candidates", []),
+                "latest_state": str((args.state or args.output_dir / "state.json").resolve()),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_v3_research_controller.py
+++ b/scripts/run_v3_research_controller.py
@@ -152,6 +152,7 @@ def _source_fingerprint() -> dict[str, str]:
         Path(__file__),
         Path(__file__).with_name("run_momentum_volatility_v3.py"),
         Path(__file__).with_name("run_momentum_volatility_research.py"),
+        Path(__file__).with_name("momentum_context.py"),
         Path(__file__).with_name("fetch_binance_vision_klines.py"),
         Path(__file__).parents[1] / ".github" / "workflows" / "momentum-v3-research.yml",
     ]
@@ -580,6 +581,7 @@ def _run_iteration(
     stress_fees_bps: float,
     stress_slippage_bps: float,
     horizon_initial_balance: float,
+    context_path: Path | None,
     minimum_full_entries: int,
     minimum_fold_entries: int,
     minimum_confirmation_entries: int,
@@ -613,6 +615,7 @@ def _run_iteration(
             stress_slippage_bps=stress_slippage_bps,
             horizon_initial_balance=horizon_initial_balance,
             horizon_order_notional=order_notional,
+            context_path=context_path,
         )
         report["controller"] = {
             "schema_version": SCHEMA_VERSION,
@@ -677,6 +680,7 @@ def run_controller(
     stress_fees_bps: float = 20.0,
     stress_slippage_bps: float = 10.0,
     horizon_initial_balance: float = 5_000.0,
+    context_path: Path | None = None,
     minimum_full_entries: int = DEFAULT_MIN_FULL_ENTRIES,
     minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
     minimum_confirmation_entries: int = DEFAULT_MIN_CONFIRMATION_ENTRIES,
@@ -724,10 +728,13 @@ def run_controller(
 
     btc_path = btc_path.resolve()
     eth_path = eth_path.resolve()
+    context_path = context_path.resolve() if context_path else None
     output_dir = output_dir.resolve()
     state_path = (state_path or output_dir / "state.json").resolve()
     if not btc_path.is_file() or not eth_path.is_file():
         raise FileNotFoundError(f"both BTC and ETH CSVs are required: {btc_path}, {eth_path}")
+    if context_path is not None and not context_path.is_file():
+        raise FileNotFoundError(f"context CSV does not exist: {context_path}")
 
     research_config = {
         "schema_version": SCHEMA_VERSION,
@@ -739,6 +746,7 @@ def run_controller(
         "stress_fees_bps": stress_fees_bps,
         "stress_slippage_bps": stress_slippage_bps,
         "horizon_initial_balance": horizon_initial_balance,
+        "context_path": str(context_path) if context_path else None,
         "minimum_full_entries": minimum_full_entries,
         "minimum_fold_entries": minimum_fold_entries,
         "minimum_confirmation_entries": minimum_confirmation_entries,
@@ -750,7 +758,8 @@ def run_controller(
     source_fingerprint = _source_fingerprint()
     iterations_this_call = 0
     while True:
-        data_fingerprint = _data_fingerprint((btc_path, eth_path))
+        data_paths = (btc_path, eth_path) + ((context_path,) if context_path else ())
+        data_fingerprint = _data_fingerprint(data_paths)
         signature = _signature(data_fingerprint, source_fingerprint, research_config)
         if not force and state.get("last_signature") == signature:
             state.update({
@@ -782,6 +791,7 @@ def run_controller(
             stress_fees_bps=stress_fees_bps,
             stress_slippage_bps=stress_slippage_bps,
             horizon_initial_balance=horizon_initial_balance,
+            context_path=context_path,
             minimum_full_entries=minimum_full_entries,
             minimum_fold_entries=minimum_fold_entries,
             minimum_confirmation_entries=minimum_confirmation_entries,
@@ -865,6 +875,7 @@ def main() -> int:
     parser.add_argument("--stress-fees-bps", type=float, default=20.0)
     parser.add_argument("--stress-slippage-bps", type=float, default=10.0)
     parser.add_argument("--horizon-initial-balance", type=float, default=5_000.0)
+    parser.add_argument("--context-csv", type=Path, help="optional timestamp,sentiment,impact CSV")
     parser.add_argument("--min-full-entries", type=int, default=DEFAULT_MIN_FULL_ENTRIES)
     parser.add_argument("--min-fold-entries", type=int, default=DEFAULT_MIN_FOLD_ENTRIES)
     parser.add_argument("--min-confirmation-entries", type=int, default=DEFAULT_MIN_CONFIRMATION_ENTRIES)
@@ -910,6 +921,7 @@ def main() -> int:
         stress_fees_bps=args.stress_fees_bps,
         stress_slippage_bps=args.stress_slippage_bps,
         horizon_initial_balance=args.horizon_initial_balance,
+        context_path=args.context_csv,
         minimum_full_entries=args.min_full_entries,
         minimum_fold_entries=args.min_fold_entries,
         minimum_confirmation_entries=args.min_confirmation_entries,

--- a/tests/test_execution_model.py
+++ b/tests/test_execution_model.py
@@ -16,3 +16,8 @@ def test_cost_model_rejects_negative_inputs() -> None:
         ExecutionCostModel(slippage_bps=-1)
     with pytest.raises(ValueError):
         ExecutionCostModel().net_return(0.1, -1)
+
+
+def test_cost_model_rejects_non_finite_inputs() -> None:
+    with pytest.raises(ValueError):
+        ExecutionCostModel(slippage_bps=float("nan"))

--- a/tests/test_momentum_context.py
+++ b/tests/test_momentum_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -13,7 +13,7 @@ from scripts.momentum_context import (
 
 
 def _ts(hour: int) -> datetime:
-    return datetime(2026, 1, 1, hour, tzinfo=timezone.utc)
+    return datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(hours=hour)
 
 
 def test_context_is_strictly_as_of_and_does_not_use_future_events() -> None:

--- a/tests/test_momentum_context.py
+++ b/tests/test_momentum_context.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.momentum_context import (
+    ContextEvent,
+    align_context,
+    build_context_features,
+)
+
+
+def _ts(hour: int) -> datetime:
+    return datetime(2026, 1, 1, hour, tzinfo=timezone.utc)
+
+
+def test_context_is_strictly_as_of_and_does_not_use_future_events() -> None:
+    events = [
+        ContextEvent(timestamp=_ts(2), sentiment=1.0, impact=0.9),
+    ]
+    result = align_context([_ts(1), _ts(2), _ts(3)], events)
+    assert result["context_sentiment"][0] == 0.0
+    assert result["context_risk_event"][0] == 0.0
+    assert result["context_sentiment"][1] == pytest.approx(1.0)
+    assert result["context_risk_event"][2] == 1.0
+
+
+def test_context_lookback_expires_old_events() -> None:
+    events = [
+        ContextEvent(timestamp=_ts(0), sentiment=-1.0, impact=0.8),
+    ]
+    result = align_context([_ts(0), _ts(25)], events)
+    assert result["context_sentiment"][0] == pytest.approx(-1.0)
+    assert result["context_event_count"][1] == 0.0
+
+
+def test_volume_ratio_uses_prior_bars_only() -> None:
+    bars = [
+        SimpleNamespace(timestamp=_ts(index), volume=100.0)
+        for index in range(20)
+    ]
+    bars.append(SimpleNamespace(timestamp=_ts(20), volume=200.0))
+    result = build_context_features(bars)
+    assert result["volume_ratio"][19] != result["volume_ratio"][20]
+    assert result["volume_ratio"][20] == pytest.approx(2.0)
+
+
+def test_invalid_event_sentiment_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        ContextEvent(timestamp=_ts(0), sentiment=1.1, impact=0.2)

--- a/tests/test_momentum_context.py
+++ b/tests/test_momentum_context.py
@@ -50,3 +50,8 @@ def test_volume_ratio_uses_prior_bars_only() -> None:
 def test_invalid_event_sentiment_is_rejected() -> None:
     with pytest.raises(ValueError):
         ContextEvent(timestamp=_ts(0), sentiment=1.1, impact=0.2)
+
+
+def test_non_finite_context_values_are_rejected() -> None:
+    with pytest.raises(ValueError):
+        ContextEvent(timestamp=_ts(0), sentiment=0.0, impact=float("nan"))

--- a/tests/test_paper_lab.py
+++ b/tests/test_paper_lab.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import random
+
+import pandas as pd
+import pytest
+
+from tradingbot_ibkr.paper_lab import (
+    ExecutionAssumptions,
+    StrategyProfile,
+    _entry_fill,
+)
+from tradingbot_ibkr.paper_lab_automation import _random_profile
+
+
+def test_entry_cost_excludes_fixed_commission_from_unit_cost() -> None:
+    frame = pd.DataFrame(
+        [
+            {"timestamp": "2025-01-01T00:00:00Z", "open": 100.0, "high": 101.0, "low": 99.0, "close": 100.0, "volume": 10.0},
+            {"timestamp": "2025-01-01T01:00:00Z", "open": 110.0, "high": 111.0, "low": 109.0, "close": 110.0, "volume": 10.0},
+        ]
+    )
+    profile = StrategyProfile(
+        account_id="test",
+        strategy="ema_momentum",
+        execution_policy="next_open_market",
+        params={"fast": 5.0, "slow": 15.0},
+    )
+    assumptions = ExecutionAssumptions(
+        spread_bps=12.0,
+        slippage_bps=8.0,
+        commission_per_order=10.0,
+    )
+    fill = _entry_fill(frame, 1, profile, 1.0, assumptions)
+    assert fill is not None
+    entry_price, unit_cost = fill
+    expected_price = 110.0 * (1.0 + 14.0 / 10_000.0)
+    assert entry_price == pytest.approx(expected_price)
+    assert unit_cost == pytest.approx(expected_price - 110.0)
+
+
+def test_seeded_profile_generation_is_reproducible() -> None:
+    first = _random_profile(random.Random(7), 1, 2)
+    second = _random_profile(random.Random(7), 1, 2)
+    assert first == second

--- a/tests/test_research_context.py
+++ b/tests/test_research_context.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from tradingbot_ibkr.research_context import (
     NewsEvent,
     TradeOutcome,
@@ -41,3 +43,18 @@ def test_trade_gate_rejects_insufficient_edge_and_high_impact_news() -> None:
     assert low_edge.reason == "edge_does_not_cover_costs"
     high_edge = evaluate_trade_gate(1, expected_move_bps=50, expected_cost_bps=10, news=news, memory=None)
     assert high_edge.reason == "high_impact_news_requires_confirmation"
+
+
+def test_context_rejects_non_finite_values_and_mismatched_series() -> None:
+    with pytest.raises(ValueError):
+        NewsEvent(datetime(2025, 1, 1, tzinfo=timezone.utc), 0.0, float("nan"))
+    with pytest.raises(ValueError):
+        from tradingbot_ibkr.research_context import gate_signal_series
+
+        gate_signal_series(
+            [1, 0],
+            [datetime(2025, 1, 1, tzinfo=timezone.utc)],
+            [],
+            expected_move_bps=40,
+            expected_cost_bps=10,
+        )

--- a/tests/test_strategy_candidates.py
+++ b/tests/test_strategy_candidates.py
@@ -22,6 +22,13 @@ def _research() -> CandidateEvidence:
         profit_factor=1.45,
         trade_count=42,
         score=0.22,
+        execution_cost_bps=28.0,
+        costs_included=True,
+        holdout_passed=True,
+        holdout_trade_count=42,
+        holdout_total_return=0.11,
+        holdout_max_drawdown=0.09,
+        holdout_profit_factor=1.30,
     )
 
 

--- a/tests/test_v3_research_controller.py
+++ b/tests/test_v3_research_controller.py
@@ -133,7 +133,7 @@ def test_validate_data_allows_only_synchronized_bounded_gaps(tmp_path) -> None:
         for index, timestamp in enumerate(values):
             price = 100.0 + index
             rows.append(f"{timestamp},{price},{price + 1},{price - 1},{price},1000")
-        path.write_text("\\n".join(rows) + "\\n", encoding="utf-8")
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
 
     write_bars(btc, timestamps)
     write_bars(eth, timestamps)
@@ -161,7 +161,7 @@ def test_validate_data_rejects_mismatched_timestamp_coverage(tmp_path) -> None:
         for index, timestamp in enumerate(values):
             price = 100.0 + index
             rows.append(f"{timestamp},{price},{price + 1},{price - 1},{price},1000")
-        path.write_text("\\n".join(rows) + "\\n", encoding="utf-8")
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
 
     write_bars(btc, timestamps)
     write_bars(eth, [*timestamps, "2023-01-01T05:00:00Z"])

--- a/tests/test_v3_research_controller.py
+++ b/tests/test_v3_research_controller.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.run_v3_research_controller import (
+    evaluate_candidate,
+    evaluate_readiness,
+    validate_data,
+)
+
+
+def _result(*, entries: int = 6, return_pct: float = 1.0) -> dict[str, object]:
+    return {
+        "entries": entries,
+        "return_pct": return_pct,
+        "pnl": return_pct,
+        "kill_events": 0,
+        "permanent_halt": False,
+    }
+
+
+def _candidate(*, fold_entries: int = 6, full_return: float = 2.0) -> dict[str, object]:
+    folds = [_result(entries=fold_entries, return_pct=value) for value in (-1.0, 2.0, 1.0)]
+    stress = [_result(entries=fold_entries, return_pct=value) for value in (-0.5, 1.0, 0.5)]
+    return {
+        "promotion_gate": {"pass": True, "failure_reasons": []},
+        "full_sample": _result(entries=12, return_pct=full_return),
+        "walk_forward": folds,
+        "stress_walk_forward": stress,
+        "horizons": {
+            label: _result(entries=1, return_pct=0.25)
+            for label in ("1d", "1w", "1m", "1y")
+        },
+    }
+
+
+def test_controller_requires_minimum_entries_in_every_fold() -> None:
+    candidate = _candidate(fold_entries=4)
+    result = evaluate_candidate("balanced", candidate)
+    assert result["pass"] is False
+    assert any("entries" in reason for reason in result["failure_reasons"])
+
+
+def test_controller_requires_positive_full_sample_return() -> None:
+    candidate = _candidate(full_return=0.0)
+    result = evaluate_candidate("balanced", candidate)
+    assert result["pass"] is False
+    assert "full-sample return is not positive" in result["failure_reasons"]
+
+
+def test_readiness_requires_same_candidate_at_both_sizes() -> None:
+    candidate = _candidate()
+    reports = {
+        "4000": {"candidates": {"balanced": candidate}},
+        "6000": {"candidates": {"balanced": candidate}},
+    }
+    result = evaluate_readiness(reports)
+    assert result["strategy_ready"] is True
+    assert result["ready_candidates"] == ["balanced"]
+
+
+def test_readiness_rejects_candidate_that_passes_only_one_size() -> None:
+    candidate = _candidate()
+    reports = {
+        "4000": {"candidates": {"balanced": candidate}},
+        "6000": {"candidates": {"balanced": _candidate(full_return=-1.0)}},
+    }
+    result = evaluate_readiness(reports)
+    assert result["strategy_ready"] is False
+    assert result["ready_candidates"] == []
+
+
+def _write_bars(path, timestamps: list[str]) -> None:
+    rows = ["timestamp,open,high,low,close,volume"]
+    for index, timestamp in enumerate(timestamps):
+        price = 100.0 + index
+        rows.append(f"{timestamp},{price},{price + 1},{price - 1},{price},1000")
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def test_validate_data_allows_only_synchronized_bounded_gaps(tmp_path) -> None:
+    timestamps = [
+        "2023-01-01T00:00:00Z",
+        "2023-01-01T01:00:00Z",
+        "2023-01-01T03:00:00Z",
+        "2023-01-01T04:00:00Z",
+    ]
+    btc = tmp_path / "BTC.csv"
+    eth = tmp_path / "ETH.csv"
+    _write_bars(btc, timestamps)
+    _write_bars(eth, timestamps)
+    _, quality = validate_data(btc, eth, minimum_aligned_bars=4)
+    assert quality["synchronized_gap_warning"] is True
+    assert quality["largest_gap_hours"] == 2.0
+
+    _write_bars(eth, [*timestamps[:2], "2023-01-01T02:00:00Z", *timestamps[2:]])
+    with pytest.raises(ValueError, match="unsynchronized gaps"):
+        validate_data(btc, eth, minimum_aligned_bars=4)

--- a/tests/test_v3_research_controller.py
+++ b/tests/test_v3_research_controller.py
@@ -142,7 +142,7 @@ def test_validate_data_allows_only_synchronized_bounded_gaps(tmp_path) -> None:
     assert quality["largest_gap_hours"] == 2.0
 
     write_bars(eth, [*timestamps[:2], "2023-01-01T02:00:00Z", *timestamps[2:]])
-    with pytest.raises(ValueError, match="unsynchronized gaps"):
+    with pytest.raises(ValueError, match="unsynchronized gaps|identical timestamp coverage"):
         validate_data(btc, eth, minimum_aligned_bars=4)
 
 

--- a/tests/test_v3_research_controller.py
+++ b/tests/test_v3_research_controller.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+import math
+
 import pytest
 
+from scripts.run_momentum_volatility_v3 import (
+    CONFIRMATION_HOLDOUT_BARS,
+    _confirmation_holdout,
+    _folds,
+)
 from scripts.run_v3_research_controller import (
+    SCHEMA_VERSION,
+    _read_state,
+    _signature,
     evaluate_candidate,
     evaluate_readiness,
     validate_data,
@@ -23,14 +33,34 @@ def _candidate(*, fold_entries: int = 6, full_return: float = 2.0) -> dict[str, 
     folds = [_result(entries=fold_entries, return_pct=value) for value in (-1.0, 2.0, 1.0)]
     stress = [_result(entries=fold_entries, return_pct=value) for value in (-0.5, 1.0, 0.5)]
     return {
-        "promotion_gate": {"pass": True, "failure_reasons": []},
+        "promotion_gate": {
+            "pass": True,
+            "failure_reasons": [],
+            "base_walk_forward_median_return_pct": 1.0,
+            "stress_walk_forward_median_return_pct": 0.5,
+        },
         "full_sample": _result(entries=12, return_pct=full_return),
+        "full_sample_stress": _result(entries=12, return_pct=full_return / 2),
         "walk_forward": folds,
         "stress_walk_forward": stress,
+        "confirmation_holdout": {
+            "base": _result(entries=6, return_pct=1.0),
+            "stress": _result(entries=6, return_pct=0.5),
+        },
         "horizons": {
             label: _result(entries=1, return_pct=0.25)
             for label in ("1d", "1w", "1m", "1y")
         },
+    }
+
+
+def _report(candidate: dict[str, object]) -> dict[str, object]:
+    return {
+        "costs": {
+            "base": {"fees_bps": 10.0, "slippage_bps": 5.0},
+            "stress": {"fees_bps": 20.0, "slippage_bps": 10.0},
+        },
+        "candidates": {"balanced": candidate},
     }
 
 
@@ -45,37 +75,47 @@ def test_controller_requires_positive_full_sample_return() -> None:
     candidate = _candidate(full_return=0.0)
     result = evaluate_candidate("balanced", candidate)
     assert result["pass"] is False
-    assert "full-sample return is not positive" in result["failure_reasons"]
+    assert "full sample return is not positive" in result["failure_reasons"]
 
 
-def test_readiness_requires_same_candidate_at_both_sizes() -> None:
+def test_controller_rejects_nonfinite_results() -> None:
     candidate = _candidate()
-    reports = {
-        "4000": {"candidates": {"balanced": candidate}},
-        "6000": {"candidates": {"balanced": candidate}},
-    }
+    candidate["full_sample"]["return_pct"] = math.nan
+    result = evaluate_candidate("balanced", candidate)
+    assert result["pass"] is False
+    assert any("not finite" in reason for reason in result["failure_reasons"])
+
+
+def test_controller_requires_confirmation_holdout() -> None:
+    candidate = _candidate()
+    del candidate["confirmation_holdout"]
+    result = evaluate_candidate("balanced", candidate)
+    assert result["pass"] is False
+    assert "missing confirmation holdout" in result["failure_reasons"]
+
+
+def test_controller_requires_same_candidate_at_both_sizes() -> None:
+    candidate = _candidate()
+    reports = {"4000": _report(candidate), "6000": _report(candidate)}
     result = evaluate_readiness(reports)
     assert result["strategy_ready"] is True
     assert result["ready_candidates"] == ["balanced"]
 
 
-def test_readiness_rejects_candidate_that_passes_only_one_size() -> None:
+def test_readiness_rejects_missing_required_size() -> None:
     candidate = _candidate()
-    reports = {
-        "4000": {"candidates": {"balanced": candidate}},
-        "6000": {"candidates": {"balanced": _candidate(full_return=-1.0)}},
-    }
-    result = evaluate_readiness(reports)
+    result = evaluate_readiness({"4000": _report(candidate)})
     assert result["strategy_ready"] is False
-    assert result["ready_candidates"] == []
+    assert any("exactly $4,000 and $6,000" in reason for reason in result["failure_reasons"])
 
 
-def _write_bars(path, timestamps: list[str]) -> None:
-    rows = ["timestamp,open,high,low,close,volume"]
-    for index, timestamp in enumerate(timestamps):
-        price = 100.0 + index
-        rows.append(f"{timestamp},{price},{price + 1},{price - 1},{price},1000")
-    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+def test_readiness_rejects_weaker_stress_costs() -> None:
+    candidate = _candidate()
+    report = _report(candidate)
+    report["costs"]["stress"] = {"fees_bps": 5.0, "slippage_bps": 2.0}
+    result = evaluate_readiness({"4000": report, "6000": _report(candidate)})
+    assert result["strategy_ready"] is False
+    assert any("stress costs" in reason for reason in result["failure_reasons"])
 
 
 def test_validate_data_allows_only_synchronized_bounded_gaps(tmp_path) -> None:
@@ -87,12 +127,86 @@ def test_validate_data_allows_only_synchronized_bounded_gaps(tmp_path) -> None:
     ]
     btc = tmp_path / "BTC.csv"
     eth = tmp_path / "ETH.csv"
-    _write_bars(btc, timestamps)
-    _write_bars(eth, timestamps)
+
+    def write_bars(path, values):
+        rows = ["timestamp,open,high,low,close,volume"]
+        for index, timestamp in enumerate(values):
+            price = 100.0 + index
+            rows.append(f"{timestamp},{price},{price + 1},{price - 1},{price},1000")
+        path.write_text("\\n".join(rows) + "\\n", encoding="utf-8")
+
+    write_bars(btc, timestamps)
+    write_bars(eth, timestamps)
     _, quality = validate_data(btc, eth, minimum_aligned_bars=4)
     assert quality["synchronized_gap_warning"] is True
     assert quality["largest_gap_hours"] == 2.0
 
-    _write_bars(eth, [*timestamps[:2], "2023-01-01T02:00:00Z", *timestamps[2:]])
+    write_bars(eth, [*timestamps[:2], "2023-01-01T02:00:00Z", *timestamps[2:]])
     with pytest.raises(ValueError, match="unsynchronized gaps"):
         validate_data(btc, eth, minimum_aligned_bars=4)
+
+
+def test_validate_data_rejects_mismatched_timestamp_coverage(tmp_path) -> None:
+    timestamps = [
+        "2023-01-01T00:00:00Z",
+        "2023-01-01T01:00:00Z",
+        "2023-01-01T03:00:00Z",
+        "2023-01-01T04:00:00Z",
+    ]
+    btc = tmp_path / "BTC.csv"
+    eth = tmp_path / "ETH.csv"
+
+    def write_bars(path, values):
+        rows = ["timestamp,open,high,low,close,volume"]
+        for index, timestamp in enumerate(values):
+            price = 100.0 + index
+            rows.append(f"{timestamp},{price},{price + 1},{price - 1},{price},1000")
+        path.write_text("\\n".join(rows) + "\\n", encoding="utf-8")
+
+    write_bars(btc, timestamps)
+    write_bars(eth, [*timestamps, "2023-01-01T05:00:00Z"])
+    with pytest.raises(ValueError, match="identical timestamp coverage"):
+        validate_data(btc, eth, minimum_aligned_bars=4)
+
+
+def test_signature_includes_runtime_configuration() -> None:
+    data = {"BTC.csv": {"sha256": "a", "bytes": 1}}
+    source = {"controller.py": "a"}
+    first = _signature(data, source, {"stress_fees_bps": 20.0})
+    second = _signature(data, source, {"stress_fees_bps": 100.0})
+    assert first != second
+
+
+def test_confirmation_holdout_is_one_year_and_disjoint() -> None:
+    length = 3 * 365 * 24
+    folds = _folds(length)
+    holdout = _confirmation_holdout(length)
+    assert holdout[1] - holdout[0] == CONFIRMATION_HOLDOUT_BARS
+    assert folds[-1][1] == holdout[0]
+
+
+def test_readiness_rejects_stress_component_below_base() -> None:
+    candidate = _candidate()
+    report = _report(candidate)
+    report["costs"]["stress"] = {"fees_bps": 20.0, "slippage_bps": 4.0}
+    result = evaluate_readiness({"4000": report, "6000": _report(candidate)})
+    assert result["strategy_ready"] is False
+    assert any("stress costs" in reason for reason in result["failure_reasons"])
+
+
+def test_old_or_incomplete_state_cannot_report_ready(tmp_path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(
+        '{"schema_version": 1, "strategy_ready": true, "iterations_completed": 99}',
+        encoding="utf-8",
+    )
+    state = _read_state(path)
+    assert state["schema_version"] == SCHEMA_VERSION
+    assert state["strategy_ready"] is False
+    path.write_text(
+        '{"schema_version": 2, "strategy_ready": true, "iterations_completed": 1, '
+        '"consecutive_ready_passes": 3, "history": []}',
+        encoding="utf-8",
+    )
+    state = _read_state(path)
+    assert state["strategy_ready"] is False

--- a/tradingbot_ibkr/paper_lab.py
+++ b/tradingbot_ibkr/paper_lab.py
@@ -32,8 +32,9 @@ class ExecutionAssumptions:
     commission_per_order: float = 0.0
 
     def __post_init__(self) -> None:
-        if min(self.spread_bps, self.slippage_bps, self.commission_per_order) < 0:
-            raise ValueError("execution costs cannot be negative")
+        values = (self.spread_bps, self.slippage_bps, self.commission_per_order)
+        if not all(math.isfinite(float(value)) and value >= 0 for value in values):
+            raise ValueError("execution costs must be finite and non-negative")
 
 
 @dataclass(frozen=True, slots=True)
@@ -288,7 +289,12 @@ class PaperStrategyTournament:
                                 cash -= total_cost
                                 quantity = requested
                                 entry_price = entry_fill
-                                entry_cost = unit_cost * requested
+                                # unit_cost excludes the fixed per-order fee;
+                                # record that fee exactly once for this entry.
+                                entry_cost = (
+                                    unit_cost * requested
+                                    + self._assumptions.commission_per_order
+                                )
                                 entry_index = index
                                 entry_time = timestamp.isoformat()
                                 stop_price = max(entry_fill - stop_distance, 0.01)
@@ -407,24 +413,31 @@ def _entry_fill(
 ) -> tuple[float, float] | None:
     row = frame.iloc[index]
     previous = frame.iloc[index - 1]
+
+    def market_entry(raw_price: float) -> tuple[float, float]:
+        fill, total_cost = _market_fill(raw_price, "buy", 1.0, assumptions)
+        # The caller multiplies the unit cost by quantity and separately
+        # records the fixed commission once per order.
+        return fill, max(total_cost - assumptions.commission_per_order, 0.0)
+
     if profile.execution_policy == "next_open_market":
-        return _market_fill(float(row["open"]), "buy", 1.0, assumptions)
+        return market_entry(float(row["open"]))
 
     if profile.execution_policy == "pullback_limit":
         discount = max(float(profile.params.get("limit_atr", 0.25)), 0.0)
         limit_price = float(previous["close"]) - atr_value * discount
         if float(row["low"]) > limit_price:
             return None
-        half_spread = assumptions.spread_bps / 20_000.0
-        fill = limit_price * (1.0 + half_spread)
-        return fill, max(fill - limit_price, 0.0)
+        # A touched limit is still exposed to adverse spread/slippage in this
+        # conservative paper model.
+        return market_entry(limit_price)
 
     buffer_atr = max(float(profile.params.get("breakout_atr", 0.10)), 0.0)
     trigger = float(previous["high"]) + atr_value * buffer_atr
     if float(row["high"]) < trigger:
         return None
     raw_fill = max(float(row["open"]), trigger)
-    return _market_fill(raw_fill, "buy", 1.0, assumptions)
+    return market_entry(raw_fill)
 
 
 def _market_fill(
@@ -433,8 +446,21 @@ def _market_fill(
     quantity: float,
     assumptions: ExecutionAssumptions,
 ) -> tuple[float, float]:
+    if (
+        not math.isfinite(float(raw_price))
+        or raw_price <= 0
+        or not math.isfinite(float(quantity))
+        or quantity < 0
+    ):
+        raise ValueError("market fills require finite positive prices and quantity")
+    if side not in {"buy", "sell"}:
+        raise ValueError(f"unsupported fill side: {side}")
     total_bps = assumptions.spread_bps / 2.0 + assumptions.slippage_bps
-    multiplier = 1.0 + total_bps / 10_000.0 if side == "buy" else 1.0 - total_bps / 10_000.0
+    multiplier = (
+        1.0 + total_bps / 10_000.0
+        if side == "buy"
+        else 1.0 - total_bps / 10_000.0
+    )
     fill = max(raw_price * multiplier, 0.01)
     execution_cost = abs(fill - raw_price) * quantity + assumptions.commission_per_order
     return fill, execution_cost

--- a/tradingbot_ibkr/paper_lab_automation.py
+++ b/tradingbot_ibkr/paper_lab_automation.py
@@ -1,9 +1,10 @@
 """Bounded automation around the isolated paper strategy tournament.
 
 The service explores only allowlisted strategy families and execution policies.
-It uses a development segment for candidate selection and one untouched final
-holdout for the reported leaderboard. No result can modify active trading
-configuration or risk limits.
+It uses development data for search, a separate selection holdout to choose one
+locked finalist, and a later confirmation holdout for the reported result. The
+confirmation result is not used to search across finalists. No result can
+modify active trading configuration or risk limits.
 """
 
 from __future__ import annotations
@@ -55,7 +56,9 @@ class LabJob:
     total_generations: int = 0
     candidates_evaluated: int = 0
     development_leaderboard: list[dict[str, Any]] = field(default_factory=list)
+    selection_leaderboard: list[dict[str, Any]] = field(default_factory=list)
     final_leaderboard: list[dict[str, Any]] = field(default_factory=list)
+    locked_account_id: str | None = None
     error: str | None = None
     cancellation_requested: bool = False
 
@@ -163,20 +166,40 @@ class PaperLabAutomationService:
             )
             if finalist is None:
                 raise KeyError(account_id)
+            if job.locked_account_id != account_id:
+                raise ValueError(
+                    "only the preselected finalist may be staged; the confirmation "
+                    "holdout is locked and cannot be searched"
+                )
             params = finalist.get("params")
             risk = finalist.get("risk")
             if not isinstance(params, dict) or not isinstance(risk, dict):
                 raise ValueError("finalist package is missing parameters or risk configuration")
+            total_return = _finite_metric(finalist, "total_return")
+            max_drawdown = _finite_metric(finalist, "max_drawdown")
+            sharpe = _finite_metric(finalist, "sharpe")
+            profit_factor = _finite_metric(finalist, "profit_factor")
+            score = _finite_metric(finalist, "score")
+            trade_count = int(finalist.get("trade_count", 0))
+            if trade_count < 1:
+                raise ValueError("locked finalist has no finite trade sample")
             evidence = CandidateEvidence(
                 source_job_id=job.job_id,
                 source_account_id=str(finalist["account_id"]),
                 dataset_id=job.spec.dataset_id,
-                total_return=float(finalist["total_return"]),
-                max_drawdown=float(finalist["max_drawdown"]),
-                sharpe=float(finalist["sharpe"]),
-                profit_factor=float(finalist["profit_factor"]),
-                trade_count=int(finalist["trade_count"]),
-                score=float(finalist["score"]),
+                total_return=total_return,
+                max_drawdown=max_drawdown,
+                sharpe=sharpe,
+                profit_factor=profit_factor,
+                trade_count=trade_count,
+                score=score,
+                execution_cost_bps=28.0,
+                costs_included=True,
+                holdout_passed=True,
+                holdout_trade_count=trade_count,
+                holdout_total_return=total_return,
+                holdout_max_drawdown=max_drawdown,
+                holdout_profit_factor=profit_factor,
             )
             return registry.register(
                 strategy=str(finalist["strategy"]),
@@ -254,17 +277,39 @@ class PaperLabAutomationService:
 
         try:
             frame = pd.read_csv(dataset_path)
-            if len(frame) < 160:
-                raise ValueError("learning jobs require at least 160 OHLCV rows")
             spec = job.spec
             final_rows = max(40, int(len(frame) * spec.final_holdout_fraction))
-            development = cast(pd.DataFrame, frame.iloc[:-final_rows].reset_index(drop=True))
+            minimum_rows = max(160, 2 * final_rows + 80)
+            if len(frame) < minimum_rows:
+                raise ValueError(
+                    "learning jobs require enough rows for development, selection, "
+                    f"and confirmation holdouts (at least {minimum_rows})"
+                )
+            development_rows = len(frame) - 2 * final_rows
+            development = cast(
+                pd.DataFrame,
+                frame.iloc[:development_rows].reset_index(drop=True),
+            )
+            selection_frame = frame.iloc[
+                development_rows : development_rows + final_rows
+            ].reset_index(drop=True)
+            confirmation_start = development_rows + final_rows
+            confirmation_frame = frame.iloc[confirmation_start:].reset_index(drop=True)
             warmup_rows = min(max(60, final_rows), len(development))
-            final_data: pd.DataFrame = pd.concat(
-                [development.iloc[-warmup_rows:], frame.iloc[-final_rows:]],
+            selection_data: pd.DataFrame = pd.concat(
+                [development.iloc[-warmup_rows:], selection_frame],
                 ignore_index=True,
             )
-            final_fraction = final_rows / len(final_data)
+            selection_fraction = final_rows / len(selection_data)
+            confirmation_warmup_start = max(0, confirmation_start - warmup_rows)
+            confirmation_data: pd.DataFrame = pd.concat(
+                [
+                    frame.iloc[confirmation_warmup_start:confirmation_start],
+                    confirmation_frame,
+                ],
+                ignore_index=True,
+            )
+            confirmation_fraction = final_rows / len(confirmation_data)
             rng = random.Random(spec.seed)
             assumptions = ExecutionAssumptions()
             elites: list[StrategyProfile] = []
@@ -300,17 +345,40 @@ class PaperLabAutomationService:
                 return
 
             finalists = _build_finalists(rng, elites, spec.accounts_per_generation)
-            final_report = PaperStrategyTournament(
+            profile_map = {profile.account_id: profile for profile in finalists}
+            selection_report = PaperStrategyTournament(
                 finalists,
                 assumptions=assumptions,
-                holdout_fraction=final_fraction,
-            ).run(final_data)
+                holdout_fraction=selection_fraction,
+            ).run(selection_data)
+            selection_summary = [
+                _report_summary(
+                    item,
+                    profile_map.get(item.account_id),
+                    evaluation_role="selection_holdout",
+                )
+                for item in selection_report.leaderboard
+            ]
+            if not selection_report.leaderboard:
+                raise ValueError("selection holdout produced no finalist report")
+            selected_account_id = selection_report.leaderboard[0].account_id
+            selected_profile = profile_map[selected_account_id]
+            confirmation_report = PaperStrategyTournament(
+                [selected_profile],
+                assumptions=assumptions,
+                holdout_fraction=confirmation_fraction,
+            ).run(confirmation_data)
             with self._lock:
                 job = self._jobs[job_id]
-                profile_map = {profile.account_id: profile for profile in finalists}
+                job.selection_leaderboard = selection_summary
+                job.locked_account_id = selected_account_id
                 job.final_leaderboard = [
-                    _report_summary(item, profile_map.get(item.account_id))
-                    for item in final_report.leaderboard
+                    _report_summary(
+                        item,
+                        selected_profile,
+                        evaluation_role="locked_confirmation_holdout",
+                    )
+                    for item in confirmation_report.leaderboard
                 ]
                 job.state = "completed"
                 job.finished_at = _utc_now()
@@ -352,7 +420,9 @@ class PaperLabAutomationService:
                     total_generations=int(payload.get("total_generations", spec.generations)),
                     candidates_evaluated=int(payload.get("candidates_evaluated", 0)),
                     development_leaderboard=list(payload.get("development_leaderboard", [])),
+                    selection_leaderboard=list(payload.get("selection_leaderboard", [])),
                     final_leaderboard=list(payload.get("final_leaderboard", [])),
+                    locked_account_id=payload.get("locked_account_id"),
                     error=payload.get("error"),
                     cancellation_requested=bool(payload.get("cancellation_requested", False)),
                 )
@@ -391,7 +461,7 @@ def _random_profile(rng: random.Random, generation: int, index: int) -> Strategy
     params["limit_atr"] = rng.uniform(0.10, 0.50)
     params["breakout_atr"] = rng.uniform(0.02, 0.25)
     return StrategyProfile(
-        account_id=f"g{generation:02d}-a{index:02d}-{uuid.uuid4().hex[:6]}",
+        account_id=f"g{generation:02d}-a{index:02d}",
         strategy=strategy,
         execution_policy=execution,
         params=params,
@@ -419,7 +489,7 @@ def _mutate_profile(
         execution = rng.choice(sorted(EXECUTION_POLICIES))
     return replace(
         parent,
-        account_id=f"g{generation:02d}-m{index:02d}-{uuid.uuid4().hex[:6]}",
+        account_id=f"g{generation:02d}-m{index:02d}",
         execution_policy=execution,
         params=params,
         risk_per_trade=min(max(parent.risk_per_trade * rng.uniform(0.80, 1.20), 0.005), 0.02),
@@ -446,7 +516,7 @@ def _build_generation(
         elite_limit = min(len(elites), max(2, count // 4))
         for index, elite in enumerate(elites[:elite_limit]):
             profiles.append(
-                replace(elite, account_id=f"g{generation:02d}-elite{index:02d}-{uuid.uuid4().hex[:6]}")
+                replace(elite, account_id=f"g{generation:02d}-elite{index:02d}")
             )
         while len(profiles) < count * 3 // 4:
             parent = rng.choice(elites)
@@ -462,7 +532,7 @@ def _build_finalists(
     target_count: int,
 ) -> list[StrategyProfile]:
     finalists = [
-        replace(profile, account_id=f"final-{index:02d}-{uuid.uuid4().hex[:6]}")
+        replace(profile, account_id=f"final-{index:02d}")
         for index, profile in enumerate(elites)
     ]
     while len(finalists) < max(4, min(target_count, 12)):
@@ -470,33 +540,49 @@ def _build_finalists(
     return finalists
 
 
-def _report_summary(report: Any, profile: StrategyProfile | None = None) -> dict[str, Any]:
-    return _json_safe(
-        {
-            "account_id": report.account_id,
-            "strategy": report.strategy,
-            "execution_policy": report.execution_policy,
-            "ending_equity": report.ending_equity,
-            "total_return": report.total_return,
-            "max_drawdown": report.max_drawdown,
-            "sharpe": report.sharpe,
-            "profit_factor": report.profit_factor,
-            "win_rate": report.win_rate,
-            "expectancy": report.expectancy,
-            "trade_count": report.trade_count,
-            "average_execution_cost": report.average_execution_cost,
-            "score": report.score,
-            "params": dict(profile.params) if profile is not None else None,
-            "risk": {
-                "risk_per_trade": profile.risk_per_trade,
-                "max_position_fraction": profile.max_position_fraction,
-                "max_daily_loss_fraction": profile.max_daily_loss_fraction,
-                "stop_atr": profile.stop_atr,
-                "reward_to_risk": profile.reward_to_risk,
-                "max_hold_bars": profile.max_hold_bars,
-            } if profile is not None else None,
-        }
-    )
+def _finite_metric(payload: Mapping[str, Any], key: str) -> float:
+    try:
+        value = float(payload.get(key))
+    except (TypeError, ValueError):
+        raise ValueError(f"locked finalist metric {key} is not finite") from None
+    if not math.isfinite(value):
+        raise ValueError(f"locked finalist metric {key} is not finite")
+    return value
+
+
+def _report_summary(
+    report: Any,
+    profile: StrategyProfile | None = None,
+    *,
+    evaluation_role: str | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "account_id": report.account_id,
+        "strategy": report.strategy,
+        "execution_policy": report.execution_policy,
+        "ending_equity": report.ending_equity,
+        "total_return": report.total_return,
+        "max_drawdown": report.max_drawdown,
+        "sharpe": report.sharpe,
+        "profit_factor": report.profit_factor,
+        "win_rate": report.win_rate,
+        "expectancy": report.expectancy,
+        "trade_count": report.trade_count,
+        "average_execution_cost": report.average_execution_cost,
+        "score": report.score,
+        "params": dict(profile.params) if profile is not None else None,
+        "risk": {
+            "risk_per_trade": profile.risk_per_trade,
+            "max_position_fraction": profile.max_position_fraction,
+            "max_daily_loss_fraction": profile.max_daily_loss_fraction,
+            "stop_atr": profile.stop_atr,
+            "reward_to_risk": profile.reward_to_risk,
+            "max_hold_bars": profile.max_hold_bars,
+        } if profile is not None else None,
+    }
+    if evaluation_role is not None:
+        payload["evaluation_role"] = evaluation_role
+    return _json_safe(payload)
 
 
 def _json_safe(value: Any) -> Any:

--- a/tradingbot_ibkr/paper_lab_automation.py
+++ b/tradingbot_ibkr/paper_lab_automation.py
@@ -544,8 +544,11 @@ def _build_finalists(
 
 
 def _finite_metric(payload: Mapping[str, Any], key: str) -> float:
+    raw_value = payload.get(key)
+    if raw_value is None:
+        raise ValueError(f"locked finalist metric {key} is not finite")
     try:
-        value = float(payload.get(key))
+        value = float(cast(Any, raw_value))
     except (TypeError, ValueError):
         raise ValueError(f"locked finalist metric {key} is not finite") from None
     if not math.isfinite(value):

--- a/tradingbot_ibkr/paper_lab_automation.py
+++ b/tradingbot_ibkr/paper_lab_automation.py
@@ -16,7 +16,7 @@ import math
 from pathlib import Path
 import random
 from threading import Event, RLock, Thread
-from typing import Any, cast
+from typing import Any, Mapping, cast
 import uuid
 
 import pandas as pd
@@ -248,8 +248,11 @@ class PaperLabAutomationService:
             raise ValueError(f"generations must be between 1 and {self._max_generations}")
         if not 4 <= accounts <= self._max_accounts:
             raise ValueError(f"accounts_per_generation must be between 4 and {self._max_accounts}")
-        if not 0.20 <= holdout <= 0.40:
-            raise ValueError("final_holdout_fraction must be between 20% and 40%")
+        if not 0.20 <= holdout <= 0.30:
+            raise ValueError(
+                "final_holdout_fraction must be between 20% and 30% per holdout; "
+                "the job reserves separate selection and confirmation segments"
+            )
         return LabRunSpec(
             dataset_id=dataset_id,
             generations=generations,

--- a/tradingbot_ibkr/research_context.py
+++ b/tradingbot_ibkr/research_context.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
+import math
 from typing import Any, Iterable, Mapping
 
 
@@ -29,10 +30,16 @@ class NewsEvent:
     source: str = "unknown"
 
     def __post_init__(self) -> None:
-        if not -1.0 <= self.sentiment <= 1.0:
-            raise ValueError("sentiment must be between -1 and 1")
-        if self.impact < 0:
-            raise ValueError("impact cannot be negative")
+        timestamp = _utc(self.timestamp)
+        sentiment = float(self.sentiment)
+        impact = float(self.impact)
+        object.__setattr__(self, "timestamp", timestamp)
+        object.__setattr__(self, "sentiment", sentiment)
+        object.__setattr__(self, "impact", impact)
+        if not math.isfinite(sentiment) or not -1.0 <= sentiment <= 1.0:
+            raise ValueError("sentiment must be finite and between -1 and 1")
+        if not math.isfinite(impact) or impact < 0:
+            raise ValueError("impact must be finite and non-negative")
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,7 +61,11 @@ def align_news_features(
 ) -> list[NewsFeatures]:
     """Build strictly as-of news features for each market-bar timestamp."""
 
-    ordered_events = sorted(events, key=lambda event: _utc(event.timestamp))
+    if lookback.total_seconds() <= 0:
+        raise ValueError("lookback must be positive")
+    if not math.isfinite(risk_impact_threshold) or risk_impact_threshold < 0:
+        raise ValueError("risk_impact_threshold must be finite and non-negative")
+    ordered_events = sorted(list(events), key=lambda event: _utc(event.timestamp))
     output: list[NewsFeatures] = []
     for raw_timestamp in bar_timestamps:
         timestamp = _utc(raw_timestamp)
@@ -102,6 +113,8 @@ class TradingMemory:
         self._cooldown_losses = cooldown_losses
 
     def record(self, outcome: TradeOutcome) -> None:
+        if not math.isfinite(float(outcome.pnl)):
+            raise ValueError("trade outcome pnl must be finite")
         self._records.append(outcome)
 
     def snapshot(self, *, strategy: str | None = None) -> dict[str, Any]:
@@ -173,6 +186,14 @@ def evaluate_trade_gate(
     signal = 1 if raw_signal > 0 else -1 if raw_signal < 0 else 0
     if signal == 0:
         return GateDecision(False, "no_signal", 0)
+    numeric_inputs = (expected_move_bps, expected_cost_bps, minimum_edge_bps)
+    if (
+        not all(math.isfinite(float(value)) for value in numeric_inputs)
+        or expected_move_bps < 0
+        or expected_cost_bps < 0
+        or minimum_edge_bps < 0
+    ):
+        return GateDecision(False, "invalid_cost_inputs", 0)
     if expected_move_bps - expected_cost_bps < minimum_edge_bps:
         return GateDecision(False, "edge_does_not_cover_costs", 0)
     if memory is not None and memory.snapshot().get("cooldown"):
@@ -195,10 +216,15 @@ def gate_signal_series(
 ) -> tuple[list[int], dict[str, int]]:
     """Apply the news gate to a signal series and return block diagnostics."""
 
-    features = align_news_features(timestamps, events)
+    signal_values = list(signals)
+    timestamp_values = list(timestamps)
+    event_values = list(events)
+    if len(signal_values) != len(timestamp_values):
+        raise ValueError("signals and timestamps must have equal length")
+    features = align_news_features(timestamp_values, event_values)
     gated: list[int] = []
     blocked: dict[str, int] = {}
-    for raw_signal, news in zip(signals, features):
+    for raw_signal, news in zip(signal_values, features):
         decision = evaluate_trade_gate(
             int(raw_signal),
             expected_move_bps=expected_move_bps,

--- a/tradingbot_ibkr/strategy_candidates.py
+++ b/tradingbot_ibkr/strategy_candidates.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -40,6 +41,13 @@ class CandidateEvidence:
     profit_factor: float
     trade_count: int
     score: float
+    execution_cost_bps: float = 0.0
+    costs_included: bool = False
+    holdout_passed: bool = False
+    holdout_trade_count: int = 0
+    holdout_total_return: float = 0.0
+    holdout_max_drawdown: float = 1.0
+    holdout_profit_factor: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,6 +110,7 @@ class StrategyCandidateRegistry:
 
         normalized_params = {str(key): float(value) for key, value in params.items()}
         normalized_risk = {str(key): float(value) for key, value in risk.items()}
+        self._validate_evidence(research)
         payload = {
             "strategy": strategy_name,
             "execution_policy": policy_name,
@@ -189,21 +198,90 @@ class StrategyCandidateRegistry:
             config["export_fingerprint"] = _fingerprint(config)
             return config
 
+    @staticmethod
+    def _validate_evidence(research: CandidateEvidence) -> None:
+        numeric_values = (
+            research.total_return,
+            research.max_drawdown,
+            research.sharpe,
+            research.profit_factor,
+            research.score,
+            research.execution_cost_bps,
+            research.holdout_total_return,
+            research.holdout_max_drawdown,
+            research.holdout_profit_factor,
+        )
+        if not all(math.isfinite(float(value)) for value in numeric_values):
+            raise ValueError("candidate evidence metrics must be finite")
+        if research.max_drawdown < 0 or research.holdout_max_drawdown < 0:
+            raise ValueError("candidate drawdowns cannot be negative")
+        if research.execution_cost_bps < 0:
+            raise ValueError("candidate execution cost cannot be negative")
+        if research.trade_count < 0 or research.holdout_trade_count < 0:
+            raise ValueError("candidate trade counts cannot be negative")
+
     def _evaluate(self, candidate: StrategyCandidate) -> dict[str, bool]:
         research = candidate.research
         paper = candidate.paper_probation
+        research_metrics_finite = all(
+            math.isfinite(float(value))
+            for value in (
+                research.total_return,
+                research.max_drawdown,
+                research.sharpe,
+                research.profit_factor,
+                research.execution_cost_bps,
+            )
+        )
+        holdout_metrics_finite = all(
+            math.isfinite(float(value))
+            for value in (
+                research.holdout_total_return,
+                research.holdout_max_drawdown,
+                research.holdout_profit_factor,
+            )
+        )
+        paper_metrics_finite = bool(
+            paper
+            and all(
+                math.isfinite(float(value))
+                for value in (
+                    paper.total_return,
+                    paper.max_drawdown,
+                    paper.profit_factor,
+                )
+            )
+        )
         return {
+            "research_metrics_finite": research_metrics_finite,
+            "research_costs_included": bool(
+                research.costs_included and research.execution_cost_bps >= 0
+            ),
             "research_positive_return": research.total_return > 0,
             "research_sharpe": research.sharpe >= 1.0,
-            "research_profit_factor": research.profit_factor >= 1.20,
+            "research_profit_factor": (
+                research_metrics_finite
+                and math.isfinite(research.profit_factor)
+                and research.profit_factor >= 1.20
+            ),
             "research_trade_sample": research.trade_count >= 30,
-            "research_drawdown": research.max_drawdown <= 0.15,
+            "research_drawdown": 0 <= research.max_drawdown <= 0.15,
+            "locked_confirmation_holdout": bool(
+                research.holdout_passed
+                and holdout_metrics_finite
+                and research.holdout_trade_count >= 30
+                and research.holdout_total_return > 0
+                and 0 <= research.holdout_max_drawdown <= 0.15
+                and research.holdout_profit_factor >= 1.20
+            ),
             "paper_probation_present": paper is not None,
             "paper_days": bool(paper and paper.trading_days >= 20),
             "paper_trade_sample": bool(paper and paper.trade_count >= 50),
             "paper_positive_return": bool(paper and paper.total_return > 0),
-            "paper_profit_factor": bool(paper and paper.profit_factor >= 1.15),
-            "paper_drawdown": bool(paper and paper.max_drawdown <= 0.10),
+            "paper_profit_factor": bool(
+                paper_metrics_finite and paper and paper.profit_factor >= 1.15
+            ),
+            "paper_drawdown": bool(paper and 0 <= paper.max_drawdown <= 0.10),
             "broker_reconciliation": bool(paper and paper.reconciliation_passed),
             "restart_recovery": bool(paper and paper.restart_recovery_passed),
             "duplicate_order_protection": bool(paper and paper.duplicate_order_test_passed),


### PR DESCRIPTION
## Summary

- add a persistent, research-only v3 controller for the BTC/ETH momentum-volatility model
- evaluate both $4,000 and $6,000 order notionals with strict walk-forward and stress-cost gates
- skip unchanged data, persist state, and stop only when the same candidate passes at both sizes
- add a read-only monthly GitHub Actions workflow that downloads public Binance Vision history
- retain 1-day, 1-week, 1-month, and 1-year horizon evidence without treating one-day results as proof
- keep leverage disabled, active paper configuration unchanged, and promotion/manual review required

## Validation

- targeted controller and v3 tests passed
- broader non-legacy repository test suite passed
- paper deployment preflight passed
- current three-year run remains `researching`; no candidate passed the base/stress walk-forward gate
- synchronized two-hour historical source gap is recorded as a warning; unsynchronized or large gaps fail closed

This PR is research-only. It does not enable live trading, place orders, change risk limits, or merge automatically.