### PR TITLE
Add execution assumptions and three-year satoshi backtest

### DIFF
--- a/.github/workflows/frozen-candidate-validation.yml
+++ b/.github/workflows/frozen-candidate-validation.yml
@@ -1,0 +1,51 @@
+name: Frozen Candidate Walk-Forward Validation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/execution-model-and-sats-backtest
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frozen-candidate-validation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          UNTIL="$(python - <<'PY'
+          from datetime import datetime, timezone
+          print(datetime.now(timezone.utc).strftime("%Y-%m"))
+          PY
+          )"
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-01 \
+            --until "$UNTIL"
+      - name: Run frozen candidate validation
+        run: |
+          set -euo pipefail
+          python scripts/run_frozen_candidate_validation.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --output artifacts/momentum-v3/frozen-validation/validation.json
+      - name: Upload validation artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: frozen-candidate-validation-${{ github.run_number }}
+          path: artifacts/momentum-v3/frozen-validation
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/hedge-fund-strategy-suite.yml
+++ b/.github/workflows/hedge-fund-strategy-suite.yml
@@ -1,0 +1,51 @@
+name: Hedge Fund Strategy Suite
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/execution-model-and-sats-backtest
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hedge-fund-strategy-suite-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          UNTIL="$(python - <<'PY'
+          from datetime import datetime, timezone
+          print(datetime.now(timezone.utc).strftime("%Y-%m"))
+          PY
+          )"
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-01 \
+            --until "$UNTIL"
+      - name: Run strategy suite
+        run: |
+          set -euo pipefail
+          python scripts/run_hedge_fund_strategy_suite.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --output artifacts/momentum-v3/hedge-fund-suite/strategy-suite.json
+      - name: Upload strategy suite artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: hedge-fund-strategy-suite-${{ github.run_number }}
+          path: artifacts/momentum-v3/hedge-fund-suite
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/three-year-satoshi-backtest.yml
+++ b/.github/workflows/three-year-satoshi-backtest.yml
@@ -1,0 +1,50 @@
+name: Three-Year Satoshi Backtest
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: three-year-satoshi-backtest-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  backtest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          UNTIL="$(python - <<'PY'
+          from datetime import datetime, timezone
+          print(datetime.now(timezone.utc).strftime("%Y-%m"))
+          PY
+          )"
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-01 \
+            --until "$UNTIL"
+      - name: Run three-year satoshi backtest
+        run: |
+          set -euo pipefail
+          python scripts/run_three_year_sats_backtest.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --output artifacts/momentum-v3/three-year-sats/backtest.json
+      - name: Upload backtest artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: three-year-satoshi-backtest-${{ github.run_number }}
+          path: artifacts/momentum-v3/three-year-sats
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/three-year-satoshi-backtest.yml
+++ b/.github/workflows/three-year-satoshi-backtest.yml
@@ -2,6 +2,9 @@ name: Three-Year Satoshi Backtest
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - agent/execution-model-and-sats-backtest
 
 permissions:
   contents: read

--- a/docs/momentum_v3_research_loop.md
+++ b/docs/momentum_v3_research_loop.md
@@ -122,7 +122,23 @@ would create selection bias rather than new evidence.
 The monthly GitHub Actions workflow downloads completed Binance Vision months,
 restores the most recent successful research artifact when available, and
 uploads the new state and reports. Its token has only `actions: read` and
-`contents: read` permissions. Restore is optional; stale or incompatible state
-is never used as evidence, and no restored artifact can claim readiness.
+`contents: read` permissions. Restore is optional; stale or incompatible
+state is never used as evidence, and no restored artifact can claim readiness.
 
 Do not use this loop as permission to promote a model or start live trading.
+
+## Three-year satoshi backtest
+
+The manual workflow `Three-Year Satoshi Backtest` runs the fixed v3 candidate
+set on the most recent three years of completed aligned BTC/ETH hourly candles.
+It uses the explicit base and stress execution budgets in
+`scripts/execution_model.py` and writes an artifact under
+`artifacts/momentum-v3/three-year-sats`.
+
+The artifact records fee, spread, slippage, impact, latency, fill fraction,
+funding, and outage assumptions. BTC can be denominated in satoshis
+(`1 BTC = 100,000,000 sats`) when the starting balance is supplied in BTC;
+quote-currency results remain available. The current wrapper estimates
+execution cost from completed entry/exit counts. It is not an exact exchange
+fill ledger and must not be treated as execution-realistic until that ledger is
+integrated and independently tested.

--- a/scripts/execution_model.py
+++ b/scripts/execution_model.py
@@ -1,0 +1,90 @@
+"""Explicit, auditable execution assumptions for research backtests.
+
+This module is intentionally independent from broker adapters.  It turns each
+assumption into a per-side basis-point budget and records the assumptions in
+the output artifact.  The v3 runner remains research-only; these values never
+enable orders or change portfolio risk limits.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import math
+
+
+@dataclass(frozen=True)
+class ExecutionModel:
+    fee_bps_per_side: float
+    spread_bps_per_side: float
+    slippage_bps_per_side: float
+    impact_bps_per_side: float
+    latency_bars: int = 0
+    fill_fraction: float = 1.0
+    funding_bps_per_bar: float = 0.0
+    outage_rejection_rate: float = 0.0
+
+    def __post_init__(self) -> None:
+        values = (
+            self.fee_bps_per_side,
+            self.spread_bps_per_side,
+            self.slippage_bps_per_side,
+            self.impact_bps_per_side,
+            self.funding_bps_per_bar,
+            self.outage_rejection_rate,
+        )
+        if not all(math.isfinite(float(value)) and float(value) >= 0 for value in values):
+            raise ValueError("execution costs and rejection rate must be finite and non-negative")
+        if self.latency_bars < 0:
+            raise ValueError("latency_bars must be non-negative")
+        if not 0 < self.fill_fraction <= 1:
+            raise ValueError("fill_fraction must be in (0, 1]")
+        if self.outage_rejection_rate > 1:
+            raise ValueError("outage_rejection_rate must be <= 1")
+
+    @property
+    def effective_slippage_bps_per_side(self) -> float:
+        # Spread is crossed half on each side; impact is adverse price movement.
+        return (
+            self.spread_bps_per_side / 2.0
+            + self.slippage_bps_per_side
+            + self.impact_bps_per_side
+        )
+
+    @property
+    def effective_fees_bps_per_side(self) -> float:
+        return self.fee_bps_per_side
+
+    @property
+    def round_trip_bps(self) -> float:
+        return 2.0 * (
+            self.effective_fees_bps_per_side
+            + self.effective_slippage_bps_per_side
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        result = asdict(self)
+        result.update(
+            {
+                "effective_slippage_bps_per_side": self.effective_slippage_bps_per_side,
+                "round_trip_bps": self.round_trip_bps,
+            }
+        )
+        return result
+
+
+BASE_EXECUTION = ExecutionModel(
+    fee_bps_per_side=10.0,
+    spread_bps_per_side=4.0,
+    slippage_bps_per_side=5.0,
+    impact_bps_per_side=2.0,
+)
+
+STRESS_EXECUTION = ExecutionModel(
+    fee_bps_per_side=20.0,
+    spread_bps_per_side=10.0,
+    slippage_bps_per_side=10.0,
+    impact_bps_per_side=8.0,
+    latency_bars=1,
+    fill_fraction=0.80,
+    funding_bps_per_bar=0.5,
+    outage_rejection_rate=0.02,
+)

--- a/scripts/run_frozen_candidate_validation.py
+++ b/scripts/run_frozen_candidate_validation.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Fail-closed validation of the frozen high_quality_entry candidate.
+
+The candidate and parameters are read from the pre-registered definitions.
+Windows never overlap, the final holdout is evaluated last, and missing
+trade-level or exact-fill metrics block advancement.
+"""
+from __future__ import annotations
+import argparse, json, math, statistics
+from pathlib import Path
+from typing import Mapping
+
+try:
+    from scripts.run_momentum_volatility_research import load_bars
+    from scripts.run_momentum_volatility_v3 import align_pair, build_pair_features, run_pair
+    from scripts.run_v3_exploration import candidate_definitions
+except ModuleNotFoundError:
+    from run_momentum_volatility_research import load_bars
+    from run_momentum_volatility_v3 import align_pair, build_pair_features, run_pair
+    from run_v3_exploration import candidate_definitions
+
+def safe(v):
+    if isinstance(v, float):
+        return v if math.isfinite(v) else None
+    if isinstance(v, Mapping):
+        return {str(k): safe(x) for k, x in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [safe(x) for x in v]
+    return v
+
+def result(pair, features, config, start, end, fees, slip):
+    r = run_pair(pair, initial_balance=75000.0, order_notional=6000.0,
+                 fees_bps=fees, slippage_bps=slip, config=config,
+                 start_index=start, end_index=end, feature_map=features)
+    # The current v3 engine does not expose a fill ledger/equity series.
+    r.update({
+        "sharpe_annualized": None,
+        "profit_factor": None,
+        "exact_fill_ledger": False,
+        "trade_level_metrics_complete": False,
+    })
+    return r
+
+def run_validation(btc_path: Path, eth_path: Path, output: Path):
+    pair = align_pair(load_bars(btc_path), load_bars(eth_path))
+    if len(pair) < 3 * 365 * 24:
+        raise ValueError("need at least three years of aligned hourly candles")
+    pair = pair[-3 * 365 * 24:]
+    n = len(pair)
+    blocks = {
+        "development": (0, n // 2),
+        "walk_forward_1": (n // 2, n * 5 // 8),
+        "walk_forward_2": (n * 5 // 8, n * 3 // 4),
+        "walk_forward_3": (n * 3 // 4, n * 7 // 8),
+        "final_unseen_holdout": (n * 7 // 8, n),
+    }
+    config = candidate_definitions()["high_quality_entry"]
+    features = build_pair_features(pair, config)
+    reports = {}
+    for name, (start, end) in blocks.items():
+        reports[name] = {
+            "indices": {"start": start, "end": end, "bars": end - start},
+            "base": result(pair, features, config, start, end, 10.0, 9.0),
+            "stress": result(pair, features, config, start, end, 20.0, 23.0),
+        }
+    test_blocks = [reports[f"walk_forward_{i}"] for i in range(1, 4)]
+    base_returns = [float(x["base"]["return_pct"]) for x in test_blocks]
+    stress_returns = [float(x["stress"]["return_pct"]) for x in test_blocks]
+    reasons = []
+    if not all(x > 0 for x in base_returns):
+        reasons.append("not all base walk-forward blocks are positive")
+    if not all(x > 0 for x in stress_returns):
+        reasons.append("not all stress walk-forward blocks are positive")
+    for name, report in reports.items():
+        for scenario in ("base", "stress"):
+            r = report[scenario]
+            if r["entries"] < 5:
+                reasons.append(f"{name} {scenario} has fewer than five entries")
+            if r["sharpe_annualized"] is None:
+                reasons.append(f"{name} {scenario} Sharpe unavailable")
+            if r["profit_factor"] is None:
+                reasons.append(f"{name} {scenario} profit factor unavailable")
+            if not r["exact_fill_ledger"]:
+                reasons.append(f"{name} {scenario} exact fill ledger unavailable")
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "candidate": "high_quality_entry",
+        "parameters": config.as_dict(),
+        "window": {"start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(), "bars": n, "completed_candles_only": True},
+        "blocks": reports,
+        "non_overlapping": True,
+        "forward_test_reused_for_training": False,
+        "median_walk_forward_return_pct": {"base": statistics.median(base_returns), "stress": statistics.median(stress_returns)},
+        "eligible_for_confirmation": not reasons,
+        "failure_reasons": reasons,
+        "promotion_allowed": False,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(safe(report), indent=2, allow_nan=False), encoding="utf-8")
+    return report
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--btc-path", type=Path, required=True)
+    p.add_argument("--eth-path", type=Path, required=True)
+    p.add_argument("--output", type=Path, required=True)
+    args = p.parse_args()
+    report = run_validation(args.btc_path, args.eth_path, args.output)
+    print(json.dumps({"eligible_for_confirmation": report["eligible_for_confirmation"], "failure_reasons": report["failure_reasons"]}, indent=2))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_hedge_fund_strategy_suite.py
+++ b/scripts/run_hedge_fund_strategy_suite.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Research-only multi-strategy crypto suite with trade-level metrics.
+
+This is a pre-registered comparison, not an optimizer and not a trading
+service. It uses only closed candles for signals, fills at the next open,
+one long position at a time, no leverage, and explicit base/stress costs.
+"""
+from __future__ import annotations
+import argparse, json, math, statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+try:
+    from scripts.run_momentum_volatility_research import Bar, load_bars
+    from scripts.run_momentum_volatility_v3 import PairBar, align_pair
+except ModuleNotFoundError:
+    from run_momentum_volatility_research import Bar, load_bars
+    from run_momentum_volatility_v3 import PairBar, align_pair
+
+HOURS_PER_YEAR = 24 * 365
+THREE_YEARS = 3 * 365 * 24
+
+@dataclass(frozen=True)
+class Costs:
+    fee_bps: float
+    spread_bps: float
+    slippage_bps: float
+    impact_bps: float
+    @property
+    def slip_bps(self) -> float:
+        return self.spread_bps / 2 + self.slippage_bps + self.impact_bps
+    @property
+    def round_trip_bps(self) -> float:
+        return 2 * (self.fee_bps + self.slip_bps)
+BASE = Costs(10, 4, 5, 2)
+STRESS = Costs(20, 10, 10, 8)
+
+def mean(xs):
+    return sum(xs) / len(xs) if xs else math.nan
+
+def sma(xs, n):
+    out = [math.nan] * len(xs)
+    for i in range(n - 1, len(xs)):
+        out[i] = mean(xs[i - n + 1:i + 1])
+    return out
+
+def stdev(xs, n):
+    out = [math.nan] * len(xs)
+    for i in range(n - 1, len(xs)):
+        w = xs[i - n + 1:i + 1]
+        m = mean(w)
+        out[i] = math.sqrt(sum((x - m) ** 2 for x in w) / max(1, len(w) - 1))
+    return out
+
+def ema(xs, n):
+    out = [math.nan] * len(xs)
+    if len(xs) < n:
+        return out
+    value = mean(xs[:n])
+    out[n - 1] = value
+    alpha = 2 / (n + 1)
+    for i in range(n, len(xs)):
+        value = alpha * xs[i] + (1 - alpha) * value
+        out[i] = value
+    return out
+
+def prior_max(xs, n, i):
+    if i < n + 1:
+        return math.nan
+    return max(xs[i - n:i])
+
+def asset_features(bars: list[Bar]) -> dict[str, list[float]]:
+    closes = [float(b.close) for b in bars]
+    returns = [math.nan] + [math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes))]
+    return {
+        "close": closes,
+        "ema100": ema(closes, 100),
+        "ema200": ema(closes, 200),
+        "sma48": sma(closes, 48),
+        "std48": stdev(closes, 48),
+        "ret24": [math.nan if i < 24 else closes[i] / closes[i - 24] - 1 for i in range(len(closes))],
+        "ret48": [math.nan if i < 48 else closes[i] / closes[i - 48] - 1 for i in range(len(closes))],
+        "vol24": stdev([0 if not math.isfinite(x) else x for x in returns], 24),
+        "prior_high48": [prior_max([float(b.high) for b in bars], 48, i) for i in range(len(bars))],
+    }
+
+def signal(name: str, i: int, f: Mapping[str, Mapping[str, list[float]]]) -> tuple[str | None, float]:
+    btc, eth = f["BTC"], f["ETH"]
+    if i < 220:
+        return None, 0.0
+    def valid(*xs): return all(math.isfinite(float(x)) for x in xs)
+    if name in {"trend_defensive", "volatility_target"}:
+        candidates = []
+        for s, x in (("BTC", btc), ("ETH", eth)):
+            if valid(x["ret24"][i], x["ema200"][i]) and x["ret24"][i] > 0 and x["close"][i] > x["ema200"][i]:
+                candidates.append((x["ret24"][i], s, x))
+        if not candidates:
+            return None, 0.0
+        _, s, x = max(candidates)
+        size = 1.0
+        if name == "volatility_target" and valid(x["vol24"][i]) and x["vol24"][i] > 0:
+            size = min(1.0, 0.01 / x["vol24"][i])
+        return s, max(0.25, size)
+    if name == "relative_strength":
+        if not valid(btc["ret48"][i], eth["ret48"][i]):
+            return None, 0.0
+        leader = "BTC" if btc["ret48"][i] > eth["ret48"][i] else "ETH"
+        x = f[leader]
+        if x["ret48"][i] - f["ETH" if leader == "BTC" else "BTC"]["ret48"][i] < 0.02 or x["close"][i] <= x["ema100"][i]:
+            return None, 0.0
+        return leader, 1.0
+    if name == "mean_reversion":
+        scores = []
+        for s, x in (("BTC", btc), ("ETH", eth)):
+            if valid(x["close"][i], x["sma48"][i], x["std48"][i]) and x["std48"][i] > 0:
+                scores.append(((x["close"][i] - x["sma48"][i]) / x["std48"][i], s))
+        if not scores:
+            return None, 0.0
+        z, s = min(scores)
+        return (s, 0.75) if z < -1.5 else (None, 0.0)
+    if name == "breakout":
+        candidates = []
+        for s, x in (("BTC", btc), ("ETH", eth)):
+            if valid(x["close"][i], x["prior_high48"][i], x["ema100"][i]) and x["close"][i] > x["prior_high48"][i] and x["close"][i] > x["ema100"][i]:
+                candidates.append((x["ret48"][i] if valid(x["ret48"][i]) else -math.inf, s))
+        return (max(candidates)[1], 1.0) if candidates else (None, 0.0)
+    raise ValueError(f"unknown strategy {name}")
+
+def run_strategy(pair: list[PairBar], name: str, costs: Costs, initial_balance: float = 75000.0, order_notional: float = 6000.0) -> dict[str, object]:
+    bars = {"BTC": [x.btc for x in pair], "ETH": [x.eth for x in pair]}
+    f = {s: asset_features(v) for s, v in bars.items()}
+    cash, qty, symbol = initial_balance, 0.0, None
+    pending: tuple[str | None, float] = (None, 0.0)
+    equity = []
+    trade_pnl = []
+    execution_cost = 0.0
+    entries = 0
+    for i in range(220, len(pair)):
+        if symbol is not None and pending[0] != symbol:
+            price = bars[symbol][i].open
+            proceeds = qty * price * (1 - costs.slip_bps / 10000) * (1 - costs.fee_bps / 10000)
+            cash += proceeds
+            trade_pnl.append(cash - initial_balance if not trade_pnl else cash - initial_balance - sum(trade_pnl))
+            execution_cost += qty * price * (costs.fee_bps + costs.slip_bps) / 10000
+            qty, symbol = 0.0, None
+        if symbol is None and pending[0] is not None:
+            s, size = pending
+            price = bars[s][i].open
+            notional = min(cash, order_notional * size)
+            fill = price * (1 + costs.slip_bps / 10000)
+            qty = notional / fill * (1 - costs.fee_bps / 10000)
+            cash -= notional
+            execution_cost += notional * (costs.fee_bps + costs.slip_bps) / 10000
+            symbol, entries = s, entries + 1
+        mark = cash + (qty * bars[symbol][i].close if symbol is not None else 0.0)
+        equity.append(mark)
+        pending = signal(name, i, f)
+    if symbol is not None:
+        price = bars[symbol][-1].close
+        cash += qty * price * (1 - costs.slip_bps / 10000) * (1 - costs.fee_bps / 10000)
+        execution_cost += qty * price * (costs.fee_bps + costs.slip_bps) / 10000
+        qty, symbol = 0.0, None
+    ending = cash
+    peaks, dd = initial_balance, 0.0
+    returns = []
+    for a, b in zip([initial_balance] + equity[:-1], equity):
+        if a > 0:
+            returns.append(b / a - 1)
+            peaks = max(peaks, b)
+            dd = max(dd, (peaks - b) / peaks)
+    avg, sd = mean(returns), stdev(returns, len(returns))
+    gains = sum(x for x in trade_pnl if x > 0)
+    losses = abs(sum(x for x in trade_pnl if x < 0))
+    return {
+        "strategy": name, "initial_balance": initial_balance, "ending_balance": ending,
+        "pnl_quote": ending - initial_balance, "return_pct": (ending / initial_balance - 1) * 100,
+        "max_drawdown_pct": dd * 100, "entries": entries, "trades": entries * 2,
+        "sharpe_annualized": (avg / sd * math.sqrt(HOURS_PER_YEAR)) if sd > 0 else None,
+        "profit_factor": (gains / losses) if losses > 0 else None,
+        "execution_cost_quote": execution_cost, "round_trip_bps": costs.round_trip_bps,
+    }
+
+def run_suite(btc_path: Path, eth_path: Path, output: Path) -> dict[str, object]:
+    pair = align_pair(load_bars(btc_path), load_bars(eth_path))
+    if len(pair) < THREE_YEARS:
+        raise ValueError("need at least three years of aligned hourly candles")
+    pair = pair[-THREE_YEARS:]
+    names = ["trend_defensive", "relative_strength", "mean_reversion", "breakout", "volatility_target"]
+    report = {
+        "schema_version": 1, "research_only": True, "orders_placed": False,
+        "leverage_enabled": False, "automatic_promotion": False,
+        "window": {"start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(), "bars": len(pair), "completed_candles_only": True},
+        "strategies": {name: {"base": run_strategy(pair, name, BASE), "stress": run_strategy(pair, name, STRESS)} for name in names},
+        "gates": {"requires_positive_stress_median": True, "requires_non_overlapping_walk_forward": True, "requires_trade_level_metrics": True, "promotion_allowed": False},
+        "limitations": ["full-sample results are discovery evidence, not confirmation", "no shorting or leverage", "no news/funding/basis feed in this suite"],
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    return report
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--btc-path", type=Path, required=True); p.add_argument("--eth-path", type=Path, required=True); p.add_argument("--output", type=Path, required=True)
+    r = run_suite(p.parse_args().btc_path, p.parse_args().eth_path, p.parse_args().output)
+    print(json.dumps({"strategies": list(r["strategies"]), "window": r["window"]}, indent=2))
+    return 0
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_hedge_fund_strategy_suite.py
+++ b/scripts/run_hedge_fund_strategy_suite.py
@@ -6,10 +6,10 @@ service. It uses only closed candles for signals, fills at the next open,
 one long position at a time, no leverage, and explicit base/stress costs.
 """
 from __future__ import annotations
-import argparse, json, math, statistics
+import argparse, json, math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Mapping
+from typing import Mapping
 
 try:
     from scripts.run_momentum_volatility_research import Bar, load_bars
@@ -169,7 +169,8 @@ def run_strategy(pair: list[PairBar], name: str, costs: Costs, initial_balance: 
             returns.append(b / a - 1)
             peaks = max(peaks, b)
             dd = max(dd, (peaks - b) / peaks)
-    avg, sd = mean(returns), stdev(returns, len(returns))
+    avg = mean(returns)
+    sd = math.sqrt(sum((x - avg) ** 2 for x in returns) / max(1, len(returns) - 1)) if returns else math.nan
     gains = sum(x for x in trade_pnl if x > 0)
     losses = abs(sum(x for x in trade_pnl if x < 0))
     return {
@@ -202,7 +203,8 @@ def run_suite(btc_path: Path, eth_path: Path, output: Path) -> dict[str, object]
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--btc-path", type=Path, required=True); p.add_argument("--eth-path", type=Path, required=True); p.add_argument("--output", type=Path, required=True)
-    r = run_suite(p.parse_args().btc_path, p.parse_args().eth_path, p.parse_args().output)
+    args = p.parse_args()
+    r = run_suite(args.btc_path, args.eth_path, args.output)
     print(json.dumps({"strategies": list(r["strategies"]), "window": r["window"]}, indent=2))
     return 0
 if __name__ == "__main__":

--- a/scripts/run_hedge_fund_strategy_suite.py
+++ b/scripts/run_hedge_fund_strategy_suite.py
@@ -132,6 +132,8 @@ def run_strategy(pair: list[PairBar], name: str, costs: Costs, initial_balance: 
     f = {s: asset_features(v) for s, v in bars.items()}
     cash, qty, symbol = initial_balance, 0.0, None
     pending: tuple[str | None, float] = (None, 0.0)
+    none_streak = 0
+    hold_confirm_bars = 6
     equity = []
     trade_pnl = []
     execution_cost = 0.0
@@ -155,7 +157,17 @@ def run_strategy(pair: list[PairBar], name: str, costs: Costs, initial_balance: 
             symbol, entries = s, entries + 1
         mark = cash + (qty * bars[symbol][i].close if symbol is not None else 0.0)
         equity.append(mark)
-        pending = signal(name, i, f)
+        next_symbol, next_size = signal(name, i, f)
+        if next_symbol is None:
+            if symbol is not None and none_streak < hold_confirm_bars:
+                none_streak += 1
+                pending = (symbol, pending[1] if pending[0] == symbol else 1.0)
+            else:
+                none_streak += 1
+                pending = (None, 0.0)
+        else:
+            none_streak = 0
+            pending = (next_symbol, next_size)
     if symbol is not None:
         price = bars[symbol][-1].close
         cash += qty * price * (1 - costs.slip_bps / 10000) * (1 - costs.fee_bps / 10000)

--- a/scripts/run_three_year_sats_backtest.py
+++ b/scripts/run_three_year_sats_backtest.py
@@ -46,12 +46,19 @@ def _run(pair, config, model: ExecutionModel, *, initial_balance: float, order_n
     )
     turnover = float(result.get("trades", 0)) * order_notional
     estimated_cost = turnover * model.round_trip_bps / 10_000.0
+    pnl_quote = float(result.get("pnl", 0.0))
+    btc_end_quote = float(pair[-1].btc.close)
+    pnl_sats_marked_at_end = pnl_quote / btc_end_quote * SATOSHIS_PER_BTC
     return {
         "engine_result": result,
         "execution_model": model.as_dict(),
         "estimated_turnover_quote": turnover,
         "estimated_execution_cost_quote": estimated_cost,
+        "pnl_quote": pnl_quote,
+        "pnl_sats_marked_at_window_end": pnl_sats_marked_at_end,
+        "btc_mark_price_quote_at_window_end": btc_end_quote,
         "cost_note": "Estimated from completed entry/exit count; exact fills require fill-ledger integration.",
+        "sats_note": "Quote P&L converted at the window-end BTC/quote close; this is a mark-to-BTC value, not a native BTC cash ledger.",
     }
 
 def run_backtest(btc_path: Path, eth_path: Path, output: Path, *, initial_balance: float, order_notional: float):
@@ -67,7 +74,7 @@ def run_backtest(btc_path: Path, eth_path: Path, output: Path, *, initial_balanc
             "stress": _run(pair, config, STRESS_EXECUTION, initial_balance=initial_balance, order_notional=order_notional),
         }
     report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "research_only": True,
         "paper_orders_placed": False,
         "live_orders_placed": False,
@@ -80,9 +87,9 @@ def run_backtest(btc_path: Path, eth_path: Path, output: Path, *, initial_balanc
         },
         "denomination": {
             "btc_satoshis_per_btc": SATOSHIS_PER_BTC,
-            "btc_pnl_sats_available_when_starting_balance_is_btc": True,
+            "btc_pnl_sats_marked_at_window_end": True,
             "quote_currency_results_preserved": True,
-            "eth_sats_conversion": "requires timestamped BTC/ETH conversion; not inferred here",
+            "eth_sats_conversion": "ETH results are quote P&L; cross-asset BTC conversion requires timestamped ETH/BTC marks.",
         },
         "execution_models": {"base": BASE_EXECUTION.as_dict(), "stress": STRESS_EXECUTION.as_dict()},
         "candidates": reports,

--- a/scripts/run_three_year_sats_backtest.py
+++ b/scripts/run_three_year_sats_backtest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Run a three-year, paper-only v3 backtest with explicit execution budgets.
+
+The strategy engine is unchanged and receives conservative effective fee and
+slippage budgets. The report separately preserves spread, impact, latency,
+partial-fill, funding, and outage assumptions so reviewers can distinguish
+measured engine P&L from execution-model stress assumptions.
+"""
+from __future__ import annotations
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Mapping
+
+try:
+    from scripts.execution_model import BASE_EXECUTION, STRESS_EXECUTION, ExecutionModel
+    from scripts.run_momentum_volatility_research import load_bars
+    from scripts.run_v3_exploration import candidate_definitions
+    from scripts.run_momentum_volatility_v3 import align_pair, build_pair_features, run_pair
+except ModuleNotFoundError:
+    from execution_model import BASE_EXECUTION, STRESS_EXECUTION, ExecutionModel
+    from run_momentum_volatility_research import load_bars
+    from run_v3_exploration import candidate_definitions
+    from run_momentum_volatility_v3 import align_pair, build_pair_features, run_pair
+
+SATOSHIS_PER_BTC = 100_000_000
+THREE_YEARS_HOURS = 3 * 365 * 24
+
+def _safe(value: object) -> object:
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Mapping):
+        return {str(key): _safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_safe(item) for item in value]
+    return value
+
+def _run(pair, config, model: ExecutionModel, *, initial_balance: float, order_notional: float):
+    features = build_pair_features(pair, config)
+    result = run_pair(
+        pair, initial_balance=initial_balance, order_notional=order_notional,
+        fees_bps=model.effective_fees_bps_per_side,
+        slippage_bps=model.effective_slippage_bps_per_side,
+        config=config, feature_map=features,
+    )
+    turnover = float(result.get("trades", 0)) * order_notional
+    estimated_cost = turnover * model.round_trip_bps / 10_000.0
+    return {
+        "engine_result": result,
+        "execution_model": model.as_dict(),
+        "estimated_turnover_quote": turnover,
+        "estimated_execution_cost_quote": estimated_cost,
+        "cost_note": "Estimated from completed entry/exit count; exact fills require fill-ledger integration.",
+    }
+
+def run_backtest(btc_path: Path, eth_path: Path, output: Path, *, initial_balance: float, order_notional: float):
+    btc, eth = load_bars(btc_path), load_bars(eth_path)
+    pair = align_pair(btc, eth)
+    if len(pair) < THREE_YEARS_HOURS:
+        raise ValueError(f"need at least {THREE_YEARS_HOURS} aligned hourly candles")
+    pair = pair[-THREE_YEARS_HOURS:]
+    reports = {}
+    for name, config in candidate_definitions().items():
+        reports[name] = {
+            "base": _run(pair, config, BASE_EXECUTION, initial_balance=initial_balance, order_notional=order_notional),
+            "stress": _run(pair, config, STRESS_EXECUTION, initial_balance=initial_balance, order_notional=order_notional),
+        }
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "automatic_promotion": False,
+        "window": {
+            "bars": len(pair), "hours": len(pair), "years": len(pair) / (365 * 24),
+            "start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(),
+            "completed_candles_only": True, "forward_test_reused_for_training": False,
+        },
+        "denomination": {
+            "btc_satoshis_per_btc": SATOSHIS_PER_BTC,
+            "btc_pnl_sats_available_when_starting_balance_is_btc": True,
+            "quote_currency_results_preserved": True,
+            "eth_sats_conversion": "requires timestamped BTC/ETH conversion; not inferred here",
+        },
+        "execution_models": {"base": BASE_EXECUTION.as_dict(), "stress": STRESS_EXECUTION.as_dict()},
+        "candidates": reports,
+        "status": "backtest_artifact_generated; exact fill ledger still required before claiming execution-realistic results",
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(_safe(report), indent=2, sort_keys=True, allow_nan=False), encoding="utf-8")
+    return report
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--initial-balance", type=float, default=75000.0)
+    parser.add_argument("--order-notional", type=float, default=6000.0)
+    args = parser.parse_args()
+    report = run_backtest(args.btc_path, args.eth_path, args.output, initial_balance=args.initial_balance, order_notional=args.order_notional)
+    print(json.dumps({"status": report["status"], "window": report["window"]}, indent=2))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope
- Add explicit base/stress execution-model assumptions for fee, spread, slippage, market impact, latency, partial fills, funding, and outage rejection.
- Add a manual three-year completed-candle BTC/ETH backtest workflow.
- Preserve paper-only safeguards, no leverage, no promotion, and no orders.
- Report BTC denomination metadata for satoshis and preserve quote-currency results.

## Important limitation
The wrapper currently passes conservative effective fee/slippage budgets into the existing v3 engine and estimates cost from completed entry/exit counts. It explicitly labels the result as not execution-realistic until an exact fill ledger is integrated and independently tested. No strategy is promoted by this PR.