### PR TITLE
Fix CI dependency and packaging failures

### DIFF
--- a/.github/workflows/backtest-summary.yml
+++ b/.github/workflows/backtest-summary.yml
@@ -12,6 +12,7 @@ on:
       - "backtest/**"
       - "pyproject.toml"
       - "requirements*.txt"
+      - ".github/workflows/backtest-summary.yml"
 
 permissions:
   contents: write

--- a/.github/workflows/backtest-summary.yml
+++ b/.github/workflows/backtest-summary.yml
@@ -65,7 +65,7 @@ jobs:
 from pathlib import Path
 
 Path("summary-latest.md").write_text(
-    """# Backtest Summary\n\n"
+    "# Backtest Summary\n\n"
     "_No backtest JSONs found in the repository (looking for `backtest*.json` or `report_*.json`)._\n"
     "Push backtest artifacts or ensure a backtest script writes results to the repo root.\n"
 )

--- a/.github/workflows/backtest-summary.yml
+++ b/.github/workflows/backtest-summary.yml
@@ -62,79 +62,79 @@ jobs:
 
           if [ ${#files[@]} -eq 0 ]; then
             python - <<'PY'
-from pathlib import Path
-
-Path("summary-latest.md").write_text(
-    "# Backtest Summary\n\n"
-    "_No backtest JSONs found in the repository (looking for `backtest*.json` or `report_*.json`)._\n"
-    "Push backtest artifacts or ensure a backtest script writes results to the repo root.\n"
-)
-PY
+          from pathlib import Path
+          
+          Path("summary-latest.md").write_text(
+              "# Backtest Summary\n\n"
+              "_No backtest JSONs found in the repository (looking for `backtest*.json` or `report_*.json`)._\n"
+              "Push backtest artifacts or ensure a backtest script writes results to the repo root.\n"
+          )
+          PY
           else
             # If your repo has scripts/summarize_backtests.py, use it; otherwise inline quick roll-up.
             if [ -f scripts/summarize_backtests.py ]; then
               python scripts/summarize_backtests.py | tee summary-latest.md
             else
               python - <<'PY' | tee summary-latest.md
-import glob
-import json
-import statistics as st
-
-
-def pct(value: float) -> str:
-    return f"{100 * value:.2f}%"
-
-
-def eq_to_rets(equity):
-    return [
-        (equity[i] / equity[i - 1] - 1)
-        for i in range(1, len(equity))
-        if equity[i - 1] > 0
-    ]
-
-
-def mdd(equity):
-    peak = 0.0
-    max_dd = 0.0
-    for value in equity:
-        peak = max(peak, value)
-        if peak > 0:
-            max_dd = max(max_dd, 1 - value / peak)
-    return max_dd
-
-
-print("# Backtest Summary\n")
-for fp in sorted(glob.glob("backtest*.json") + glob.glob("report_*.json")):
-    try:
-        with open(fp) as f:
-            data = json.load(f)
-        results = data.get("results", data)
-        eq = (
-            results.get("equity_curve")
-            or results.get("equity")
-            or data.get("equity_series")
-            or []
-        )
-        if len(eq) < 2:
-            print(f"- {fp}: _no equity curve_\n")
-            continue
-        returns = eq_to_rets(eq)
-        total = eq[-1] / eq[0] - 1
-        ann = ((1 + (st.mean(returns) if returns else 0)) ** 252) - 1
-        drawdown = mdd(eq)
-        sharpe = (
-            (st.mean(returns) if returns else 0)
-            / (st.pstdev(returns) or 1e-12)
-            if returns
-            else 0.0
-        )
-        print(
-            f"## {fp}\nPnL: {pct(total)} | Annualized: {pct(ann)} | "
-            f"MaxDD: {pct(drawdown)} | Sharpe: {sharpe:.2f}\n"
-        )
-    except Exception as exc:
-        print(f"- {fp}: _error parsing: {exc}_\n")
-PY
+          import glob
+          import json
+          import statistics as st
+          
+          
+          def pct(value: float) -> str:
+              return f"{100 * value:.2f}%"
+          
+          
+          def eq_to_rets(equity):
+              return [
+                  (equity[i] / equity[i - 1] - 1)
+                  for i in range(1, len(equity))
+                  if equity[i - 1] > 0
+              ]
+          
+          
+          def mdd(equity):
+              peak = 0.0
+              max_dd = 0.0
+              for value in equity:
+                  peak = max(peak, value)
+                  if peak > 0:
+                      max_dd = max(max_dd, 1 - value / peak)
+              return max_dd
+          
+          
+          print("# Backtest Summary\n")
+          for fp in sorted(glob.glob("backtest*.json") + glob.glob("report_*.json")):
+              try:
+                  with open(fp) as f:
+                      data = json.load(f)
+                  results = data.get("results", data)
+                  eq = (
+                      results.get("equity_curve")
+                      or results.get("equity")
+                      or data.get("equity_series")
+                      or []
+                  )
+                  if len(eq) < 2:
+                      print(f"- {fp}: _no equity curve_\n")
+                      continue
+                  returns = eq_to_rets(eq)
+                  total = eq[-1] / eq[0] - 1
+                  ann = ((1 + (st.mean(returns) if returns else 0)) ** 252) - 1
+                  drawdown = mdd(eq)
+                  sharpe = (
+                      (st.mean(returns) if returns else 0)
+                      / (st.pstdev(returns) or 1e-12)
+                      if returns
+                      else 0.0
+                  )
+                  print(
+                      f"## {fp}\nPnL: {pct(total)} | Annualized: {pct(ann)} | "
+                      f"MaxDD: {pct(drawdown)} | Sharpe: {sharpe:.2f}\n"
+                  )
+              except Exception as exc:
+                  print(f"- {fp}: _error parsing: {exc}_\n")
+          PY
             fi
           fi
 

--- a/.github/workflows/backtest-summary.yml
+++ b/.github/workflows/backtest-summary.yml
@@ -146,7 +146,7 @@ jobs:
           path: summary-latest.md
 
       - name: Commit and push results
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           git config user.name "market-bot"

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -7,10 +7,13 @@ jobs:
       - uses: actions/checkout@v3
       - run: ./install.sh
       - run: source venv/bin/activate && python check_trading_readiness.py --fix-issues --verbose
-      - run: source venv/bin/activate && python scripts/run_backtest.py \
-          --source csv --path backtest/sample_data/sample_ohlcv.csv \
-          --strategy backtest.strategies.sma_filtered:generate_signals \
-          --strategy_args fast=8 slow=34 trend_fast=55 trend_slow=144 \
-          --fees_bps 5 --slip_bps 2 --tp_bps 60 --sl_bps 40 \
-          --max_bars 200 --notional 1.0 --risk_per_trade 0.01 \
-          --out_prefix artifacts/sample_backtest
+      - name: Run sample backtest
+        run: |
+          source venv/bin/activate
+          python scripts/run_backtest.py \
+            --source csv --path backtest/sample_data/sample_ohlcv.csv \
+            --strategy backtest.strategies.sma_filtered:generate_signals \
+            --strategy_args fast=8 slow=34 trend_fast=55 trend_slow=144 \
+            --fees_bps 5 --slip_bps 2 --tp_bps 60 --sl_bps 40 \
+            --max_bars 200 --notional 1.0 --risk_per_trade 0.01 \
+            --out_prefix artifacts/sample_backtest

--- a/scripts/package_desktop.py
+++ b/scripts/package_desktop.py
@@ -36,7 +36,6 @@ def run_pyinstaller(spec_path: Path, build_dir: Path, dist_dir: Path, clean: boo
         "-m",
         "PyInstaller",
         "--noconfirm",
-        f"--specpath={spec_path.parent}",
         f"--workpath={build_dir}",
         f"--distpath={dist_dir}",
     ]

--- a/summary-latest.md
+++ b/summary-latest.md
@@ -47,42 +47,6 @@
   Win-rate: 0.00% | ProfitFactor: ∞
   Trades: 0
 
-- backtest_csv_tmp0l5xbz6t_csv_sma_cross_20251021T051845Z.json
-  PnL: 0.00%  | Annualized: 0.00%
-  MaxDD: 0.00% | Sharpe: 0.00 | Sortino: 0.00
-  Win-rate: 0.00% | ProfitFactor: ∞
-  Trades: 0
-
-- backtest_csv_tmphmsr2kct_csv_sma_cross_20251004T172433Z.json
-  PnL: -19.83%  | Annualized: -92.05%
-  MaxDD: 19.83% | Sharpe: -6689.35 | Sortino: -6689.35
-  Win-rate: 0.00% | ProfitFactor: 0.00
-  Trades: 23
-
-- backtest_csv_tmplrjhde1q_csv_sma_cross_20251004T172353Z.json
-  PnL: -18.21%  | Annualized: -92.05%
-  MaxDD: 18.21% | Sharpe: -4713.15 | Sortino: -4713.15
-  Win-rate: 0.00% | ProfitFactor: 0.00
-  Trades: 20
-
-- backtest_csv_tmpvizwya8b_csv_sma_cross_20251015T224604Z.json
-  PnL: -19.83%  | Annualized: -92.05%
-  MaxDD: 19.83% | Sharpe: -6689.35 | Sortino: -6689.35
-  Win-rate: 0.00% | ProfitFactor: 0.00
-  Trades: 23
-
-- backtest_csv_tmpvqkx890o_csv_sma_cross_20251004T172040Z.json
-  PnL: -19.83%  | Annualized: -92.05%
-  MaxDD: 19.83% | Sharpe: -6223.40 | Sortino: -6223.40
-  Win-rate: 0.00% | ProfitFactor: 0.00
-  Trades: 22
-
-- backtest_csv_tmpyb4oynlm_csv_sma_cross_20251021T052200Z.json
-  PnL: 0.00%  | Annualized: 0.00%
-  MaxDD: 0.00% | Sharpe: 0.00 | Sortino: 0.00
-  Win-rate: 0.00% | ProfitFactor: ∞
-  Trades: 0
-
 - backtest_csv_yourfile_for_aggr_csv_20250910T034754Z.json
   PnL: 0.00%  | Annualized: 0.00%
   MaxDD: 0.00% | Sharpe: 0.00 | Sortino: 0.00

--- a/summary-latest.md
+++ b/summary-latest.md
@@ -47,6 +47,42 @@
   Win-rate: 0.00% | ProfitFactor: ∞
   Trades: 0
 
+- backtest_csv_tmp0l5xbz6t_csv_sma_cross_20251021T051845Z.json
+  PnL: 0.00%  | Annualized: 0.00%
+  MaxDD: 0.00% | Sharpe: 0.00 | Sortino: 0.00
+  Win-rate: 0.00% | ProfitFactor: ∞
+  Trades: 0
+
+- backtest_csv_tmphmsr2kct_csv_sma_cross_20251004T172433Z.json
+  PnL: -19.83%  | Annualized: -92.05%
+  MaxDD: 19.83% | Sharpe: -6689.35 | Sortino: -6689.35
+  Win-rate: 0.00% | ProfitFactor: 0.00
+  Trades: 23
+
+- backtest_csv_tmplrjhde1q_csv_sma_cross_20251004T172353Z.json
+  PnL: -18.21%  | Annualized: -92.05%
+  MaxDD: 18.21% | Sharpe: -4713.15 | Sortino: -4713.15
+  Win-rate: 0.00% | ProfitFactor: 0.00
+  Trades: 20
+
+- backtest_csv_tmpvizwya8b_csv_sma_cross_20251015T224604Z.json
+  PnL: -19.83%  | Annualized: -92.05%
+  MaxDD: 19.83% | Sharpe: -6689.35 | Sortino: -6689.35
+  Win-rate: 0.00% | ProfitFactor: 0.00
+  Trades: 23
+
+- backtest_csv_tmpvqkx890o_csv_sma_cross_20251004T172040Z.json
+  PnL: -19.83%  | Annualized: -92.05%
+  MaxDD: 19.83% | Sharpe: -6223.40 | Sortino: -6223.40
+  Win-rate: 0.00% | ProfitFactor: 0.00
+  Trades: 22
+
+- backtest_csv_tmpyb4oynlm_csv_sma_cross_20251021T052200Z.json
+  PnL: 0.00%  | Annualized: 0.00%
+  MaxDD: 0.00% | Sharpe: 0.00 | Sortino: 0.00
+  Win-rate: 0.00% | ProfitFactor: ∞
+  Trades: 0
+
 - backtest_csv_yourfile_for_aggr_csv_20250910T034754Z.json
   PnL: 0.00%  | Annualized: 0.00%
   MaxDD: 0.00% | Sharpe: 0.00 | Sortino: 0.00

--- a/tradingbot_ibkr/requirements.txt
+++ b/tradingbot_ibkr/requirements.txt
@@ -4,8 +4,6 @@ ib_insync==0.9.86
 python-dotenv==1.0.1
 pandas==2.2.2
 numpy==1.26.4
-pyarrow==16.1.0
-duckdb==1.0.0
 polars==0.20.31
 lightgbm==4.3.0
 Flask==2.2.5
@@ -20,7 +18,6 @@ tqdm==4.67.1
 python-binance==1.0.16
 google-cloud-storage==2.11.0
 requests==2.32.4
-pyarrow==14.0.1
 python-dateutil>=2.8.2
 beautifulsoup4==4.12.2
 pytest==8.3.2


### PR DESCRIPTION
## Summary

- remove duplicate/conflicting PyArrow and DuckDB pins from the IBKR requirements include
- stop passing PyInstaller's `--specpath` option when a `.spec` file is used
- run the sample backtest as a real YAML block command so argparse receives `--source`
- fix the malformed and incorrectly indented inline Python in the backtest-summary workflow
- keep summary auto-commits on `main` only, so feature branches remain immutable

## Root causes

The shared requirements require `pyarrow>=17.0` and `duckdb>=1.1.3`, while the nested IBKR requirements overrode them with incompatible exact pins. The Windows packaging helper passed a makespec-only PyInstaller option with a spec file. The backtest workflow used YAML-folded backslashes, and the summary workflow had both malformed/column-zero heredocs and an overly broad branch write condition.

## Validation

On the current fix head, Python CI, the sample backtest, and Backtest Summary all pass. The Windows packaging change is limited to the confirmed PyInstaller invocation error and will run when this PR is merged because that workflow is intentionally `main`-only.

This is CI/build-only. It does not touch trading logic, leverage, live trading, promotion, or paper risk settings.