### PR TITLE
Add gated multi-asset rollout infrastructure

### DIFF
--- a/.github/workflows/multi-asset-rollout.yml
+++ b/.github/workflows/multi-asset-rollout.yml
@@ -1,0 +1,31 @@
+name: Multi-Asset Rollout Policy
+
+on:
+  pull_request:
+    paths:
+      - "config/multi_asset_rollout.json"
+      - "scripts/evaluate_multi_asset_rollout.py"
+      - "tests/test_multi_asset_rollout.py"
+      - ".github/workflows/multi-asset-rollout.yml"
+  workflow_dispatch:
+    inputs:
+      equity:
+        description: "Settled account equity used for policy evaluation"
+        required: false
+        default: "25000"
+
+permissions:
+  contents: read
+
+jobs:
+  policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run policy tests
+        run: python -m unittest -v tests/test_multi_asset_rollout.py
+      - name: Evaluate default milestone
+        run: python scripts/evaluate_multi_asset_rollout.py --equity "${{ inputs.equity || '25000' }}"

--- a/MULTI_ASSET_ROLLOUT.md
+++ b/MULTI_ASSET_ROLLOUT.md
@@ -1,16 +1,24 @@
-# Multi-Asset Rollout Policy
+# Multi-Asset Rollout and Capital Growth Policy
 
-This infrastructure defines the account-growth milestone without turning it into an
-automatic live-trading switch.
+This infrastructure defines the account-growth milestone ladder without turning
+any milestone into an automatic live-trading switch.
+
+## Milestone ladder
+
+`$25,000 → $50,000 → $100,000 → $250,000 → $500,000 → $1,000,000`
+
+The planner uses settled equity and reports the next target, dollar gap,
+contribution-only months, and an optional reconciliation of starting equity,
+deposits, and verified net P&L. It deliberately does not forecast returns.
 
 ## Operating rules
 
 - The policy is permanently `paper_research_only`; live orders are not authorized.
 - Global leverage remains disabled.
-- The $25,000 trigger uses settled equity. Crossing it makes sleeves eligible for
-  paper validation only.
-- A $5,000 buffer separates the milestone from the operating floor. The evaluator
-  reports the buffer, but does not authorize live trading.
+- Reaching $25,000 makes sleeves eligible for paper validation only.
+- Each higher milestone is a capital-accounting checkpoint, not permission to
+  increase risk.
+- A $5,000 buffer separates the first milestone from the operating floor.
 - Each sleeve has independent capital and risk limits. There is no cross-margining
   or shared unbounded risk pool.
 - Options are defined-risk only; futures are micro-contract research only; forex
@@ -22,17 +30,20 @@ automatic live-trading switch.
 ## Usage
 
 ```bash
-python scripts/evaluate_multi_asset_rollout.py --equity 25000
+python scripts/evaluate_multi_asset_rollout.py \
+  --equity 15000 \
+  --monthly-contribution 500 \
+  --starting-equity 5000 \
+  --net-contributions 10000 \
+  --verified-net-pnl 0
+
 python -m unittest -v tests/test_multi_asset_rollout.py
 ```
 
-The output is an auditable JSON decision. It never returns a live-activation
-authorization. Research runners should consume this decision before creating
-any instrument-specific paper experiment.
+The output is an auditable JSON decision. It never returns live-activation
+authorization.
 
-## Required next adapters
-
-Before any paper sleeve is considered for promotion, add and test:
+## Required adapters before any promotion
 
 1. stock/ETF corporate-action and borrow-cost handling;
 2. option chain, Greeks, implied-volatility, assignment, and max-loss ledger;
@@ -40,5 +51,5 @@ Before any paper sleeve is considered for promotion, add and test:
 4. forex spread, rollover, session, and currency-conversion model;
 5. broker fill reconciliation against the immutable execution ledger.
 
-The milestone is therefore a workflow gate, not a claim that a strategy is
-profitable or that a broker/regulator permits a particular trading pattern.
+The ladder is therefore a planning and governance framework, not a claim that a
+strategy is profitable or that any broker/regulator permits a particular pattern.

--- a/MULTI_ASSET_ROLLOUT.md
+++ b/MULTI_ASSET_ROLLOUT.md
@@ -1,0 +1,44 @@
+# Multi-Asset Rollout Policy
+
+This infrastructure defines the account-growth milestone without turning it into an
+automatic live-trading switch.
+
+## Operating rules
+
+- The policy is permanently `paper_research_only`; live orders are not authorized.
+- Global leverage remains disabled.
+- The $25,000 trigger uses settled equity. Crossing it makes sleeves eligible for
+  paper validation only.
+- A $5,000 buffer separates the milestone from the operating floor. The evaluator
+  reports the buffer, but does not authorize live trading.
+- Each sleeve has independent capital and risk limits. There is no cross-margining
+  or shared unbounded risk pool.
+- Options are defined-risk only; futures are micro-contract research only; forex
+  leverage is disabled.
+- Promotion requires positive net performance after costs, positive median
+  walk-forward performance, stress drawdown compliance, at least 30 trades, no
+  leakage, an exact fill ledger, and explicit human approval.
+
+## Usage
+
+```bash
+python scripts/evaluate_multi_asset_rollout.py --equity 25000
+python -m unittest -v tests/test_multi_asset_rollout.py
+```
+
+The output is an auditable JSON decision. It never returns a live-activation
+authorization. Research runners should consume this decision before creating
+any instrument-specific paper experiment.
+
+## Required next adapters
+
+Before any paper sleeve is considered for promotion, add and test:
+
+1. stock/ETF corporate-action and borrow-cost handling;
+2. option chain, Greeks, implied-volatility, assignment, and max-loss ledger;
+3. futures contract specifications, expiry/roll, margin, and liquidation model;
+4. forex spread, rollover, session, and currency-conversion model;
+5. broker fill reconciliation against the immutable execution ledger.
+
+The milestone is therefore a workflow gate, not a claim that a strategy is
+profitable or that a broker/regulator permits a particular trading pattern.

--- a/config/multi_asset_rollout.json
+++ b/config/multi_asset_rollout.json
@@ -1,8 +1,10 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "mode": "paper_research_only",
   "live_trading_enabled": false,
   "leverage_enabled": false,
+  "risk_profile": "moderate_aggressive",
+  "risk_sizing_mode": "adaptive_with_hard_caps",
   "growth_milestones_usd": [25000, 50000, 100000, 250000, 500000, 1000000],
   "target_monthly_growth_usd": 1000,
   "target_months": 24,
@@ -16,37 +18,10 @@
   "minimum_paper_trades": 30,
   "minimum_paper_weeks": 6,
   "sleeves": {
-    "stocks_etf": {
-      "status": "research_only",
-      "priority": 1,
-      "max_capital_pct": 15.0,
-      "allowed_order_types": ["market", "limit"],
-      "requirements": ["settled_equity_milestone", "paper_validation", "cost_reconciliation"]
-    },
-    "options_defined_risk": {
-      "status": "research_only",
-      "priority": 2,
-      "max_capital_pct": 5.0,
-      "allowed_order_types": ["limit"],
-      "naked_short_options": false,
-      "requirements": ["paper_validation", "greeks_and_iv_model", "max_loss_known", "cost_reconciliation"]
-    },
-    "futures_micro": {
-      "status": "research_only",
-      "priority": 3,
-      "max_capital_pct": 5.0,
-      "allowed_order_types": ["limit"],
-      "contract_size": "micro_only",
-      "requirements": ["paper_validation", "margin_model", "liquidation_model", "cost_reconciliation"]
-    },
-    "forex": {
-      "status": "research_only",
-      "priority": 4,
-      "max_capital_pct": 5.0,
-      "allowed_order_types": ["limit"],
-      "leverage_allowed": false,
-      "requirements": ["paper_validation", "spread_model", "rollover_model", "cost_reconciliation"]
-    }
+    "stocks_etf": {"status": "research_only", "priority": 1, "max_capital_pct": 15.0, "allowed_order_types": ["market", "limit"], "requirements": ["settled_equity_milestone", "paper_validation", "cost_reconciliation"]},
+    "options_defined_risk": {"status": "research_only", "priority": 2, "max_capital_pct": 5.0, "allowed_order_types": ["limit"], "naked_short_options": false, "requirements": ["paper_validation", "greeks_and_iv_model", "max_loss_known", "cost_reconciliation"]},
+    "futures_micro": {"status": "research_only", "priority": 3, "max_capital_pct": 5.0, "allowed_order_types": ["limit"], "contract_size": "micro_only", "requirements": ["paper_validation", "margin_model", "liquidation_model", "cost_reconciliation"]},
+    "forex": {"status": "research_only", "priority": 4, "max_capital_pct": 5.0, "allowed_order_types": ["limit"], "leverage_allowed": false, "requirements": ["paper_validation", "spread_model", "rollover_model", "cost_reconciliation"]}
   },
   "promotion_gates": {
     "positive_net_return_after_costs": true,

--- a/config/multi_asset_rollout.json
+++ b/config/multi_asset_rollout.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "mode": "paper_research_only",
+  "live_trading_enabled": false,
+  "leverage_enabled": false,
+  "account_growth_milestone_usd": 25000,
+  "activation_buffer_usd": 5000,
+  "milestone_uses_settled_equity": true,
+  "max_portfolio_drawdown_pct": 2.0,
+  "max_open_risk_pct": 1.0,
+  "max_sleeve_risk_pct": 0.5,
+  "promotion_requires_human_approval": true,
+  "minimum_paper_trades": 30,
+  "minimum_paper_weeks": 6,
+  "sleeves": {
+    "stocks_etf": {
+      "status": "research_only",
+      "priority": 1,
+      "max_capital_pct": 15.0,
+      "allowed_order_types": ["market", "limit"],
+      "requirements": ["settled_equity_milestone", "paper_validation", "cost_reconciliation"]
+    },
+    "options_defined_risk": {
+      "status": "research_only",
+      "priority": 2,
+      "max_capital_pct": 5.0,
+      "allowed_order_types": ["limit"],
+      "naked_short_options": false,
+      "requirements": ["paper_validation", "greeks_and_iv_model", "max_loss_known", "cost_reconciliation"]
+    },
+    "futures_micro": {
+      "status": "research_only",
+      "priority": 3,
+      "max_capital_pct": 5.0,
+      "allowed_order_types": ["limit"],
+      "contract_size": "micro_only",
+      "requirements": ["paper_validation", "margin_model", "liquidation_model", "cost_reconciliation"]
+    },
+    "forex": {
+      "status": "research_only",
+      "priority": 4,
+      "max_capital_pct": 5.0,
+      "allowed_order_types": ["limit"],
+      "leverage_allowed": false,
+      "requirements": ["paper_validation", "spread_model", "rollover_model", "cost_reconciliation"]
+    }
+  },
+  "promotion_gates": {
+    "positive_net_return_after_costs": true,
+    "positive_median_walk_forward_return": true,
+    "stress_drawdown_within_limit": true,
+    "minimum_trade_count": 30,
+    "no_data_leakage": true,
+    "exact_fill_ledger": true,
+    "human_approval": true
+  }
+}

--- a/config/multi_asset_rollout.json
+++ b/config/multi_asset_rollout.json
@@ -1,10 +1,34 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "mode": "paper_research_only",
   "live_trading_enabled": false,
   "leverage_enabled": false,
   "risk_profile": "moderate_aggressive",
   "risk_sizing_mode": "adaptive_with_hard_caps",
+  "max_leverage_multiple": 2.0,
+  "leverage_policy": {
+    "status": "paper_model_only",
+    "activation_requires_positive_window": true,
+    "positive_window": {
+      "minimum_observations": 20,
+      "minimum_net_return_after_costs_pct": 0.0,
+      "minimum_median_walk_forward_return_pct": 0.0,
+      "maximum_drawdown_pct": 1.0,
+      "requires_fresh_unseen_data": true
+    },
+    "entry": {
+      "signal_persistence_bars": 2,
+      "max_signal_age_bars": 1,
+      "late_entry_confirmation": true
+    },
+    "exit": {
+      "early_exit_on_signal_decay": true,
+      "early_exit_before_session_close": true,
+      "profit_lock_trigger_pct": 0.5,
+      "never_widen_stop": true
+    },
+    "requires_human_approval": true
+  },
   "growth_milestones_usd": [25000, 50000, 100000, 250000, 500000, 1000000],
   "target_monthly_growth_usd": 1000,
   "target_months": 24,

--- a/config/multi_asset_rollout.json
+++ b/config/multi_asset_rollout.json
@@ -1,9 +1,9 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "mode": "paper_research_only",
   "live_trading_enabled": false,
   "leverage_enabled": false,
-  "account_growth_milestone_usd": 25000,
+  "growth_milestones_usd": [25000, 50000, 100000, 250000, 500000, 1000000],
   "activation_buffer_usd": 5000,
   "milestone_uses_settled_equity": true,
   "max_portfolio_drawdown_pct": 2.0,

--- a/config/multi_asset_rollout.json
+++ b/config/multi_asset_rollout.json
@@ -1,9 +1,12 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "mode": "paper_research_only",
   "live_trading_enabled": false,
   "leverage_enabled": false,
   "growth_milestones_usd": [25000, 50000, 100000, 250000, 500000, 1000000],
+  "target_monthly_growth_usd": 1000,
+  "target_months": 24,
+  "growth_target_policy": "contributions_and_verified_net_pnl_only",
   "activation_buffer_usd": 5000,
   "milestone_uses_settled_equity": true,
   "max_portfolio_drawdown_pct": 2.0,

--- a/scripts/evaluate_multi_asset_rollout.py
+++ b/scripts/evaluate_multi_asset_rollout.py
@@ -24,6 +24,8 @@ def load_policy(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
     milestones = policy.get("growth_milestones_usd", [])
     if milestones != sorted(set(milestones)) or not milestones:
         raise ValueError("growth milestones must be unique and ascending")
+    if policy.get("target_monthly_growth_usd", 0) <= 0:
+        raise ValueError("monthly growth target must be positive")
     return policy
 
 
@@ -32,6 +34,7 @@ def growth_plan(equity: float, policy: dict[str, Any], *, monthly_contribution: 
                 verified_net_pnl: float = 0.0) -> dict[str, Any]:
     if equity < 0 or monthly_contribution < 0:
         raise ValueError("equity and contributions cannot be negative")
+    target = float(policy["target_monthly_growth_usd"])
     milestones = [float(value) for value in policy["growth_milestones_usd"]]
     reached = [value for value in milestones if equity >= value]
     current = reached[-1] if reached else 0.0
@@ -57,7 +60,9 @@ def growth_plan(equity: float, policy: dict[str, Any], *, monthly_contribution: 
         "current_milestone_usd": current,
         "next_milestone_usd": next_target,
         "gap_to_next_milestone_usd": gap,
-        "monthly_contribution_usd": round(monthly_contribution, 2),
+        "target_monthly_growth_usd": target,
+        "planned_monthly_contribution_usd": round(monthly_contribution, 2),
+        "verified_net_pnl_required_usd": round(max(target - monthly_contribution, 0.0), 2),
         "contribution_only_months_to_next": months,
         "return_assumptions_used": False,
         "reconciliation": reconciliation,

--- a/scripts/evaluate_multi_asset_rollout.py
+++ b/scripts/evaluate_multi_asset_rollout.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """Fail-closed milestone evaluator and capital-growth planner."""
 from __future__ import annotations
-
-import argparse
-import json
-import math
+import argparse, json, math
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +18,8 @@ def load_policy(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
         raise ValueError("live trading must be disabled")
     if policy.get("leverage_enabled") is not False:
         raise ValueError("global leverage must be disabled")
+    if float(policy.get("max_leverage_multiple", 0)) > 2.0:
+        raise ValueError("leverage cap cannot exceed 2x")
     milestones = policy.get("growth_milestones_usd", [])
     if milestones != sorted(set(milestones)) or not milestones:
         raise ValueError("growth milestones must be unique and ascending")
@@ -41,7 +40,6 @@ def growth_plan(equity: float, policy: dict[str, Any], *, monthly_contribution: 
     next_target = next((value for value in milestones if equity < value), None)
     gap = round(max(next_target - equity, 0.0), 2) if next_target else 0.0
     months = math.ceil(gap / monthly_contribution) if next_target and monthly_contribution else None
-
     reconciliation = None
     if starting_equity is not None:
         reconciled = starting_equity + net_contributions + verified_net_pnl
@@ -52,7 +50,6 @@ def growth_plan(equity: float, policy: dict[str, Any], *, monthly_contribution: 
             "reconciled_equity_usd": round(reconciled, 2),
             "unreconciled_delta_usd": round(equity - reconciled, 2),
         }
-
     return {
         "settled_equity_usd": round(equity, 2),
         "milestones_usd": milestones,
@@ -75,8 +72,7 @@ def evaluate(equity: float, policy: dict[str, Any], **planner_kwargs: Any) -> di
     buffer = float(policy["activation_buffer_usd"])
     milestone_reached = equity >= milestones[0]
     buffer_reached = equity >= milestones[0] + buffer
-
-    sleeves: dict[str, Any] = {}
+    sleeves = {}
     for name, config in sorted(policy["sleeves"].items(), key=lambda item: item[1]["priority"]):
         sleeves[name] = {
             "status": "paper_validation_eligible" if milestone_reached else "locked_below_milestone",
@@ -86,7 +82,6 @@ def evaluate(equity: float, policy: dict[str, Any], **planner_kwargs: Any) -> di
             "requires_human_approval": True,
             "requirements": list(config["requirements"]),
         }
-
     return {
         "mode": policy["mode"],
         "equity_usd": round(equity, 2),
@@ -99,6 +94,8 @@ def evaluate(equity: float, policy: dict[str, Any], **planner_kwargs: Any) -> di
         "research_only": True,
         "live_trading_authorized": False,
         "leverage_authorized": False,
+        "max_leverage_multiple": float(policy["max_leverage_multiple"]),
+        "leverage_policy": policy["leverage_policy"],
         "capital_growth_plan": growth_plan(equity, policy, **planner_kwargs),
         "portfolio_limits": {
             "max_drawdown_pct": policy["max_portfolio_drawdown_pct"],
@@ -119,14 +116,11 @@ def main() -> int:
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
-
-    result = evaluate(
-        args.equity, load_policy(args.config),
-        monthly_contribution=args.monthly_contribution,
-        starting_equity=args.starting_equity,
-        net_contributions=args.net_contributions,
-        verified_net_pnl=args.verified_net_pnl,
-    )
+    result = evaluate(args.equity, load_policy(args.config),
+                      monthly_contribution=args.monthly_contribution,
+                      starting_equity=args.starting_equity,
+                      net_contributions=args.net_contributions,
+                      verified_net_pnl=args.verified_net_pnl)
     rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
     if args.output:
         args.output.write_text(rendered, encoding="utf-8")

--- a/scripts/evaluate_multi_asset_rollout.py
+++ b/scripts/evaluate_multi_asset_rollout.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Fail-closed account-milestone and multi-asset rollout evaluator.
+
+This policy module is deliberately independent of broker adapters. It can only
+authorize research/paper validation; live activation is never returned.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = ROOT / "config" / "multi_asset_rollout.json"
+
+
+def load_policy(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        policy = json.load(handle)
+    if policy.get("mode") != "paper_research_only":
+        raise ValueError("rollout policy must remain paper_research_only")
+    if policy.get("live_trading_enabled") is not False:
+        raise ValueError("live trading must be disabled")
+    if policy.get("leverage_enabled") is not False:
+        raise ValueError("global leverage must be disabled")
+    return policy
+
+
+def evaluate(equity: float, policy: dict[str, Any]) -> dict[str, Any]:
+    milestone = float(policy["account_growth_milestone_usd"])
+    buffer = float(policy["activation_buffer_usd"])
+    settled = bool(policy["milestone_uses_settled_equity"])
+    milestone_reached = equity >= milestone
+    buffer_reached = equity >= milestone + buffer
+
+    sleeves: dict[str, Any] = {}
+    for name, config in sorted(
+        policy["sleeves"].items(), key=lambda item: item[1]["priority"]
+    ):
+        # Crossing the milestone starts research only. No sleeve is promoted here.
+        sleeves[name] = {
+            "status": "paper_validation_eligible"
+            if milestone_reached
+            else "locked_below_milestone",
+            "priority": config["priority"],
+            "max_capital_pct": config["max_capital_pct"],
+            "live_activation": False,
+            "requires_human_approval": True,
+            "requirements": list(config["requirements"]),
+        }
+
+    return {
+        "mode": policy["mode"],
+        "equity_usd": round(equity, 2),
+        "milestone_usd": milestone,
+        "buffer_usd": buffer,
+        "settled_equity_required": settled,
+        "milestone_reached": milestone_reached,
+        "buffer_reached": buffer_reached,
+        "research_only": True,
+        "live_trading_authorized": False,
+        "leverage_authorized": False,
+        "portfolio_limits": {
+            "max_drawdown_pct": policy["max_portfolio_drawdown_pct"],
+            "max_open_risk_pct": policy["max_open_risk_pct"],
+            "max_sleeve_risk_pct": policy["max_sleeve_risk_pct"],
+        },
+        "sleeves": sleeves,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--equity", type=float, required=True)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    result = evaluate(args.equity, load_policy(args.config))
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_multi_asset_rollout.py
+++ b/scripts/evaluate_multi_asset_rollout.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python3
-"""Fail-closed account-milestone and multi-asset rollout evaluator.
-
-This policy module is deliberately independent of broker adapters. It can only
-authorize research/paper validation; live activation is never returned.
-"""
+"""Fail-closed milestone evaluator and capital-growth planner."""
 from __future__ import annotations
 
 import argparse
 import json
+import math
 from pathlib import Path
 from typing import Any
-
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CONFIG = ROOT / "config" / "multi_asset_rollout.json"
@@ -25,25 +21,60 @@ def load_policy(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
         raise ValueError("live trading must be disabled")
     if policy.get("leverage_enabled") is not False:
         raise ValueError("global leverage must be disabled")
+    milestones = policy.get("growth_milestones_usd", [])
+    if milestones != sorted(set(milestones)) or not milestones:
+        raise ValueError("growth milestones must be unique and ascending")
     return policy
 
 
-def evaluate(equity: float, policy: dict[str, Any]) -> dict[str, Any]:
-    milestone = float(policy["account_growth_milestone_usd"])
+def growth_plan(equity: float, policy: dict[str, Any], *, monthly_contribution: float = 0.0,
+                starting_equity: float | None = None, net_contributions: float = 0.0,
+                verified_net_pnl: float = 0.0) -> dict[str, Any]:
+    if equity < 0 or monthly_contribution < 0:
+        raise ValueError("equity and contributions cannot be negative")
+    milestones = [float(value) for value in policy["growth_milestones_usd"]]
+    reached = [value for value in milestones if equity >= value]
+    current = reached[-1] if reached else 0.0
+    next_target = next((value for value in milestones if equity < value), None)
+    gap = round(max(next_target - equity, 0.0), 2) if next_target else 0.0
+    months = math.ceil(gap / monthly_contribution) if next_target and monthly_contribution else None
+
+    reconciliation = None
+    if starting_equity is not None:
+        reconciled = starting_equity + net_contributions + verified_net_pnl
+        reconciliation = {
+            "starting_equity_usd": round(starting_equity, 2),
+            "net_contributions_usd": round(net_contributions, 2),
+            "verified_net_pnl_usd": round(verified_net_pnl, 2),
+            "reconciled_equity_usd": round(reconciled, 2),
+            "unreconciled_delta_usd": round(equity - reconciled, 2),
+        }
+
+    return {
+        "settled_equity_usd": round(equity, 2),
+        "milestones_usd": milestones,
+        "reached_milestones_usd": reached,
+        "current_milestone_usd": current,
+        "next_milestone_usd": next_target,
+        "gap_to_next_milestone_usd": gap,
+        "monthly_contribution_usd": round(monthly_contribution, 2),
+        "contribution_only_months_to_next": months,
+        "return_assumptions_used": False,
+        "reconciliation": reconciliation,
+    }
+
+
+def evaluate(equity: float, policy: dict[str, Any], **planner_kwargs: Any) -> dict[str, Any]:
+    milestones = [float(value) for value in policy["growth_milestones_usd"]]
+    milestone = next((value for value in milestones if equity < value), milestones[-1])
     buffer = float(policy["activation_buffer_usd"])
-    settled = bool(policy["milestone_uses_settled_equity"])
-    milestone_reached = equity >= milestone
-    buffer_reached = equity >= milestone + buffer
+    milestone_reached = equity >= milestones[0]
+    buffer_reached = equity >= milestones[0] + buffer
 
     sleeves: dict[str, Any] = {}
-    for name, config in sorted(
-        policy["sleeves"].items(), key=lambda item: item[1]["priority"]
-    ):
-        # Crossing the milestone starts research only. No sleeve is promoted here.
+    for name, config in sorted(policy["sleeves"].items(), key=lambda item: item[1]["priority"]):
         sleeves[name] = {
-            "status": "paper_validation_eligible"
-            if milestone_reached
-            else "locked_below_milestone",
+            "status": "paper_validation_eligible" if milestone_reached else "locked_below_milestone",
             "priority": config["priority"],
             "max_capital_pct": config["max_capital_pct"],
             "live_activation": False,
@@ -55,13 +86,15 @@ def evaluate(equity: float, policy: dict[str, Any]) -> dict[str, Any]:
         "mode": policy["mode"],
         "equity_usd": round(equity, 2),
         "milestone_usd": milestone,
+        "growth_milestones_usd": milestones,
         "buffer_usd": buffer,
-        "settled_equity_required": settled,
+        "settled_equity_required": bool(policy["milestone_uses_settled_equity"]),
         "milestone_reached": milestone_reached,
         "buffer_reached": buffer_reached,
         "research_only": True,
         "live_trading_authorized": False,
         "leverage_authorized": False,
+        "capital_growth_plan": growth_plan(equity, policy, **planner_kwargs),
         "portfolio_limits": {
             "max_drawdown_pct": policy["max_portfolio_drawdown_pct"],
             "max_open_risk_pct": policy["max_open_risk_pct"],
@@ -74,11 +107,21 @@ def evaluate(equity: float, policy: dict[str, Any]) -> dict[str, Any]:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--equity", type=float, required=True)
+    parser.add_argument("--monthly-contribution", type=float, default=0.0)
+    parser.add_argument("--starting-equity", type=float)
+    parser.add_argument("--net-contributions", type=float, default=0.0)
+    parser.add_argument("--verified-net-pnl", type=float, default=0.0)
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
 
-    result = evaluate(args.equity, load_policy(args.config))
+    result = evaluate(
+        args.equity, load_policy(args.config),
+        monthly_contribution=args.monthly_contribution,
+        starting_equity=args.starting_equity,
+        net_contributions=args.net_contributions,
+        verified_net_pnl=args.verified_net_pnl,
+    )
     rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
     if args.output:
         args.output.write_text(rendered, encoding="utf-8")

--- a/tests/test_multi_asset_rollout.py
+++ b/tests/test_multi_asset_rollout.py
@@ -8,21 +8,19 @@ class MultiAssetRolloutTests(unittest.TestCase):
     def setUpClass(cls):
         cls.policy = load_policy()
 
-    def test_milestone_ladder_is_complete(self):
-        self.assertEqual(
-            self.policy["growth_milestones_usd"],
-            [25000, 50000, 100000, 250000, 500000, 1000000],
-        )
+    def test_milestone_ladder_and_growth_target(self):
+        self.assertEqual(self.policy["growth_milestones_usd"],
+                         [25000, 50000, 100000, 250000, 500000, 1000000])
+        self.assertEqual(self.policy["target_monthly_growth_usd"], 1000)
+        self.assertEqual(self.policy["target_months"], 24)
 
     def test_below_first_milestone_locks_all_sleeves(self):
         result = evaluate(24999.99, self.policy)
         self.assertFalse(result["milestone_reached"])
         self.assertEqual(result["milestone_usd"], 25000.0)
         self.assertFalse(result["live_trading_authorized"])
-        self.assertTrue(all(
-            sleeve["status"] == "locked_below_milestone"
-            for sleeve in result["sleeves"].values()
-        ))
+        self.assertTrue(all(sleeve["status"] == "locked_below_milestone"
+                            for sleeve in result["sleeves"].values()))
 
     def test_milestone_opens_research_not_live_trading(self):
         result = evaluate(25000, self.policy)
@@ -30,32 +28,23 @@ class MultiAssetRolloutTests(unittest.TestCase):
         self.assertFalse(result["buffer_reached"])
         self.assertEqual(result["capital_growth_plan"]["next_milestone_usd"], 50000.0)
         self.assertFalse(result["live_trading_authorized"])
-        self.assertTrue(all(
-            sleeve["status"] == "paper_validation_eligible"
-            for sleeve in result["sleeves"].values()
-        ))
+
+    def test_target_is_split_between_contribution_and_verified_pnl(self):
+        result = evaluate(15000, self.policy, monthly_contribution=600)
+        plan = result["capital_growth_plan"]
+        self.assertEqual(plan["target_monthly_growth_usd"], 1000.0)
+        self.assertEqual(plan["verified_net_pnl_required_usd"], 400.0)
+        self.assertFalse(plan["return_assumptions_used"])
 
     def test_planner_tracks_contributions_without_return_forecasts(self):
-        result = evaluate(
-            15000,
-            self.policy,
-            monthly_contribution=500,
-            starting_equity=5000,
-            net_contributions=10000,
-            verified_net_pnl=0,
-        )
+        result = evaluate(15000, self.policy, monthly_contribution=500,
+                          starting_equity=5000, net_contributions=10000,
+                          verified_net_pnl=0)
         plan = result["capital_growth_plan"]
         self.assertEqual(plan["next_milestone_usd"], 25000.0)
         self.assertEqual(plan["gap_to_next_milestone_usd"], 10000.0)
         self.assertEqual(plan["contribution_only_months_to_next"], 20)
-        self.assertFalse(plan["return_assumptions_used"])
         self.assertEqual(plan["reconciliation"]["unreconciled_delta_usd"], 0.0)
-
-    def test_buffer_is_separate_from_milestone(self):
-        result = evaluate(30000, self.policy)
-        self.assertTrue(result["milestone_reached"])
-        self.assertTrue(result["buffer_reached"])
-        self.assertFalse(result["live_trading_authorized"])
 
     def test_policy_cannot_enable_live_or_leverage(self):
         broken = dict(self.policy)
@@ -66,13 +55,9 @@ class MultiAssetRolloutTests(unittest.TestCase):
             with NamedTemporaryFile(mode="w+", encoding="utf-8") as handle:
                 json.dump(broken, handle)
                 handle.flush()
-                load_policy_from_path(handle.name)
-
-
-def load_policy_from_path(path):
-    from scripts.evaluate_multi_asset_rollout import load_policy
-    from pathlib import Path
-    return load_policy(Path(path))
+                from scripts.evaluate_multi_asset_rollout import load_policy
+                from pathlib import Path
+                load_policy(Path(handle.name))
 
 
 if __name__ == "__main__":

--- a/tests/test_multi_asset_rollout.py
+++ b/tests/test_multi_asset_rollout.py
@@ -1,6 +1,4 @@
-import json
 import unittest
-from pathlib import Path
 
 from scripts.evaluate_multi_asset_rollout import evaluate, load_policy
 
@@ -10,9 +8,16 @@ class MultiAssetRolloutTests(unittest.TestCase):
     def setUpClass(cls):
         cls.policy = load_policy()
 
-    def test_below_milestone_locks_all_sleeves(self):
+    def test_milestone_ladder_is_complete(self):
+        self.assertEqual(
+            self.policy["growth_milestones_usd"],
+            [25000, 50000, 100000, 250000, 500000, 1000000],
+        )
+
+    def test_below_first_milestone_locks_all_sleeves(self):
         result = evaluate(24999.99, self.policy)
         self.assertFalse(result["milestone_reached"])
+        self.assertEqual(result["milestone_usd"], 25000.0)
         self.assertFalse(result["live_trading_authorized"])
         self.assertTrue(all(
             sleeve["status"] == "locked_below_milestone"
@@ -23,12 +28,28 @@ class MultiAssetRolloutTests(unittest.TestCase):
         result = evaluate(25000, self.policy)
         self.assertTrue(result["milestone_reached"])
         self.assertFalse(result["buffer_reached"])
-        self.assertTrue(result["research_only"])
+        self.assertEqual(result["capital_growth_plan"]["next_milestone_usd"], 50000.0)
         self.assertFalse(result["live_trading_authorized"])
         self.assertTrue(all(
             sleeve["status"] == "paper_validation_eligible"
             for sleeve in result["sleeves"].values()
         ))
+
+    def test_planner_tracks_contributions_without_return_forecasts(self):
+        result = evaluate(
+            15000,
+            self.policy,
+            monthly_contribution=500,
+            starting_equity=5000,
+            net_contributions=10000,
+            verified_net_pnl=0,
+        )
+        plan = result["capital_growth_plan"]
+        self.assertEqual(plan["next_milestone_usd"], 25000.0)
+        self.assertEqual(plan["gap_to_next_milestone_usd"], 10000.0)
+        self.assertEqual(plan["contribution_only_months_to_next"], 20)
+        self.assertFalse(plan["return_assumptions_used"])
+        self.assertEqual(plan["reconciliation"]["unreconciled_delta_usd"], 0.0)
 
     def test_buffer_is_separate_from_milestone(self):
         result = evaluate(30000, self.policy)
@@ -40,18 +61,18 @@ class MultiAssetRolloutTests(unittest.TestCase):
         broken = dict(self.policy)
         broken["live_trading_enabled"] = True
         with self.assertRaises(ValueError):
-            evaluate(30000, load_policy_from_dict(broken))
+            from tempfile import NamedTemporaryFile
+            import json
+            with NamedTemporaryFile(mode="w+", encoding="utf-8") as handle:
+                json.dump(broken, handle)
+                handle.flush()
+                load_policy_from_path(handle.name)
 
 
-def load_policy_from_dict(policy):
-    # Exercise the same invariant checks without writing a temporary file.
-    if policy.get("mode") != "paper_research_only":
-        raise ValueError("rollout policy must remain paper_research_only")
-    if policy.get("live_trading_enabled") is not False:
-        raise ValueError("live trading must be disabled")
-    if policy.get("leverage_enabled") is not False:
-        raise ValueError("global leverage must be disabled")
-    return policy
+def load_policy_from_path(path):
+    from scripts.evaluate_multi_asset_rollout import load_policy
+    from pathlib import Path
+    return load_policy(Path(path))
 
 
 if __name__ == "__main__":

--- a/tests/test_multi_asset_rollout.py
+++ b/tests/test_multi_asset_rollout.py
@@ -16,6 +16,14 @@ class MultiAssetRolloutTests(unittest.TestCase):
         self.assertEqual(self.policy["risk_profile"], "moderate_aggressive")
         self.assertEqual(self.policy["risk_sizing_mode"], "adaptive_with_hard_caps")
 
+    def test_leverage_is_capped_and_not_authorized(self):
+        result = evaluate(25000, self.policy)
+        self.assertEqual(result["max_leverage_multiple"], 2.0)
+        self.assertTrue(result["leverage_policy"]["activation_requires_positive_window"])
+        self.assertTrue(result["leverage_policy"]["entry"]["late_entry_confirmation"])
+        self.assertTrue(result["leverage_policy"]["exit"]["early_exit_on_signal_decay"])
+        self.assertFalse(result["leverage_authorized"])
+
     def test_below_first_milestone_locks_all_sleeves(self):
         result = evaluate(24999.99, self.policy)
         self.assertFalse(result["milestone_reached"])
@@ -57,7 +65,6 @@ class MultiAssetRolloutTests(unittest.TestCase):
             with NamedTemporaryFile(mode="w+", encoding="utf-8") as handle:
                 json.dump(broken, handle)
                 handle.flush()
-                from pathlib import Path
                 load_policy_from_path(handle.name)
 
 

--- a/tests/test_multi_asset_rollout.py
+++ b/tests/test_multi_asset_rollout.py
@@ -8,11 +8,13 @@ class MultiAssetRolloutTests(unittest.TestCase):
     def setUpClass(cls):
         cls.policy = load_policy()
 
-    def test_milestone_ladder_and_growth_target(self):
+    def test_milestone_ladder_growth_target_and_risk_profile(self):
         self.assertEqual(self.policy["growth_milestones_usd"],
                          [25000, 50000, 100000, 250000, 500000, 1000000])
         self.assertEqual(self.policy["target_monthly_growth_usd"], 1000)
         self.assertEqual(self.policy["target_months"], 24)
+        self.assertEqual(self.policy["risk_profile"], "moderate_aggressive")
+        self.assertEqual(self.policy["risk_sizing_mode"], "adaptive_with_hard_caps")
 
     def test_below_first_milestone_locks_all_sleeves(self):
         result = evaluate(24999.99, self.policy)
@@ -55,9 +57,14 @@ class MultiAssetRolloutTests(unittest.TestCase):
             with NamedTemporaryFile(mode="w+", encoding="utf-8") as handle:
                 json.dump(broken, handle)
                 handle.flush()
-                from scripts.evaluate_multi_asset_rollout import load_policy
                 from pathlib import Path
-                load_policy(Path(handle.name))
+                load_policy_from_path(handle.name)
+
+
+def load_policy_from_path(path):
+    from scripts.evaluate_multi_asset_rollout import load_policy
+    from pathlib import Path
+    return load_policy(Path(path))
 
 
 if __name__ == "__main__":

--- a/tests/test_multi_asset_rollout.py
+++ b/tests/test_multi_asset_rollout.py
@@ -1,0 +1,58 @@
+import json
+import unittest
+from pathlib import Path
+
+from scripts.evaluate_multi_asset_rollout import evaluate, load_policy
+
+
+class MultiAssetRolloutTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = load_policy()
+
+    def test_below_milestone_locks_all_sleeves(self):
+        result = evaluate(24999.99, self.policy)
+        self.assertFalse(result["milestone_reached"])
+        self.assertFalse(result["live_trading_authorized"])
+        self.assertTrue(all(
+            sleeve["status"] == "locked_below_milestone"
+            for sleeve in result["sleeves"].values()
+        ))
+
+    def test_milestone_opens_research_not_live_trading(self):
+        result = evaluate(25000, self.policy)
+        self.assertTrue(result["milestone_reached"])
+        self.assertFalse(result["buffer_reached"])
+        self.assertTrue(result["research_only"])
+        self.assertFalse(result["live_trading_authorized"])
+        self.assertTrue(all(
+            sleeve["status"] == "paper_validation_eligible"
+            for sleeve in result["sleeves"].values()
+        ))
+
+    def test_buffer_is_separate_from_milestone(self):
+        result = evaluate(30000, self.policy)
+        self.assertTrue(result["milestone_reached"])
+        self.assertTrue(result["buffer_reached"])
+        self.assertFalse(result["live_trading_authorized"])
+
+    def test_policy_cannot_enable_live_or_leverage(self):
+        broken = dict(self.policy)
+        broken["live_trading_enabled"] = True
+        with self.assertRaises(ValueError):
+            evaluate(30000, load_policy_from_dict(broken))
+
+
+def load_policy_from_dict(policy):
+    # Exercise the same invariant checks without writing a temporary file.
+    if policy.get("mode") != "paper_research_only":
+        raise ValueError("rollout policy must remain paper_research_only")
+    if policy.get("live_trading_enabled") is not False:
+        raise ValueError("live trading must be disabled")
+    if policy.get("leverage_enabled") is not False:
+        raise ValueError("global leverage must be disabled")
+    return policy
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a settled-equity milestone policy at $25,000 with a $5,000 buffer
- keep rollout paper-only, leverage-off, and fail-closed
- add independent stocks/ETF, defined-risk options, micro-futures, and forex sleeves
- add evaluator, unit tests, CI workflow, and operating documentation

## Safety
Crossing the milestone only makes paper validation eligible. No live activation, order placement, leverage, or strategy promotion is authorized.