### PR TITLE
Add bounded v3 profitability exploration screen

### DIFF
--- a/.github/workflows/backtest-summary.yml
+++ b/.github/workflows/backtest-summary.yml
@@ -12,6 +12,7 @@ on:
       - "backtest/**"
       - "pyproject.toml"
       - "requirements*.txt"
+      - ".github/workflows/backtest-summary.yml"
 
 permissions:
   contents: write
@@ -62,79 +63,79 @@ jobs:
 
           if [ ${#files[@]} -eq 0 ]; then
             python - <<'PY'
-from pathlib import Path
+          from pathlib import Path
 
-Path("summary-latest.md").write_text(
-    """# Backtest Summary\n\n"
-    "_No backtest JSONs found in the repository (looking for `backtest*.json` or `report_*.json`)._\n"
-    "Push backtest artifacts or ensure a backtest script writes results to the repo root.\n"
-)
-PY
+          Path("summary-latest.md").write_text(
+              """# Backtest Summary\n\n"
+              "_No backtest JSONs found in the repository (looking for `backtest*.json` or `report_*.json`)._\n"
+              "Push backtest artifacts or ensure a backtest script writes results to the repo root.\n"
+          )
+          PY
           else
             # If your repo has scripts/summarize_backtests.py, use it; otherwise inline quick roll-up.
             if [ -f scripts/summarize_backtests.py ]; then
               python scripts/summarize_backtests.py | tee summary-latest.md
             else
               python - <<'PY' | tee summary-latest.md
-import glob
-import json
-import statistics as st
+          import glob
+          import json
+          import statistics as st
 
 
-def pct(value: float) -> str:
-    return f"{100 * value:.2f}%"
+          def pct(value: float) -> str:
+              return f"{100 * value:.2f}%"
 
 
-def eq_to_rets(equity):
-    return [
-        (equity[i] / equity[i - 1] - 1)
-        for i in range(1, len(equity))
-        if equity[i - 1] > 0
-    ]
+          def eq_to_rets(equity):
+              return [
+                  (equity[i] / equity[i - 1] - 1)
+                  for i in range(1, len(equity))
+                  if equity[i - 1] > 0
+              ]
 
 
-def mdd(equity):
-    peak = 0.0
-    max_dd = 0.0
-    for value in equity:
-        peak = max(peak, value)
-        if peak > 0:
-            max_dd = max(max_dd, 1 - value / peak)
-    return max_dd
+          def mdd(equity):
+              peak = 0.0
+              max_dd = 0.0
+              for value in equity:
+                  peak = max(peak, value)
+                  if peak > 0:
+                      max_dd = max(max_dd, 1 - value / peak)
+              return max_dd
 
 
-print("# Backtest Summary\n")
-for fp in sorted(glob.glob("backtest*.json") + glob.glob("report_*.json")):
-    try:
-        with open(fp) as f:
-            data = json.load(f)
-        results = data.get("results", data)
-        eq = (
-            results.get("equity_curve")
-            or results.get("equity")
-            or data.get("equity_series")
-            or []
-        )
-        if len(eq) < 2:
-            print(f"- {fp}: _no equity curve_\n")
-            continue
-        returns = eq_to_rets(eq)
-        total = eq[-1] / eq[0] - 1
-        ann = ((1 + (st.mean(returns) if returns else 0)) ** 252) - 1
-        drawdown = mdd(eq)
-        sharpe = (
-            (st.mean(returns) if returns else 0)
-            / (st.pstdev(returns) or 1e-12)
-            if returns
-            else 0.0
-        )
-        print(
-            f"## {fp}\nPnL: {pct(total)} | Annualized: {pct(ann)} | "
-            f"MaxDD: {pct(drawdown)} | Sharpe: {sharpe:.2f}\n"
-        )
-    except Exception as exc:
-        print(f"- {fp}: _error parsing: {exc}_\n")
-PY
+          print("# Backtest Summary\n")
+          for fp in sorted(glob.glob("backtest*.json") + glob.glob("report_*.json")):
+              try:
+                  with open(fp) as f:
+                      data = json.load(f)
+                  results = data.get("results", data)
+                  eq = (
+                      results.get("equity_curve")
+                      or results.get("equity")
+                      or data.get("equity_series")
+                      or []
+                  )
+                  if len(eq) < 2:
+                      print(f"- {fp}: _no equity curve_\n")
+                      continue
+                  returns = eq_to_rets(eq)
+                  total = eq[-1] / eq[0] - 1
+                  ann = ((1 + (st.mean(returns) if returns else 0)) ** 252) - 1
+                  drawdown = mdd(eq)
+                  sharpe = (
+                      (st.mean(returns) if returns else 0)
+                      / (st.pstdev(returns) or 1e-12)
+                      if returns
+                      else 0.0
+                  )
+                  print(
+                      f"## {fp}\nPnL: {pct(total)} | Annualized: {pct(ann)} | "
+                      f"MaxDD: {pct(drawdown)} | Sharpe: {sharpe:.2f}\n"
+                  )
+              except Exception as exc:
+                  print(f"- {fp}: _error parsing: {exc}_\n")
+          PY
             fi
           fi
 
@@ -145,7 +146,7 @@ PY
           path: summary-latest.md
 
       - name: Commit and push results
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           git config user.name "market-bot"

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -1,16 +1,29 @@
 name: Run Backtest
+
 on: [push]
+
+permissions:
+  contents: read
+
 jobs:
   backtest:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-      - run: ./install.sh
-      - run: source venv/bin/activate && python check_trading_readiness.py --fix-issues --verbose
-      - run: source venv/bin/activate && python scripts/run_backtest.py \
-          --source csv --path backtest/sample_data/sample_ohlcv.csv \
-          --strategy backtest.strategies.sma_filtered:generate_signals \
-          --strategy_args fast=8 slow=34 trend_fast=55 trend_slow=144 \
-          --fees_bps 5 --slip_bps 2 --tp_bps 60 --sl_bps 40 \
-          --max_bars 200 --notional 1.0 --risk_per_trade 0.01 \
-          --out_prefix artifacts/sample_backtest
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install sample-backtest dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "numpy>=1.26,<3" "pandas>=2.0,<3"
+      - name: Run sample backtest
+        run: |
+          python scripts/run_backtest.py \
+            --source csv --path backtest/sample_data/sample_ohlcv.csv \
+            --strategy backtest.strategies.sma_filtered:generate_signals \
+            --strategy_args fast=8 slow=34 trend_fast=55 trend_slow=144 \
+            --fees_bps 5 --slip_bps 2 --tp_bps 60 --sl_bps 40 \
+            --max_bars 200 --notional 1.0 --risk_per_trade 0.01 \
+            --out_prefix artifacts/sample_backtest

--- a/.github/workflows/momentum-v3-research.yml
+++ b/.github/workflows/momentum-v3-research.yml
@@ -176,7 +176,7 @@ jobs:
             --since 2023-01 \
             --until "$UNTIL"
 
-      - name: Run strict paper-only research controller
+      - name: Run non-promotable paper-only research snapshot
         run: |
           set -euo pipefail
           python scripts/run_v3_research_controller.py \
@@ -184,7 +184,6 @@ jobs:
             --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
             --min-aligned-bars 26280 \
             --max-data-age-days 45 \
-            --required-consecutive-passes 3 \
             --output-dir artifacts/momentum-v3/research-controller
 
       - name: Upload research state and reports

--- a/.github/workflows/v3-exploration.yml
+++ b/.github/workflows/v3-exploration.yml
@@ -1,0 +1,60 @@
+name: V3 Bounded Development Screen
+
+on:
+  # Manual only: this is a finite, pre-registered research screen rather than
+  # an unattended search process.
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: v3-bounded-development-screen-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  exploration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          # --until is exclusive and avoids treating the current partial month
+          # as historical evidence.
+          UNTIL="$(python - <<'PY'
+          from datetime import datetime, timezone
+          print(datetime.now(timezone.utc).strftime("%Y-%m"))
+          PY
+          )"
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-01 \
+            --until "$UNTIL"
+
+      - name: Run bounded development screen
+        run: |
+          set -euo pipefail
+          python scripts/run_v3_exploration.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --max-data-age-days 45 \
+            --output artifacts/momentum-v3/exploration/screen.json
+
+      - name: Upload development-screen artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: v3-bounded-development-screen-${{ github.run_number }}
+          path: artifacts/momentum-v3/exploration
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/momentum_v3_research_loop.md
+++ b/docs/momentum_v3_research_loop.md
@@ -1,12 +1,12 @@
-# Continuous v3 research loop
+# Bounded v3 research snapshots
 
-The v3 research phase is driven by the persistent controller at
-scripts/run_v3_research_controller.py. It is a bounded research process, not a
-promotion or trading process.
+The v3 research phase is driven by `scripts/run_v3_research_controller.py`. It
+is a bounded research process, not a promotion or trading process. It never
+sets `strategy_ready`, even if a candidate has positive historical results.
 
-Every iteration evaluates exactly two order notionals: $4,000 and $6,000.
-Readiness requires the same candidate to pass at both sizes. Each size must
-contain:
+Every snapshot evaluates exactly two order notionals: $4,000 and $6,000. A
+historical shortlist requires the same candidate to pass at both sizes. Each
+size must contain:
 
 - a profitable finite full-sample result at base and stress costs;
 - exactly three walk-forward folds, with finite results and at least five
@@ -16,18 +16,25 @@ contain:
 - visible evidence for the 1-day, 1-week, 1-month, and 1-year snapshots.
 
 The four horizon snapshots are evidence only. In particular, a positive 1-day
-result cannot make a candidate ready. The full sample, stress full sample,
-walk-forward medians, and confirmation holdout are the actual gate inputs.
-Stress costs must be finite, non-negative, and strictly higher than base costs.
+result cannot create a shortlist. Stress costs must be finite, non-negative,
+and strictly higher than base costs.
 
 The controller uses fixed candidate definitions from the research runner. It
 does not select a winner by taking the best result from an arbitrary search
-space. A code or cost/configuration change changes the experiment signature and
-resets the readiness streak. The controller also requires the same candidate
-to pass at both sizes on three distinct data vintages before recording
-strategy_ready. These vintages are deliberately treated as repeated evidence,
-not as independent proof; a human must still review the reports and holdout
-before any promotion decision.
+space. A code or cost/configuration change changes the experiment signature.
+
+## Overlap protection and manual confirmation
+
+The final-year historical holdout rolls forward each month. Consecutive monthly
+windows therefore share most of their data and cannot be counted as independent
+confirmation. The controller deliberately does **not** accumulate readiness
+streaks, permit forced reruns, or report `strategy_ready`.
+
+If a bounded development screen creates a shortlist, an operator must manually
+freeze one candidate and a new confirmation process must evaluate only data
+observed after that freeze. Each counted confirmation cohort must be
+non-overlapping with every prior counted cohort. A previously viewed holdout is
+diagnostic only and is never recycled as fresh confirmation evidence.
 
 The output state is research metadata only. The controller never changes the
 active profile, stages a finalist, enables leverage, places paper or live
@@ -105,25 +112,17 @@ by default. It writes state.json, latest.json, and per-iteration reports under
 artifacts/momentum-v3/research-controller. An old state schema is discarded
 rather than trusted.
 
-## Unchanged data and bounded polling
+## Unchanged data
 
 When the input data, source files, and research configuration have not changed,
-the controller records a skip and does not rerun the backtest. Use --force only
-for a deliberate rerun. The --until-ready mode requires --max-iterations so an
-unattended process has a finite stop bound, for example:
-
-    python scripts/run_v3_research_controller.py \
-      --until-ready \
-      --max-iterations 30 \
-      --interval-hours 24 \
-      --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
-      --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
-      --output-dir artifacts/momentum-v3/research-controller
+the controller records a skip and does not rerun the backtest. It has no
+`--force` or `--until-ready` mode: repeated searches over unchanged history
+would create selection bias rather than new evidence.
 
 The monthly GitHub Actions workflow downloads completed Binance Vision months,
 restores the most recent successful research artifact when available, and
-uploads the new state and reports. Its token has only actions: read and
-contents: read permissions. Restore is optional; stale or incompatible state
-is never used as evidence.
+uploads the new state and reports. Its token has only `actions: read` and
+`contents: read` permissions. Restore is optional; stale or incompatible state
+is never used as evidence, and no restored artifact can claim readiness.
 
 Do not use this loop as permission to promote a model or start live trading.

--- a/docs/v3_bounded_exploration.md
+++ b/docs/v3_bounded_exploration.md
@@ -1,0 +1,37 @@
+# Bounded v3 development screen
+
+`scripts/run_v3_exploration.py` is a research-only screening tool for the
+adaptive BTC/ETH momentum-volatility model. It is separate from the continuous
+controller and cannot mark a strategy ready, alter the active paper profile,
+enable leverage, or place an order.
+
+## What it evaluates
+
+The suite contains exactly 12 named v3 configurations: the existing balanced,
+selective, and conservative variants plus nine pre-declared hypotheses for
+trend speed, volatility expansion, entry quality, leader selection, liquidity,
+edge, and exit handling. The source-defined suite is intentionally bounded;
+adding or removing candidates is a new experiment, not a continuation of the
+same evidence.
+
+Every candidate is evaluated at both $4,000 and $6,000 order notionals under
+the normal 10-bps fee plus 5-bps slippage costs and the higher 20-bps fee plus
+10-bps slippage stress costs. A development screen pass requires both sizes,
+positive base and stress development returns, positive median returns across
+three non-overlapping development folds, minimum entry counts, and no permanent
+halt or repeated kill-switch event.
+
+## Protected confirmation year
+
+The latest complete one-year period is deliberately excluded from every screen
+calculation and report. A development-screen pass is only a manually reviewed
+shortlist for a later frozen confirmation run; it is never a promotion result.
+The main controller's dual-size, stress, holdout, data-vintage, and manual
+promotion rules remain unchanged.
+
+## Manual run
+
+From GitHub Actions, choose **V3 Bounded Development Screen**, select the
+research branch containing the screen, and use **Run workflow**. The workflow
+downloads completed monthly Binance Vision data, uploads its report as an
+artifact, and has read-only repository permissions.

--- a/docs/v3_bounded_exploration.md
+++ b/docs/v3_bounded_exploration.md
@@ -26,8 +26,9 @@ halt or repeated kill-switch event.
 The latest complete one-year period is deliberately excluded from every screen
 calculation and report. A development-screen pass is only a manually reviewed
 shortlist for a later frozen confirmation run; it is never a promotion result.
-The main controller's dual-size, stress, holdout, data-vintage, and manual
-promotion rules remain unchanged.
+The controller does not count rolling historical data vintages as independent
+confirmation or set `strategy_ready`; confirmation must be manually frozen and
+use new, non-overlapping future data.
 
 ## Manual run
 

--- a/scripts/run_v3_exploration.py
+++ b/scripts/run_v3_exploration.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Bounded, research-only development screen for v3 candidates.
+
+The screen deliberately excludes the latest one-year confirmation period from
+every calculation. It can shortlist pre-registered candidates for a future,
+separate confirmation run, but it never marks a strategy ready, changes an
+active profile, enables leverage, or places an order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+try:
+    from scripts.momentum_context import load_context_events
+    from scripts.run_momentum_volatility_v3 import (
+        CONFIRMATION_HOLDOUT_BARS,
+        V3Config,
+        build_pair_features,
+        run_pair,
+    )
+    from scripts.run_v3_research_controller import (
+        DEFAULT_MAX_DATA_AGE_DAYS,
+        DEFAULT_MIN_ALIGNED_BARS,
+        validate_data,
+    )
+except ModuleNotFoundError:  # pragma: no cover - direct script fallback
+    from momentum_context import load_context_events
+    from run_momentum_volatility_v3 import (
+        CONFIRMATION_HOLDOUT_BARS,
+        V3Config,
+        build_pair_features,
+        run_pair,
+    )
+    from run_v3_research_controller import (
+        DEFAULT_MAX_DATA_AGE_DAYS,
+        DEFAULT_MIN_ALIGNED_BARS,
+        validate_data,
+    )
+
+
+SUITE_VERSION = "v3-bounded-development-screen-1"
+ORDER_NOTIONALS = (4_000.0, 6_000.0)
+BASE_COSTS = {"fees_bps": 10.0, "slippage_bps": 5.0}
+STRESS_COSTS = {"fees_bps": 20.0, "slippage_bps": 10.0}
+MIN_FULL_ENTRIES = 8
+MIN_FOLD_ENTRIES = 5
+MAX_CANDIDATES = 12
+
+
+def candidate_definitions() -> dict[str, V3Config]:
+    """Return a fixed, intentionally small candidate suite.
+
+    The suite is pre-declared in source so a run cannot adapt its search space
+    after observing the result. It contains the three current candidates and
+    nine distinct regime, entry, and exit hypotheses.
+    """
+
+    base = V3Config()
+    candidates = {
+        "balanced": replace(
+            base,
+            expansion_ratio=1.05,
+            min_vol_rank=0.25,
+            reduce_size_rank=0.75,
+            extreme_vol_rank=0.90,
+            trailing_stop_atr=2.5,
+            time_stop_bars=72,
+        ),
+        "selective": replace(
+            base,
+            expansion_ratio=1.10,
+            min_vol_rank=0.35,
+            reduce_size_rank=0.75,
+            extreme_vol_rank=0.90,
+            trailing_stop_atr=2.5,
+            time_stop_bars=72,
+        ),
+        "conservative": replace(
+            base,
+            expansion_ratio=1.10,
+            min_vol_rank=0.35,
+            reduce_size_rank=0.70,
+            extreme_vol_rank=0.85,
+            trailing_stop_atr=3.0,
+            time_stop_bars=96,
+            profit_lock_activation_atr=1.25,
+        ),
+        "early_expansion": replace(
+            base,
+            expansion_ratio=1.02,
+            min_vol_rank=0.20,
+            trailing_stop_atr=2.0,
+            time_stop_bars=48,
+        ),
+        "fast_trend": replace(
+            base,
+            fast_window=5,
+            slow_window=15,
+            breakout_lookback=16,
+            expansion_ratio=1.03,
+            min_vol_rank=0.20,
+            trailing_stop_atr=2.0,
+            time_stop_bars=48,
+        ),
+        "slow_trend": replace(
+            base,
+            fast_window=13,
+            slow_window=34,
+            breakout_lookback=24,
+            expansion_ratio=1.05,
+            min_vol_rank=0.25,
+            trailing_stop_atr=3.0,
+            time_stop_bars=96,
+        ),
+        "high_quality_entry": replace(
+            base,
+            expansion_ratio=1.08,
+            min_vol_rank=0.30,
+            entry_min_body_atr=0.65,
+            entry_volume_multiplier=1.25,
+            min_expected_edge_bps=10.0,
+            trailing_stop_atr=2.5,
+        ),
+        "strict_leader": replace(
+            base,
+            expansion_ratio=1.05,
+            min_vol_rank=0.25,
+            leader_min_score=0.10,
+            leader_margin=0.10,
+            trailing_stop_atr=2.5,
+        ),
+        "liquidity_strict": replace(
+            base,
+            expansion_ratio=1.05,
+            min_vol_rank=0.25,
+            min_context_volume_ratio=0.90,
+            entry_volume_multiplier=1.25,
+            trailing_stop_atr=2.5,
+        ),
+        "wide_trail": replace(
+            base,
+            expansion_ratio=1.05,
+            min_vol_rank=0.25,
+            hard_stop_atr=2.5,
+            trailing_stop_atr=3.5,
+            time_stop_bars=96,
+        ),
+        "tight_risk": replace(
+            base,
+            expansion_ratio=1.05,
+            min_vol_rank=0.25,
+            hard_stop_atr=1.5,
+            trailing_stop_atr=2.0,
+            time_stop_bars=48,
+        ),
+        "edge_strict": replace(
+            base,
+            expansion_ratio=1.05,
+            min_vol_rank=0.25,
+            expected_move_atr_multiple=1.20,
+            min_expected_edge_bps=12.0,
+            trailing_stop_atr=2.5,
+        ),
+    }
+    if len(candidates) != MAX_CANDIDATES:
+        raise RuntimeError("bounded exploration suite was modified unexpectedly")
+    return candidates
+
+
+def development_folds(length: int) -> tuple[int, list[tuple[int, int]]]:
+    """Create three non-overlapping folds before a protected final year."""
+
+    confirmation_start = length - CONFIRMATION_HOLDOUT_BARS
+    if confirmation_start <= 0:
+        raise ValueError("data must contain a protected one-year confirmation period")
+    screen_start = confirmation_start // 2
+    width = (confirmation_start - screen_start) // 3
+    if width < 24 * 30:
+        raise ValueError("not enough pre-confirmation data for three development folds")
+    folds = [
+        (screen_start, screen_start + width),
+        (screen_start + width, screen_start + 2 * width),
+        (screen_start + 2 * width, confirmation_start),
+    ]
+    if any(start >= end for start, end in folds):
+        raise ValueError("invalid development fold boundaries")
+    return confirmation_start, folds
+
+
+def _number(payload: Mapping[str, object], key: str) -> float:
+    try:
+        value = float(payload.get(key, math.nan))
+    except (TypeError, ValueError):
+        return math.nan
+    return value
+
+
+def _integer(payload: Mapping[str, object], key: str) -> int:
+    try:
+        value = int(payload.get(key, -1))
+    except (TypeError, ValueError):
+        return -1
+    return value
+
+
+def _result_reasons(
+    label: str,
+    result: Mapping[str, object],
+    *,
+    minimum_entries: int,
+    require_positive: bool,
+) -> list[str]:
+    reasons: list[str] = []
+    entries = _integer(result, "entries")
+    if entries < minimum_entries:
+        reasons.append(f"{label} has {entries} entries; {minimum_entries} required")
+    return_pct = _number(result, "return_pct")
+    if not math.isfinite(return_pct):
+        reasons.append(f"{label} return is not finite")
+    elif require_positive and return_pct <= 0:
+        reasons.append(f"{label} return is not positive")
+    if result.get("permanent_halt") is not False:
+        reasons.append(f"{label} has an invalid or permanent halt state")
+    kill_events = _integer(result, "kill_events")
+    if kill_events < 0:
+        reasons.append(f"{label} kill-switch count is invalid")
+    elif kill_events > 1:
+        reasons.append(f"{label} has repeated kill-switch events")
+    return reasons
+
+
+def _median_return(results: Sequence[Mapping[str, object]]) -> float:
+    values = [_number(result, "return_pct") for result in results]
+    if not values or not all(math.isfinite(value) for value in values):
+        return math.nan
+    return statistics.median(values)
+
+
+def screen_size(
+    pair: Sequence[Any],
+    config: V3Config,
+    feature_map: Mapping[str, Mapping[str, list[float]]],
+    *,
+    order_notional: float,
+    development_end: int,
+    folds: Sequence[tuple[int, int]],
+) -> dict[str, object]:
+    """Screen one candidate at one notional without touching final confirmation."""
+
+    base = run_pair(
+        pair,
+        initial_balance=75_000.0,
+        order_notional=order_notional,
+        fees_bps=BASE_COSTS["fees_bps"],
+        slippage_bps=BASE_COSTS["slippage_bps"],
+        config=config,
+        end_index=development_end,
+        feature_map=feature_map,
+    )
+    stress = run_pair(
+        pair,
+        initial_balance=75_000.0,
+        order_notional=order_notional,
+        fees_bps=STRESS_COSTS["fees_bps"],
+        slippage_bps=STRESS_COSTS["slippage_bps"],
+        config=config,
+        end_index=development_end,
+        feature_map=feature_map,
+    )
+    base_folds = [
+        run_pair(
+            pair,
+            initial_balance=75_000.0,
+            order_notional=order_notional,
+            fees_bps=BASE_COSTS["fees_bps"],
+            slippage_bps=BASE_COSTS["slippage_bps"],
+            config=config,
+            start_index=start,
+            end_index=end,
+            feature_map=feature_map,
+        )
+        for start, end in folds
+    ]
+    stress_folds = [
+        run_pair(
+            pair,
+            initial_balance=75_000.0,
+            order_notional=order_notional,
+            fees_bps=STRESS_COSTS["fees_bps"],
+            slippage_bps=STRESS_COSTS["slippage_bps"],
+            config=config,
+            start_index=start,
+            end_index=end,
+            feature_map=feature_map,
+        )
+        for start, end in folds
+    ]
+
+    reasons = _result_reasons(
+        "development base", base, minimum_entries=MIN_FULL_ENTRIES, require_positive=True
+    )
+    reasons.extend(
+        _result_reasons(
+            "development stress",
+            stress,
+            minimum_entries=MIN_FULL_ENTRIES,
+            require_positive=True,
+        )
+    )
+    for label, results in (("base fold", base_folds), ("stress fold", stress_folds)):
+        if len(results) != 3:
+            reasons.append(f"{label} count is not three")
+            continue
+        for index, result in enumerate(results, start=1):
+            reasons.extend(
+                _result_reasons(
+                    f"{label} {index}",
+                    result,
+                    minimum_entries=MIN_FOLD_ENTRIES,
+                    require_positive=False,
+                )
+            )
+
+    base_median = _median_return(base_folds)
+    stress_median = _median_return(stress_folds)
+    if not math.isfinite(base_median) or base_median <= 0:
+        reasons.append("base development-fold median is not positive and finite")
+    if not math.isfinite(stress_median) or stress_median <= 0:
+        reasons.append("stress development-fold median is not positive and finite")
+
+    return {
+        "screen_pass": not reasons,
+        "failure_reasons": reasons,
+        "base": base,
+        "stress": stress,
+        "base_folds": base_folds,
+        "stress_folds": stress_folds,
+        "base_fold_median_return_pct": base_median,
+        "stress_fold_median_return_pct": stress_median,
+    }
+
+
+def candidate_gate(size_reports: Mapping[str, Mapping[str, object]]) -> dict[str, object]:
+    """Require the same screen result at exactly $4,000 and $6,000."""
+
+    required = {"4000", "6000"}
+    reasons: list[str] = []
+    if set(size_reports) != required:
+        reasons.append("screen requires exactly $4,000 and $6,000 reports")
+    for size in sorted(required):
+        report = size_reports.get(size)
+        if not isinstance(report, Mapping) or report.get("screen_pass") is not True:
+            reasons.append(f"{chr(36)}{size} does not pass the development screen")
+    medians = [
+        _number(report, "stress_fold_median_return_pct")
+        for report in size_reports.values()
+        if isinstance(report, Mapping)
+    ]
+    max_drawdown = max(
+        (
+            _number(result, "max_drawdown_pct")
+            for report in size_reports.values()
+            if isinstance(report, Mapping)
+            for result in (report.get("base"), report.get("stress"))
+            if isinstance(result, Mapping)
+        ),
+        default=math.nan,
+    )
+    robust_score = min(medians) - 0.25 * max_drawdown if (
+        medians
+        and all(math.isfinite(value) for value in medians)
+        and math.isfinite(max_drawdown)
+    ) else math.nan
+    return {
+        "screen_pass": not reasons,
+        "failure_reasons": reasons,
+        "minimum_stress_fold_median_return_pct": min(medians) if medians else math.nan,
+        "maximum_development_drawdown_pct": max_drawdown,
+        "robust_rank_score": robust_score,
+        "eligible_for_promotion": False,
+        "future_confirmation_required": True,
+    }
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def run_exploration(
+    *,
+    btc_path: Path,
+    eth_path: Path,
+    output: Path,
+    context_path: Path | None = None,
+    max_data_age_days: float = DEFAULT_MAX_DATA_AGE_DAYS,
+) -> dict[str, object]:
+    """Run the fixed screen and save a research-only artifact."""
+
+    pair, data_quality = validate_data(
+        btc_path,
+        eth_path,
+        minimum_aligned_bars=DEFAULT_MIN_ALIGNED_BARS,
+        max_data_age_days=max_data_age_days,
+    )
+    development_end, folds = development_folds(len(pair))
+    context_events = load_context_events(context_path) if context_path else []
+    candidates = candidate_definitions()
+    results: list[dict[str, object]] = []
+
+    for name, config in candidates.items():
+        feature_map = build_pair_features(pair, config, context_events)
+        sizes = {
+            str(int(notional)): screen_size(
+                pair,
+                config,
+                feature_map,
+                order_notional=notional,
+                development_end=development_end,
+                folds=folds,
+            )
+            for notional in ORDER_NOTIONALS
+        }
+        gate = candidate_gate(sizes)
+        results.append(
+            {
+                "candidate": name,
+                "parameters": config.as_dict(),
+                "sizes": sizes,
+                "development_gate": gate,
+            }
+        )
+
+    results.sort(
+        key=lambda item: (
+            not bool(item["development_gate"]["screen_pass"]),
+            -float(item["development_gate"]["robust_rank_score"])
+            if item["development_gate"]["robust_rank_score"] is not None
+            else math.inf,
+            str(item["candidate"]),
+        )
+    )
+    shortlist = [
+        str(item["candidate"])
+        for item in results
+        if item["development_gate"]["screen_pass"] is True
+    ]
+    report = {
+        "schema_version": 1,
+        "suite_version": SUITE_VERSION,
+        "research_only": True,
+        "strategy_ready": False,
+        "active_profile_changed": False,
+        "paper_orders_placed": False,
+        "leverage_enabled": False,
+        "automatic_promotion": False,
+        "purpose": "development screening only",
+        "data_quality": data_quality,
+        "costs": {"base": BASE_COSTS, "stress": STRESS_COSTS},
+        "required_order_notionals": list(ORDER_NOTIONALS),
+        "context": {
+            "path": str(context_path) if context_path else None,
+            "events": len(context_events),
+            "as_of_only": True,
+            "neutral_when_missing": True,
+        },
+        "development_folds": [
+            {"start_index": start, "end_index": end} for start, end in folds
+        ],
+        "protected_confirmation_holdout": {
+            "start_index": development_end,
+            "end_index": len(pair),
+            "bars": len(pair) - development_end,
+            "evaluated": False,
+            "reason": "reserved for a later, separately frozen confirmation run",
+        },
+        "candidate_count": len(results),
+        "shortlist_for_manual_freeze_only": shortlist,
+        "candidates": results,
+    }
+    safe_report = _json_safe(report)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(safe_report, indent=2, sort_keys=True, allow_nan=False),
+        encoding="utf-8",
+    )
+    return safe_report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--context-csv", type=Path)
+    parser.add_argument(
+        "--max-data-age-days",
+        type=float,
+        default=DEFAULT_MAX_DATA_AGE_DAYS,
+    )
+    args = parser.parse_args()
+    report = run_exploration(
+        btc_path=args.btc_path,
+        eth_path=args.eth_path,
+        output=args.output,
+        context_path=args.context_csv,
+        max_data_age_days=args.max_data_age_days,
+    )
+    print(
+        json.dumps(
+            {
+                "candidate_count": report["candidate_count"],
+                "shortlist_for_manual_freeze_only": report[
+                    "shortlist_for_manual_freeze_only"
+                ],
+                "strategy_ready": False,
+                "output": str(args.output),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_v3_research_controller.py
+++ b/scripts/run_v3_research_controller.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Keep the v3 historical research loop running until it is ready.
+"""Run bounded v3 historical research without automatic readiness.
 
 This controller is deliberately research-only.  It runs the existing causal
 v3 backtest at the two requested order sizes, persists a small state file, and
@@ -7,10 +7,13 @@ returns to a waiting state when the data and code have not changed.  It never
 changes an active portfolio, stages a candidate, enables leverage, contacts a
 broker, or places an order.
 
-For a long-running local process use ``--until-ready``.  For a scheduler such
-as GitHub Actions, invoke the controller once per scheduled run; a new data
-fingerprint causes a fresh research iteration.  ``--force`` is available for
-deliberate reruns against unchanged inputs.
+Historical confirmation windows roll forward as new data arrives, so they
+overlap almost completely.  They cannot be counted as independent evidence.
+This controller therefore never sets ``strategy_ready`` or accumulates a
+readiness streak.  A historical pass is only a manual-freeze candidate for a
+separate confirmation process that must use newly observed, non-overlapping
+future data.  For a scheduler such as GitHub Actions, invoke the controller
+once per completed calendar month; unchanged inputs are skipped.
 """
 
 from __future__ import annotations
@@ -20,7 +23,6 @@ import hashlib
 import json
 import math
 import statistics
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -33,7 +35,7 @@ except ModuleNotFoundError:  # pragma: no cover - direct import fallback
     from run_momentum_volatility_v3 import align_pair, research
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 DEFAULT_MIN_CONFIRMATION_ENTRIES = 5
 DEFAULT_MAX_DATA_AGE_DAYS = 45.0
 REQUIRED_ORDER_SIZE_KEYS = frozenset({"4000", "6000"})
@@ -44,6 +46,23 @@ DEFAULT_MIN_ALIGNED_BARS = 3 * 365 * 24
 DEFAULT_ORDER_NOTIONALS = (4_000.0, 6_000.0)
 DEFAULT_MIN_FULL_ENTRIES = 8
 DEFAULT_MIN_FOLD_ENTRIES = 5
+
+
+def _fresh_state(*, migration_notice: str | None = None) -> dict[str, Any]:
+    """Return a fail-closed, non-promotable controller state."""
+
+    state: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "researching",
+        "strategy_ready": False,
+        "iterations_completed": 0,
+        "history": [],
+        "automatic_promotion": False,
+        "manual_frozen_confirmation_required": True,
+    }
+    if migration_notice:
+        state["migration_notice"] = migration_notice
+    return state
 
 
 def _utc_now() -> str:
@@ -64,14 +83,7 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
 
 def _read_state(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {
-            "schema_version": SCHEMA_VERSION,
-            "status": "researching",
-            "strategy_ready": False,
-            "iterations_completed": 0,
-            "consecutive_ready_passes": 0,
-            "history": [],
-        }
+        return _fresh_state()
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"research state must be a JSON object: {path}")
@@ -79,18 +91,12 @@ def _read_state(path: Path) -> dict[str, Any]:
         # Never trust readiness from an older state format. Reset to a clean
         # research state so an optional artifact restore cannot block the
         # monthly job or carry an old winner across changed gate semantics.
-        return {
-            "schema_version": SCHEMA_VERSION,
-            "status": "researching",
-            "strategy_ready": False,
-            "iterations_completed": 0,
-            "consecutive_ready_passes": 0,
-            "history": [],
-            "migration_notice": (
+        return _fresh_state(
+            migration_notice=(
                 f"discarded unsupported research state schema "
                 f"{payload.get('schema_version')!r}"
-            ),
-        }
+            )
+        )
     if not isinstance(payload.get("strategy_ready", False), bool):
         raise ValueError("research state strategy_ready must be boolean")
     if (
@@ -102,38 +108,17 @@ def _read_state(path: Path) -> dict[str, Any]:
     history = payload.get("history", [])
     if not isinstance(history, list):
         raise ValueError("research state history must be a list")
-    payload.setdefault("consecutive_ready_passes", 0)
-    payload.setdefault("last_ready_signature", None)
-    payload.setdefault("last_ready_experiment", None)
-    payload.setdefault("last_ready_candidates", [])
-    consecutive = payload["consecutive_ready_passes"]
-    if not isinstance(consecutive, int) or isinstance(consecutive, bool) or consecutive < 0:
-        raise ValueError("research state consecutive_ready_passes must be non-negative")
-    for field in ("last_ready_signature", "last_ready_experiment"):
-        if payload[field] is not None and not isinstance(payload[field], Mapping):
-            raise ValueError(f"research state {field} must be an object or null")
-    if (
-        not isinstance(payload["last_ready_candidates"], list)
-        or not all(isinstance(item, str) for item in payload["last_ready_candidates"])
-    ):
-        raise ValueError("research state last_ready_candidates must be a string list")
+    payload["automatic_promotion"] = False
+    payload["manual_frozen_confirmation_required"] = True
     if payload.get("strategy_ready"):
-        last_run = payload.get("last_run")
-        readiness = last_run.get("readiness") if isinstance(last_run, Mapping) else None
-        if (
-            not isinstance(last_run, Mapping)
-            or last_run.get("strategy_ready") is not True
-            or not isinstance(readiness, Mapping)
-            or readiness.get("strategy_ready") is not True
-        ):
-            # A cached flag without the complete evidence record is not
-            # sufficient to report readiness after an artifact restore.
-            payload["strategy_ready"] = False
-            payload["status"] = "researching"
-            payload["consecutive_ready_passes"] = 0
-            payload["last_ready_signature"] = None
-            payload["last_ready_experiment"] = None
-            payload["last_ready_candidates"] = []
+        # Even a complete artifact cannot establish readiness here because
+        # rolling historical confirmation periods overlap across iterations.
+        payload["strategy_ready"] = False
+        payload["status"] = "researching"
+        payload["migration_notice"] = (
+            "cleared cached readiness: overlapping historical confirmations "
+            "cannot establish strategy readiness"
+        )
     return payload
 
 
@@ -488,7 +473,13 @@ def evaluate_readiness(
     minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
     minimum_confirmation_entries: int = DEFAULT_MIN_CONFIRMATION_ENTRIES,
 ) -> dict[str, Any]:
-    """Require one candidate to pass the complete gate at exactly both sizes."""
+    """Evaluate the historical gate without authorizing promotion.
+
+    The candidate reports include a rolling final-year holdout.  That is useful
+    diagnostics, but later controller runs share most of the same bars.  A
+    historical pass can therefore only create a manual-freeze shortlist; it
+    must never become ``strategy_ready`` in this controller.
+    """
 
     normalized_reports = {str(size): report for size, report in reports.items()}
     global_reasons: list[str] = []
@@ -531,10 +522,18 @@ def evaluate_readiness(
     )
     if global_reasons:
         ready_candidates = []
+    historical_gate_pass = bool(ready_candidates)
     return {
-        "pass": bool(ready_candidates),
-        "strategy_ready": bool(ready_candidates),
+        "pass": historical_gate_pass,
+        "historical_gate_pass": historical_gate_pass,
+        "strategy_ready": False,
         "ready_candidates": ready_candidates,
+        "shortlist_for_manual_freeze_only": ready_candidates,
+        "promotion_blocker": (
+            "rolling historical confirmation windows overlap across data vintages; "
+            "a separately frozen manual confirmation on new, non-overlapping "
+            "future data is required"
+        ),
         "required_sizes": sorted(REQUIRED_ORDER_SIZE_KEYS),
         "common_candidates": sorted(common_candidates),
         "checks_by_size": checks_by_size,
@@ -543,7 +542,9 @@ def evaluate_readiness(
             "same_candidate_must_pass_all_required_sizes": True,
             "required_order_notionals": [4_000.0, 6_000.0],
             "required_confirmation_holdout": True,
-            "required_distinct_data_vintages": 3,
+            "overlapping_historical_vintages_count_as_confirmation": False,
+            "automatic_strategy_ready": False,
+            "manual_frozen_non_overlapping_confirmation_required": True,
             "leverage_allowed": False,
             "paper_promotion_is_not_automatic": True,
         },
@@ -641,8 +642,15 @@ def _run_iteration(
     finished_at = _utc_now()
     return {
         "schema_version": SCHEMA_VERSION,
-        "status": "ready" if readiness["strategy_ready"] else "researching",
-        "strategy_ready": bool(readiness["strategy_ready"]),
+        "status": (
+            "candidate_requires_manual_frozen_confirmation"
+            if readiness["historical_gate_pass"]
+            else "researching"
+        ),
+        "historical_gate_pass": bool(readiness["historical_gate_pass"]),
+        "strategy_ready": False,
+        "automatic_promotion": False,
+        "manual_frozen_confirmation_required": True,
         "iteration": iteration,
         "started_at": started_at,
         "finished_at": finished_at,
@@ -685,11 +693,6 @@ def run_controller(
     minimum_fold_entries: int = DEFAULT_MIN_FOLD_ENTRIES,
     minimum_confirmation_entries: int = DEFAULT_MIN_CONFIRMATION_ENTRIES,
     max_data_age_days: float | None = DEFAULT_MAX_DATA_AGE_DAYS,
-    required_consecutive_passes: int = 3,
-    until_ready: bool = False,
-    interval_hours: float = 24.0,
-    max_iterations: int = 0,
-    force: bool = False,
 ) -> dict[str, Any]:
     if len(order_notionals) != 2 or set(order_notionals) != {4_000.0, 6_000.0}:
         raise ValueError("the controller requires exactly $4,000 and $6,000 order notionals")
@@ -702,8 +705,6 @@ def run_controller(
         or minimum_confirmation_entries < 1
     ):
         raise ValueError("research minimums must be positive")
-    if required_consecutive_passes < 1:
-        raise ValueError("required_consecutive_passes must be positive")
     cost_values = (fees_bps, slippage_bps, stress_fees_bps, stress_slippage_bps)
     if not all(math.isfinite(value) and value >= 0 for value in cost_values):
         raise ValueError("cost assumptions must be finite and non-negative")
@@ -719,13 +720,6 @@ def run_controller(
         not math.isfinite(max_data_age_days) or max_data_age_days <= 0
     ):
         raise ValueError("max_data_age_days must be finite and positive")
-    if until_ready and max_iterations == 0:
-        raise ValueError("--until-ready requires a finite --max-iterations safety bound")
-    if until_ready and (not math.isfinite(interval_hours) or interval_hours < 0):
-        raise ValueError("interval_hours must be finite and non-negative")
-    if max_iterations < 0:
-        raise ValueError("max_iterations cannot be negative")
-
     btc_path = btc_path.resolve()
     eth_path = eth_path.resolve()
     context_path = context_path.resolve() if context_path else None
@@ -751,115 +745,89 @@ def run_controller(
         "minimum_fold_entries": minimum_fold_entries,
         "minimum_confirmation_entries": minimum_confirmation_entries,
         "max_data_age_days": max_data_age_days,
-        "required_consecutive_passes": required_consecutive_passes,
+        "automatic_strategy_ready": False,
+        "overlapping_historical_vintages_count_as_confirmation": False,
     }
 
     state = _read_state(state_path)
     source_fingerprint = _source_fingerprint()
-    iterations_this_call = 0
-    while True:
-        data_paths = (btc_path, eth_path) + ((context_path,) if context_path else ())
-        data_fingerprint = _data_fingerprint(data_paths)
-        signature = _signature(data_fingerprint, source_fingerprint, research_config)
-        if not force and state.get("last_signature") == signature:
-            state.update({
-                "schema_version": SCHEMA_VERSION,
-                "status": "ready" if state.get("strategy_ready") else "waiting_for_new_data",
-                "last_checked_at": _utc_now(),
-                "active_profile_changed": False,
-            })
-            _save_status(state_path, state)
-            if not until_ready:
-                return state
-            iterations_this_call += 1
-            if max_iterations and iterations_this_call >= max_iterations:
-                return state
-            time.sleep(interval_hours * 3600.0)
-            continue
-
-        iteration = int(state.get("iterations_completed", 0)) + 1
-        result = _run_iteration(
-            iteration=iteration,
-            btc_path=btc_path,
-            eth_path=eth_path,
-            output_dir=output_dir,
-            minimum_aligned_bars=minimum_aligned_bars,
-            order_notionals=order_notionals,
-            research_initial_balance=research_initial_balance,
-            fees_bps=fees_bps,
-            slippage_bps=slippage_bps,
-            stress_fees_bps=stress_fees_bps,
-            stress_slippage_bps=stress_slippage_bps,
-            horizon_initial_balance=horizon_initial_balance,
-            context_path=context_path,
-            minimum_full_entries=minimum_full_entries,
-            minimum_fold_entries=minimum_fold_entries,
-            minimum_confirmation_entries=minimum_confirmation_entries,
-            max_data_age_days=max_data_age_days,
-            research_config=research_config,
-            data_fingerprint=data_fingerprint,
-            source_fingerprint=source_fingerprint,
-        )
-        candidate_ready = bool(result["strategy_ready"])
-        ready_candidates = list(result["readiness"]["ready_candidates"])
-        experiment_signature = {"source": dict(source_fingerprint), "config": dict(research_config)}
-        previous_ready_signature = state.get("last_ready_signature")
-        same_data = previous_ready_signature == signature
-        same_experiment = state.get("last_ready_experiment") == experiment_signature
-        same_candidates = state.get("last_ready_candidates") == ready_candidates
-        if candidate_ready:
-            previous_count = int(state.get("consecutive_ready_passes", 0))
-            consecutive_ready_passes = (
-                previous_count + 1
-                if same_experiment and same_candidates and not same_data
-                else 1
-            )
-            state["last_ready_signature"] = signature
-            state["last_ready_experiment"] = experiment_signature
-            state["last_ready_candidates"] = ready_candidates
-        else:
-            consecutive_ready_passes = 0
-            state["last_ready_signature"] = None
-            state["last_ready_experiment"] = None
-            state["last_ready_candidates"] = []
-        strategy_ready = candidate_ready and consecutive_ready_passes >= required_consecutive_passes
-        result["candidate_ready"] = candidate_ready
-        result["strategy_ready"] = strategy_ready
-        result["consecutive_ready_passes"] = consecutive_ready_passes
-        result["required_consecutive_passes"] = required_consecutive_passes
-
+    data_paths = (btc_path, eth_path) + ((context_path,) if context_path else ())
+    data_fingerprint = _data_fingerprint(data_paths)
+    signature = _signature(data_fingerprint, source_fingerprint, research_config)
+    if state.get("last_signature") == signature:
         state.update({
             "schema_version": SCHEMA_VERSION,
-            "status": "ready" if strategy_ready else "candidate_for_review" if candidate_ready else "researching",
-            "strategy_ready": strategy_ready,
-            "iterations_completed": iteration,
+            "status": "waiting_for_new_data",
+            "strategy_ready": False,
             "last_checked_at": _utc_now(),
-            "last_run": result,
-            "last_signature": signature,
             "active_profile_changed": False,
-            "paper_orders_placed": False,
-            "leverage_enabled": False,
-            "consecutive_ready_passes": consecutive_ready_passes,
-        })
-        _append_history(state, {
-            "iteration": iteration,
-            "finished_at": result["finished_at"],
-            "data_end": result["data_quality"]["end"],
-            "data_signature": signature,
-            "candidate_ready": candidate_ready,
-            "strategy_ready": strategy_ready,
-            "consecutive_ready_passes": consecutive_ready_passes,
-            "ready_candidates": result["readiness"]["ready_candidates"],
-            "report_paths": result["report_paths"],
+            "automatic_promotion": False,
+            "manual_frozen_confirmation_required": True,
         })
         _save_status(state_path, state)
-        iterations_this_call += 1
-        force = False
-        if strategy_ready or not until_ready:
-            return state
-        if max_iterations and iterations_this_call >= max_iterations:
-            return state
-        time.sleep(interval_hours * 3600.0)
+        return state
+
+    iteration = int(state.get("iterations_completed", 0)) + 1
+    result = _run_iteration(
+        iteration=iteration,
+        btc_path=btc_path,
+        eth_path=eth_path,
+        output_dir=output_dir,
+        minimum_aligned_bars=minimum_aligned_bars,
+        order_notionals=order_notionals,
+        research_initial_balance=research_initial_balance,
+        fees_bps=fees_bps,
+        slippage_bps=slippage_bps,
+        stress_fees_bps=stress_fees_bps,
+        stress_slippage_bps=stress_slippage_bps,
+        horizon_initial_balance=horizon_initial_balance,
+        context_path=context_path,
+        minimum_full_entries=minimum_full_entries,
+        minimum_fold_entries=minimum_fold_entries,
+        minimum_confirmation_entries=minimum_confirmation_entries,
+        max_data_age_days=max_data_age_days,
+        research_config=research_config,
+        data_fingerprint=data_fingerprint,
+        source_fingerprint=source_fingerprint,
+    )
+    historical_gate_pass = bool(result["historical_gate_pass"])
+    result["candidate_ready"] = historical_gate_pass
+    result["strategy_ready"] = False
+    result["automatic_promotion"] = False
+    result["manual_frozen_confirmation_required"] = True
+
+    state.update({
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "candidate_requires_manual_frozen_confirmation"
+            if historical_gate_pass
+            else "researching"
+        ),
+        "strategy_ready": False,
+        "iterations_completed": iteration,
+        "last_checked_at": _utc_now(),
+        "last_run": result,
+        "last_signature": signature,
+        "active_profile_changed": False,
+        "paper_orders_placed": False,
+        "leverage_enabled": False,
+        "automatic_promotion": False,
+        "manual_frozen_confirmation_required": True,
+    })
+    _append_history(state, {
+        "iteration": iteration,
+        "finished_at": result["finished_at"],
+        "data_end": result["data_quality"]["end"],
+        "data_signature": signature,
+        "historical_gate_pass": historical_gate_pass,
+        "candidate_ready": historical_gate_pass,
+        "strategy_ready": False,
+        "automatic_promotion": False,
+        "ready_candidates": result["readiness"]["ready_candidates"],
+        "report_paths": result["report_paths"],
+    })
+    _save_status(state_path, state)
+    return state
 
 
 def main() -> int:
@@ -880,34 +848,6 @@ def main() -> int:
     parser.add_argument("--min-fold-entries", type=int, default=DEFAULT_MIN_FOLD_ENTRIES)
     parser.add_argument("--min-confirmation-entries", type=int, default=DEFAULT_MIN_CONFIRMATION_ENTRIES)
     parser.add_argument("--max-data-age-days", type=float, default=DEFAULT_MAX_DATA_AGE_DAYS)
-    parser.add_argument(
-        "--required-consecutive-passes",
-        type=int,
-        default=3,
-        help="distinct data vintages required before strategy_ready becomes true",
-    )
-    parser.add_argument(
-        "--until-ready",
-        action="store_true",
-        help="continue polling until the same candidate passes the required data vintages",
-    )
-    parser.add_argument(
-        "--interval-hours",
-        type=float,
-        default=24.0,
-        help="sleep between checks while --until-ready is active",
-    )
-    parser.add_argument(
-        "--max-iterations",
-        type=int,
-        default=0,
-        help="optional safety bound for one invocation; 0 means no bound",
-    )
-    parser.add_argument(
-        "--force",
-        action="store_true",
-        help="rerun even when the data and research code are unchanged",
-    )
     args = parser.parse_args()
     state = run_controller(
         btc_path=args.btc_path,
@@ -926,11 +866,6 @@ def main() -> int:
         minimum_fold_entries=args.min_fold_entries,
         minimum_confirmation_entries=args.min_confirmation_entries,
         max_data_age_days=args.max_data_age_days,
-        required_consecutive_passes=args.required_consecutive_passes,
-        until_ready=args.until_ready,
-        interval_hours=args.interval_hours,
-        max_iterations=args.max_iterations,
-        force=args.force,
     )
     print(
         json.dumps(

--- a/tests/test_v3_exploration.py
+++ b/tests/test_v3_exploration.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from scripts.run_momentum_volatility_v3 import CONFIRMATION_HOLDOUT_BARS
+from scripts.run_v3_exploration import (
+    MAX_CANDIDATES,
+    candidate_definitions,
+    candidate_gate,
+    development_folds,
+)
+
+
+def _size_report(*, passed: bool, median: float = 0.25) -> dict[str, object]:
+    return {
+        "screen_pass": passed,
+        "stress_fold_median_return_pct": median,
+        "base": {"max_drawdown_pct": 1.0},
+        "stress": {"max_drawdown_pct": 1.5},
+    }
+
+
+def test_exploration_suite_is_bounded_and_named() -> None:
+    candidates = candidate_definitions()
+    assert len(candidates) == MAX_CANDIDATES
+    assert {"balanced", "selective", "conservative"} <= set(candidates)
+
+
+def test_development_folds_do_not_touch_protected_final_year() -> None:
+    length = 4 * 365 * 24
+    protected_start, folds = development_folds(length)
+    assert protected_start == length - CONFIRMATION_HOLDOUT_BARS
+    assert len(folds) == 3
+    assert folds[-1][1] == protected_start
+    assert all(start < end <= protected_start for start, end in folds)
+
+
+def test_candidate_gate_requires_both_notionals_and_never_promotes() -> None:
+    gate = candidate_gate(
+        {"4000": _size_report(passed=True), "6000": _size_report(passed=True)}
+    )
+    assert gate["screen_pass"] is True
+    assert gate["eligible_for_promotion"] is False
+    assert gate["future_confirmation_required"] is True
+
+
+def test_candidate_gate_rejects_one_size_failure() -> None:
+    gate = candidate_gate(
+        {"4000": _size_report(passed=True), "6000": _size_report(passed=False)}
+    )
+    assert gate["screen_pass"] is False
+    assert any("$6000" in reason for reason in gate["failure_reasons"])

--- a/tests/test_v3_research_controller.py
+++ b/tests/test_v3_research_controller.py
@@ -94,12 +94,15 @@ def test_controller_requires_confirmation_holdout() -> None:
     assert "missing confirmation holdout" in result["failure_reasons"]
 
 
-def test_controller_requires_same_candidate_at_both_sizes() -> None:
+def test_controller_shortlists_same_candidate_at_both_sizes_without_promotion() -> None:
     candidate = _candidate()
     reports = {"4000": _report(candidate), "6000": _report(candidate)}
     result = evaluate_readiness(reports)
-    assert result["strategy_ready"] is True
+    assert result["historical_gate_pass"] is True
+    assert result["strategy_ready"] is False
     assert result["ready_candidates"] == ["balanced"]
+    assert result["shortlist_for_manual_freeze_only"] == ["balanced"]
+    assert result["rules"]["manual_frozen_non_overlapping_confirmation_required"] is True
 
 
 def test_readiness_rejects_missing_required_size() -> None:
@@ -203,6 +206,19 @@ def test_old_or_incomplete_state_cannot_report_ready(tmp_path) -> None:
     state = _read_state(path)
     assert state["schema_version"] == SCHEMA_VERSION
     assert state["strategy_ready"] is False
+
+
+def test_current_schema_state_cannot_restore_automatic_readiness(tmp_path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(
+        '{"schema_version": ' + str(SCHEMA_VERSION) + ', "strategy_ready": true, '
+        '"iterations_completed": 1, "history": []}',
+        encoding="utf-8",
+    )
+    state = _read_state(path)
+    assert state["strategy_ready"] is False
+    assert state["automatic_promotion"] is False
+    assert state["manual_frozen_confirmation_required"] is True
     path.write_text(
         '{"schema_version": 2, "strategy_ready": true, "iterations_completed": 1, '
         '"consecutive_ready_passes": 3, "history": []}',


### PR DESCRIPTION
## Summary

- add a fixed 12-candidate v3 development screen covering the current variants plus pre-declared trend, volatility, entry, leader, liquidity, edge, and exit hypotheses
- evaluate every candidate at both $4,000 and $6,000 notionals under the existing base and higher stress costs
- exclude the latest complete one-year period from all screening calculations so it remains protected for a later frozen confirmation run
- add a manual-only, read-only GitHub Actions workflow that downloads completed Binance Vision data and uploads a research artifact
- add regression tests and protocol documentation

## Research boundary

This is exploratory screening only. A screen pass is not a profitability claim, paper-ready result, or promotion result. The screen always emits `strategy_ready: false`; it cannot modify an active profile, change paper-risk settings, enable leverage, place live or paper orders, or promote automatically.

## Validation

- local Python syntax checks passed for the new script and tests
- GitHub CI is pending on this draft PR
- the manual workflow will be run only after CI passes and will be reviewed separately