### PR TITLE
Add cost-aware edge efficiency screen

### DIFF
--- a/.github/workflows/edge-efficiency-screen.yml
+++ b/.github/workflows/edge-efficiency-screen.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run edge-efficiency screen
         run: |
           python scripts/run_edge_efficiency_screen.py             --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv             --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv             --output artifacts/edge-efficiency/edge_screen.json
+      - name: Run mathematical pattern scan
+        run: |
+          python scripts/run_pattern_trend_scan.py             --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv             --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv             --output artifacts/edge-efficiency/pattern_scan.json
       - name: Upload edge report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/edge-efficiency-screen.yml
+++ b/.github/workflows/edge-efficiency-screen.yml
@@ -1,0 +1,40 @@
+name: Edge Efficiency Screen
+
+on:
+  push:
+    branches:
+      - agent/edge-efficiency-screen
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: edge-efficiency-screen
+  cancel-in-progress: false
+
+jobs:
+  screen:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          UNTIL="$(date -u +%Y-%m)"
+          python scripts/fetch_binance_vision_klines.py             --symbols BTCUSDT ETHUSDT             --since 2023-01             --until "$UNTIL"
+      - name: Run edge-efficiency screen
+        run: |
+          python scripts/run_edge_efficiency_screen.py             --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv             --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv             --output artifacts/edge-efficiency/edge_screen.json
+      - name: Upload edge report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: edge-efficiency-screen-${{ github.run_number }}
+          path: artifacts/edge-efficiency
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/frozen-candidate-validation.yml
+++ b/.github/workflows/frozen-candidate-validation.yml
@@ -1,0 +1,51 @@
+name: Frozen Candidate Walk-Forward Validation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/execution-model-and-sats-backtest
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frozen-candidate-validation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          UNTIL="$(python - <<'PY'
+          from datetime import datetime, timezone
+          print(datetime.now(timezone.utc).strftime("%Y-%m"))
+          PY
+          )"
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-01 \
+            --until "$UNTIL"
+      - name: Run frozen candidate validation
+        run: |
+          set -euo pipefail
+          python scripts/run_frozen_candidate_validation.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --output artifacts/momentum-v3/frozen-validation/validation.json
+      - name: Upload validation artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: frozen-candidate-validation-${{ github.run_number }}
+          path: artifacts/momentum-v3/frozen-validation
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/hedge-fund-strategy-suite.yml
+++ b/.github/workflows/hedge-fund-strategy-suite.yml
@@ -1,0 +1,51 @@
+name: Hedge Fund Strategy Suite
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/execution-model-and-sats-backtest
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hedge-fund-strategy-suite-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          UNTIL="$(python - <<'PY'
+          from datetime import datetime, timezone
+          print(datetime.now(timezone.utc).strftime("%Y-%m"))
+          PY
+          )"
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-01 \
+            --until "$UNTIL"
+      - name: Run strategy suite
+        run: |
+          set -euo pipefail
+          python scripts/run_hedge_fund_strategy_suite.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --output artifacts/momentum-v3/hedge-fund-suite/strategy-suite.json
+      - name: Upload strategy suite artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: hedge-fund-strategy-suite-${{ github.run_number }}
+          path: artifacts/momentum-v3/hedge-fund-suite
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/three-year-satoshi-backtest.yml
+++ b/.github/workflows/three-year-satoshi-backtest.yml
@@ -1,0 +1,50 @@
+name: Three-Year Satoshi Backtest
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: three-year-satoshi-backtest-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  backtest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed Binance Vision history
+        run: |
+          set -euo pipefail
+          UNTIL="$(python - <<'PY'
+          from datetime import datetime, timezone
+          print(datetime.now(timezone.utc).strftime("%Y-%m"))
+          PY
+          )"
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-01 \
+            --until "$UNTIL"
+      - name: Run three-year satoshi backtest
+        run: |
+          set -euo pipefail
+          python scripts/run_three_year_sats_backtest.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --output artifacts/momentum-v3/three-year-sats/backtest.json
+      - name: Upload backtest artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: three-year-satoshi-backtest-${{ github.run_number }}
+          path: artifacts/momentum-v3/three-year-sats
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/three-year-satoshi-backtest.yml
+++ b/.github/workflows/three-year-satoshi-backtest.yml
@@ -2,6 +2,9 @@ name: Three-Year Satoshi Backtest
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - agent/execution-model-and-sats-backtest
 
 permissions:
   contents: read

--- a/config/pattern_adjustment_plan.json
+++ b/config/pattern_adjustment_plan.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "research_only": true,
+  "adjustment_order": [
+    "execution_cost_filter",
+    "holding_horizon",
+    "entry_confirmation",
+    "regime_filter",
+    "exit_logic",
+    "asset_selection",
+    "position_sizing"
+  ],
+  "pattern_classes": [
+    "trend_structure",
+    "breakout",
+    "vol_expansion",
+    "vol_contraction_break",
+    "relative_strength",
+    "momentum_decay",
+    "mean_reversion",
+    "exhaustion"
+  ],
+  "adjustment_rules": {
+    "execution_cost_filter": "Require expected gross movement >= 4x stress round-trip cost before entry.",
+    "holding_horizon": "Evaluate 6, 24, 48, and 96 completed-hour labels without overlapping samples.",
+    "entry_confirmation": "Require signal persistence and enter only on the next completed candle.",
+    "regime_filter": "Segment trend, range, expansion, contraction, and crisis regimes.",
+    "exit_logic": "Compare time stop, signal decay, ATR stop, trailing stop, and profit-lock variants.",
+    "asset_selection": "Select the strongest liquid leader only when relative strength is significant.",
+    "position_sizing": "Volatility-scale within the existing hard portfolio risk caps."
+  },
+  "validation": {
+    "walk_forward_blocks": 6,
+    "minimum_observations_per_block": 20,
+    "positive_blocks_required_for_promising": 4,
+    "stress_cost_multiple_for_robust_candidate": 4,
+    "multiple_testing_correction": "pre_registered_universe_and_holdout_confirmation",
+    "forward_holdout_is_frozen": true,
+    "leverage_enabled": false,
+    "orders_placed": false
+  }
+}

--- a/config/pattern_adjustment_plan.json
+++ b/config/pattern_adjustment_plan.json
@@ -1,6 +1,7 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "research_only": true,
+  "execution_realism": "gross_movement_diagnostic",
   "adjustment_order": [
     "execution_cost_filter",
     "holding_horizon",
@@ -21,9 +22,9 @@
     "exhaustion"
   ],
   "adjustment_rules": {
-    "execution_cost_filter": "Require expected gross movement >= 4x stress round-trip cost before entry.",
-    "holding_horizon": "Evaluate 6, 24, 48, and 96 completed-hour labels without overlapping samples.",
-    "entry_confirmation": "Require signal persistence and enter only on the next completed candle.",
+    "execution_cost_filter": "Use the shared execution model stress round-trip reference; this screen is gross movement only.",
+    "holding_horizon": "Evaluate registered completed-hour labels without overlapping samples.",
+    "entry_confirmation": "Require a chronological discovery pass and untouched holdout pass before a candidate is robust.",
     "regime_filter": "Segment trend, range, expansion, contraction, and crisis regimes.",
     "exit_logic": "Compare time stop, signal decay, ATR stop, trailing stop, and profit-lock variants.",
     "asset_selection": "Select the strongest liquid leader only when relative strength is significant.",
@@ -32,10 +33,13 @@
   "validation": {
     "walk_forward_blocks": 6,
     "minimum_observations_per_block": 20,
-    "positive_blocks_required_for_promising": 4,
+    "minimum_holdout_hours": 11520,
+    "positive_blocks_required_for_promising": 6,
     "stress_cost_multiple_for_robust_candidate": 4,
-    "multiple_testing_correction": "pre_registered_universe_and_holdout_confirmation",
+    "multiple_testing_correction": "chronological_holdout_confirmation_for_every_registered_pattern_horizon",
     "forward_holdout_is_frozen": true,
+    "robust_requires_discovery_and_holdout": true,
+    "fill_based_net_validation_required": true,
     "leverage_enabled": false,
     "orders_placed": false
   }

--- a/docs/momentum_v3_research_loop.md
+++ b/docs/momentum_v3_research_loop.md
@@ -122,7 +122,23 @@ would create selection bias rather than new evidence.
 The monthly GitHub Actions workflow downloads completed Binance Vision months,
 restores the most recent successful research artifact when available, and
 uploads the new state and reports. Its token has only `actions: read` and
-`contents: read` permissions. Restore is optional; stale or incompatible state
-is never used as evidence, and no restored artifact can claim readiness.
+`contents: read` permissions. Restore is optional; stale or incompatible
+state is never used as evidence, and no restored artifact can claim readiness.
 
 Do not use this loop as permission to promote a model or start live trading.
+
+## Three-year satoshi backtest
+
+The manual workflow `Three-Year Satoshi Backtest` runs the fixed v3 candidate
+set on the most recent three years of completed aligned BTC/ETH hourly candles.
+It uses the explicit base and stress execution budgets in
+`scripts/execution_model.py` and writes an artifact under
+`artifacts/momentum-v3/three-year-sats`.
+
+The artifact records fee, spread, slippage, impact, latency, fill fraction,
+funding, and outage assumptions. BTC can be denominated in satoshis
+(`1 BTC = 100,000,000 sats`) when the starting balance is supplied in BTC;
+quote-currency results remain available. The current wrapper estimates
+execution cost from completed entry/exit counts. It is not an exact exchange
+fill ledger and must not be treated as execution-realistic until that ledger is
+integrated and independently tested.

--- a/scripts/execution_model.py
+++ b/scripts/execution_model.py
@@ -1,0 +1,90 @@
+"""Explicit, auditable execution assumptions for research backtests.
+
+This module is intentionally independent from broker adapters.  It turns each
+assumption into a per-side basis-point budget and records the assumptions in
+the output artifact.  The v3 runner remains research-only; these values never
+enable orders or change portfolio risk limits.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import math
+
+
+@dataclass(frozen=True)
+class ExecutionModel:
+    fee_bps_per_side: float
+    spread_bps_per_side: float
+    slippage_bps_per_side: float
+    impact_bps_per_side: float
+    latency_bars: int = 0
+    fill_fraction: float = 1.0
+    funding_bps_per_bar: float = 0.0
+    outage_rejection_rate: float = 0.0
+
+    def __post_init__(self) -> None:
+        values = (
+            self.fee_bps_per_side,
+            self.spread_bps_per_side,
+            self.slippage_bps_per_side,
+            self.impact_bps_per_side,
+            self.funding_bps_per_bar,
+            self.outage_rejection_rate,
+        )
+        if not all(math.isfinite(float(value)) and float(value) >= 0 for value in values):
+            raise ValueError("execution costs and rejection rate must be finite and non-negative")
+        if self.latency_bars < 0:
+            raise ValueError("latency_bars must be non-negative")
+        if not 0 < self.fill_fraction <= 1:
+            raise ValueError("fill_fraction must be in (0, 1]")
+        if self.outage_rejection_rate > 1:
+            raise ValueError("outage_rejection_rate must be <= 1")
+
+    @property
+    def effective_slippage_bps_per_side(self) -> float:
+        # Spread is crossed half on each side; impact is adverse price movement.
+        return (
+            self.spread_bps_per_side / 2.0
+            + self.slippage_bps_per_side
+            + self.impact_bps_per_side
+        )
+
+    @property
+    def effective_fees_bps_per_side(self) -> float:
+        return self.fee_bps_per_side
+
+    @property
+    def round_trip_bps(self) -> float:
+        return 2.0 * (
+            self.effective_fees_bps_per_side
+            + self.effective_slippage_bps_per_side
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        result = asdict(self)
+        result.update(
+            {
+                "effective_slippage_bps_per_side": self.effective_slippage_bps_per_side,
+                "round_trip_bps": self.round_trip_bps,
+            }
+        )
+        return result
+
+
+BASE_EXECUTION = ExecutionModel(
+    fee_bps_per_side=10.0,
+    spread_bps_per_side=4.0,
+    slippage_bps_per_side=5.0,
+    impact_bps_per_side=2.0,
+)
+
+STRESS_EXECUTION = ExecutionModel(
+    fee_bps_per_side=20.0,
+    spread_bps_per_side=10.0,
+    slippage_bps_per_side=10.0,
+    impact_bps_per_side=8.0,
+    latency_bars=1,
+    fill_fraction=0.80,
+    funding_bps_per_bar=0.5,
+    outage_rejection_rate=0.02,
+)

--- a/scripts/run_edge_efficiency_screen.py
+++ b/scripts/run_edge_efficiency_screen.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Pre-registered edge-efficiency screen.
+
+Measures directional forward movement after closed-candle signals and compares
+it with explicit round-trip costs. Labels are sampled every holding horizon,
+so overlapping windows are not counted as independent evidence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+try:
+    from scripts.run_momentum_volatility_research import load_bars
+    from scripts.run_momentum_volatility_v3 import align_pair
+except ModuleNotFoundError:
+    from run_momentum_volatility_research import load_bars
+    from run_momentum_volatility_v3 import align_pair
+
+BASE_COST = 0.0038
+STRESS_COST = 0.0086
+HORIZONS = (6, 12, 24, 48, 96)
+BLOCKS = 6
+MIN_OBSERVATIONS_PER_BLOCK = 20
+
+
+def finite(*values: float) -> bool:
+    return all(math.isfinite(float(value)) for value in values)
+
+
+def rolling_mean(values: list[float], window: int, i: int) -> float:
+    if i < window - 1:
+        return math.nan
+    return sum(values[i - window + 1:i + 1]) / window
+
+
+def features(bars: list[Any]) -> dict[str, list[float]]:
+    close = [float(bar.close) for bar in bars]
+    high = [float(bar.high) for bar in bars]
+    low = [float(bar.low) for bar in bars]
+    daily_range = [(h - l) / c if c else math.nan for h, l, c in zip(high, low, close)]
+    mom24 = [math.nan if i < 24 else close[i] / close[i - 24] - 1 for i in range(len(close))]
+    mom48 = [math.nan if i < 48 else close[i] / close[i - 48] - 1 for i in range(len(close))]
+    sma200 = [rolling_mean(close, 200, i) for i in range(len(close))]
+    range24 = [rolling_mean(daily_range, 24, i) for i in range(len(close))]
+    prior_high48 = [max(high[i - 48:i]) if i >= 49 else math.nan for i in range(len(close))]
+    return {"close": close, "mom24": mom24, "mom48": mom48,
+            "sma200": sma200, "range": daily_range,
+            "range24": range24, "prior_high48": prior_high48}
+
+
+def signal_names() -> tuple[str, ...]:
+    return ("trend_volatility", "breakout_volatility", "relative_strength_volatility")
+
+
+def choose_signal(name: str, i: int, btc: dict[str, list[float]],
+                  eth: dict[str, list[float]]) -> tuple[str | None, int]:
+    if i < 220:
+        return None, 0
+    candidates = (("BTC", btc), ("ETH", eth))
+    if name == "relative_strength_volatility":
+        if not finite(btc["mom24"][i], eth["mom24"][i]):
+            return None, 0
+        leader, other = ("BTC", "ETH") if btc["mom24"][i] > eth["mom24"][i] else ("ETH", "BTC")
+        lead, lag = (btc, eth) if leader == "BTC" else (eth, btc)
+        if not finite(lead["range"][i], lead["range24"][i], lead["sma200"][i], lag["mom24"][i]):
+            return None, 0
+        if lead["mom24"][i] - lag["mom24"][i] >= 0.01 and lead["close"][i] > lead["sma200"][i] and lead["range"][i] >= 1.25 * lead["range24"][i]:
+            return leader, 1
+        return None, 0
+    eligible = []
+    for symbol, data in candidates:
+        if not finite(data["mom24"][i], data["sma200"][i], data["range"][i], data["range24"][i]):
+            continue
+        trend = data["close"][i] > data["sma200"][i] and data["mom24"][i] > 0
+        expansion = data["range"][i] >= 1.25 * data["range24"][i]
+        breakout = finite(data["prior_high48"][i]) and data["close"][i] > data["prior_high48"][i]
+        if trend and expansion and (name == "trend_volatility" or breakout):
+            eligible.append((data["mom24"][i], symbol))
+    return max(eligible)[1], 1 if eligible else (None, 0)
+
+
+def evaluate(btc_path: Path, eth_path: Path) -> dict[str, Any]:
+    pair = align_pair(load_bars(btc_path), load_bars(eth_path))
+    if len(pair) < 3 * 365 * 24:
+        raise ValueError("need at least three years of aligned hourly candles")
+    pair = pair[-3 * 365 * 24:]
+    bars = {"BTC": [item.btc for item in pair], "ETH": [item.eth for item in pair]}
+    feat = {symbol: features(values) for symbol, values in bars.items()}
+    results: dict[str, Any] = {}
+    for name in signal_names():
+        results[name] = {}
+        for horizon in HORIZONS:
+            rows: list[dict[str, float]] = []
+            start = 220
+            for i in range(start, len(pair) - horizon, horizon):
+                symbol, direction = choose_signal(name, i, feat["BTC"], feat["ETH"])
+                if symbol is None:
+                    continue
+                data = feat[symbol]
+                gross = direction * (data["close"][i + horizon] / data["close"][i] - 1)
+                rows.append({"index": i, "gross_return": gross})
+            block_values: list[list[float]] = [[] for _ in range(BLOCKS)]
+            block_size = len(pair) / BLOCKS
+            for row in rows:
+                block = min(BLOCKS - 1, int(row["index"] / block_size))
+                block_values[block].append(row["gross_return"])
+            block_means = [sum(values) / len(values) if values else math.nan for values in block_values]
+            valid_blocks = [value for value in block_means if math.isfinite(value)]
+            base_multiple = median(valid_blocks) / BASE_COST if valid_blocks else math.nan
+            stress_multiple = median(valid_blocks) / STRESS_COST if valid_blocks else math.nan
+            eligible = (
+                len(rows) >= MIN_OBSERVATIONS_PER_BLOCK * BLOCKS
+                and len(valid_blocks) == BLOCKS
+                and all(value > 0 for value in valid_blocks)
+                and stress_multiple >= 4.0
+            )
+            results[name][str(horizon)] = {
+                "observations": len(rows),
+                "non_overlapping": True,
+                "block_mean_gross_returns": block_means,
+                "median_block_gross_return": median(valid_blocks) if valid_blocks else None,
+                "base_cost_multiple": base_multiple if math.isfinite(base_multiple) else None,
+                "stress_cost_multiple": stress_multiple if math.isfinite(stress_multiple) else None,
+                "passes_4x_stress_gate": eligible,
+            }
+    passing = [f"{name}:{horizon}" for name, horizons in results.items()
+               for horizon, result in horizons.items() if result["passes_4x_stress_gate"]]
+    return {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "window": {"start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(),
+                   "bars": len(pair), "blocks": BLOCKS, "completed_candles_only": True},
+        "costs": {"base_round_trip": BASE_COST, "stress_round_trip": STRESS_COST},
+        "method": {"horizons_hours": HORIZONS, "sample_every_horizon": True,
+                   "minimum_observations_per_block": MIN_OBSERVATIONS_PER_BLOCK,
+                   "promotion_requires_4x_stress_and_positive_blocks": True},
+        "candidates": results,
+        "passing_candidates": passing,
+        "status": "candidate_found" if passing else "no_candidate_passed",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    report = evaluate(args.btc_path, args.eth_path)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(json.dumps({"status": report["status"], "passing_candidates": report["passing_candidates"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_edge_efficiency_screen.py
+++ b/scripts/run_edge_efficiency_screen.py
@@ -81,7 +81,7 @@ def choose_signal(name: str, i: int, btc: dict[str, list[float]],
         breakout = finite(data["prior_high48"][i]) and data["close"][i] > data["prior_high48"][i]
         if trend and expansion and (name == "trend_volatility" or breakout):
             eligible.append((data["mom24"][i], symbol))
-    return max(eligible)[1], 1 if eligible else (None, 0)
+    if not eligible:\n        return None, 0\n    return max(eligible)[1], 1
 
 
 def evaluate(btc_path: Path, eth_path: Path) -> dict[str, Any]:

--- a/scripts/run_edge_efficiency_screen.py
+++ b/scripts/run_edge_efficiency_screen.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Pre-registered edge-efficiency screen.
+"""Pre-registered, cost-referenced gross-movement diagnostic.
 
-Measures directional forward movement after closed-candle signals and compares
-it with explicit round-trip costs. Labels are sampled every holding horizon,
-so overlapping windows are not counted as independent evidence.
+This screen is intentionally not an execution backtest. It uses completed
+candles and non-overlapping labels to discover directional movement, then
+requires the same frozen candidate/horizon to pass a chronological holdout.
+Execution costs are read from the shared execution model for the reference
+gate; latency, fills, funding, and rejected orders are not simulated here.
 """
 from __future__ import annotations
 
@@ -15,17 +17,20 @@ from statistics import median
 from typing import Any
 
 try:
+    from scripts.execution_model import STRESS_EXECUTION
     from scripts.run_momentum_volatility_research import load_bars
     from scripts.run_momentum_volatility_v3 import align_pair
 except ModuleNotFoundError:
+    from execution_model import STRESS_EXECUTION
     from run_momentum_volatility_research import load_bars
     from run_momentum_volatility_v3 import align_pair
 
-BASE_COST = 0.0038
-STRESS_COST = 0.0086
 HORIZONS = (6, 12, 24, 48, 96)
 BLOCKS = 6
 MIN_OBSERVATIONS_PER_BLOCK = 20
+HOLDOUT_MIN_HOURS = BLOCKS * MIN_OBSERVATIONS_PER_BLOCK * max(HORIZONS)
+STRESS_COST = STRESS_EXECUTION.round_trip_bps / 10_000.0
+FAMILY_SIZE = 3 * len(HORIZONS)
 
 
 def finite(*values: float) -> bool:
@@ -42,109 +47,217 @@ def features(bars: list[Any]) -> dict[str, list[float]]:
     close = [float(bar.close) for bar in bars]
     high = [float(bar.high) for bar in bars]
     low = [float(bar.low) for bar in bars]
-    daily_range = [(h - l) / c if c else math.nan for h, l, c in zip(high, low, close)]
-    mom24 = [math.nan if i < 24 else close[i] / close[i - 24] - 1 for i in range(len(close))]
-    mom48 = [math.nan if i < 48 else close[i] / close[i - 48] - 1 for i in range(len(close))]
+    candle_range = [(h - l) / c if c else math.nan
+                    for h, l, c in zip(high, low, close)]
+    mom24 = [math.nan if i < 24 else close[i] / close[i - 24] - 1
+             for i in range(len(close))]
     sma200 = [rolling_mean(close, 200, i) for i in range(len(close))]
-    range24 = [rolling_mean(daily_range, 24, i) for i in range(len(close))]
-    prior_high48 = [max(high[i - 48:i]) if i >= 49 else math.nan for i in range(len(close))]
-    return {"close": close, "mom24": mom24, "mom48": mom48,
-            "sma200": sma200, "range": daily_range,
-            "range24": range24, "prior_high48": prior_high48}
+    range24 = [rolling_mean(candle_range, 24, i)
+               for i in range(len(close))]
+    prior_high48 = [max(high[i - 48:i]) if i >= 49 else math.nan
+                    for i in range(len(close))]
+    return {
+        "close": close, "mom24": mom24, "sma200": sma200,
+        "range": candle_range, "range24": range24,
+        "prior_high48": prior_high48,
+    }
 
 
 def signal_names() -> tuple[str, ...]:
-    return ("trend_volatility", "breakout_volatility", "relative_strength_volatility")
+    return ("trend_volatility", "breakout_volatility",
+            "relative_strength_volatility")
 
 
-def choose_signal(name: str, i: int, btc: dict[str, list[float]],
-                  eth: dict[str, list[float]]) -> tuple[str | None, int]:
+def choose_signal(
+    name: str,
+    i: int,
+    btc: dict[str, list[float]],
+    eth: dict[str, list[float]],
+) -> tuple[str | None, int]:
     if i < 220:
         return None, 0
     candidates = (("BTC", btc), ("ETH", eth))
     if name == "relative_strength_volatility":
         if not finite(btc["mom24"][i], eth["mom24"][i]):
             return None, 0
-        leader, other = ("BTC", "ETH") if btc["mom24"][i] > eth["mom24"][i] else ("ETH", "BTC")
+        leader = "BTC" if btc["mom24"][i] >= eth["mom24"][i] else "ETH"
         lead, lag = (btc, eth) if leader == "BTC" else (eth, btc)
-        if not finite(lead["range"][i], lead["range24"][i], lead["sma200"][i], lag["mom24"][i]):
+        if not finite(lead["range"][i], lead["range24"][i],
+                      lead["sma200"][i], lag["mom24"][i]):
             return None, 0
-        if lead["mom24"][i] - lag["mom24"][i] >= 0.01 and lead["close"][i] > lead["sma200"][i] and lead["range"][i] >= 1.25 * lead["range24"][i]:
+        if (lead["mom24"][i] - lag["mom24"][i] >= 0.01
+                and lead["close"][i] > lead["sma200"][i]
+                and lead["range"][i] >= 1.25 * lead["range24"][i]):
             return leader, 1
         return None, 0
+
     eligible = []
     for symbol, data in candidates:
-        if not finite(data["mom24"][i], data["sma200"][i], data["range"][i], data["range24"][i]):
+        if not finite(data["mom24"][i], data["sma200"][i],
+                      data["range"][i], data["range24"][i]):
             continue
         trend = data["close"][i] > data["sma200"][i] and data["mom24"][i] > 0
         expansion = data["range"][i] >= 1.25 * data["range24"][i]
-        breakout = finite(data["prior_high48"][i]) and data["close"][i] > data["prior_high48"][i]
-        if trend and expansion and (name == "trend_volatility" or breakout):
+        breakout = (finite(data["prior_high48"][i])
+                    and data["close"][i] > data["prior_high48"][i])
+        if trend and expansion and (
+                name == "trend_volatility" or breakout):
             eligible.append((data["mom24"][i], symbol))
-    if not eligible:\n        return None, 0\n    return max(eligible)[1], 1
+    if not eligible:
+        return None, 0
+    return max(eligible)[1], 1
+
+
+def summarize(
+    rows: list[dict[str, float]],
+    segment_start: int,
+    segment_end: int,
+) -> dict[str, Any]:
+    block_values: list[list[float]] = [[] for _ in range(BLOCKS)]
+    block_size = (segment_end - segment_start) / BLOCKS
+    for row in rows:
+        block = min(
+            BLOCKS - 1,
+            int((row["index"] - segment_start) / block_size),
+        )
+        block_values[block].append(row["gross_return"])
+
+    counts = [len(values) for values in block_values]
+    means = [
+        sum(values) / len(values) if values else None
+        for values in block_values
+    ]
+    valid = [value for value in means if value is not None]
+    med = median(valid) if valid else math.nan
+    stress_multiple = med / STRESS_COST if math.isfinite(med) else math.nan
+    gate = (
+        len(rows) >= BLOCKS * MIN_OBSERVATIONS_PER_BLOCK
+        and all(count >= MIN_OBSERVATIONS_PER_BLOCK for count in counts)
+        and len(valid) == BLOCKS
+        and all(value > 0 for value in valid)
+        and stress_multiple >= 4.0
+    )
+    return {
+        "observations": len(rows),
+        "block_observations": counts,
+        "non_overlapping": True,
+        "block_mean_gross_returns": means,
+        "median_block_gross_return": med if math.isfinite(med) else None,
+        "stress_cost_multiple": (
+            stress_multiple if math.isfinite(stress_multiple) else None
+        ),
+        "passes_4x_stress_gate": gate,
+    }
+
+
+def evaluate_segment(
+    name: str,
+    horizon: int,
+    feat: dict[str, dict[str, list[float]]],
+    pair_length: int,
+    segment_start: int,
+    segment_end: int,
+) -> dict[str, Any]:
+    rows: list[dict[str, float]] = []
+    start = max(220, segment_start)
+    for i in range(start, segment_end - horizon, horizon):
+        symbol, direction = choose_signal(
+            name, i, feat["BTC"], feat["ETH"]
+        )
+        if symbol is None:
+            continue
+        data = feat[symbol]
+        gross = direction * (
+            data["close"][i + horizon] / data["close"][i] - 1
+        )
+        rows.append({"index": i, "gross_return": gross})
+    return summarize(rows, segment_start, segment_end)
 
 
 def evaluate(btc_path: Path, eth_path: Path) -> dict[str, Any]:
     pair = align_pair(load_bars(btc_path), load_bars(eth_path))
-    if len(pair) < 3 * 365 * 24:
+    required = 3 * 365 * 24
+    if len(pair) < required:
         raise ValueError("need at least three years of aligned hourly candles")
-    pair = pair[-3 * 365 * 24:]
-    bars = {"BTC": [item.btc for item in pair], "ETH": [item.eth for item in pair]}
+    pair = pair[-required:]
+    holdout_start = len(pair) - HOLDOUT_MIN_HOURS
+    if holdout_start <= 220:
+        raise ValueError("three-year window is too short for the frozen holdout")
+
+    bars = {
+        "BTC": [item.btc for item in pair],
+        "ETH": [item.eth for item in pair],
+    }
     feat = {symbol: features(values) for symbol, values in bars.items()}
     results: dict[str, Any] = {}
+
     for name in signal_names():
         results[name] = {}
         for horizon in HORIZONS:
-            rows: list[dict[str, float]] = []
-            start = 220
-            for i in range(start, len(pair) - horizon, horizon):
-                symbol, direction = choose_signal(name, i, feat["BTC"], feat["ETH"])
-                if symbol is None:
-                    continue
-                data = feat[symbol]
-                gross = direction * (data["close"][i + horizon] / data["close"][i] - 1)
-                rows.append({"index": i, "gross_return": gross})
-            block_values: list[list[float]] = [[] for _ in range(BLOCKS)]
-            block_size = len(pair) / BLOCKS
-            for row in rows:
-                block = min(BLOCKS - 1, int(row["index"] / block_size))
-                block_values[block].append(row["gross_return"])
-            block_means = [sum(values) / len(values) if values else math.nan for values in block_values]
-            valid_blocks = [value for value in block_means if math.isfinite(value)]
-            base_multiple = median(valid_blocks) / BASE_COST if valid_blocks else math.nan
-            stress_multiple = median(valid_blocks) / STRESS_COST if valid_blocks else math.nan
-            eligible = (
-                len(rows) >= MIN_OBSERVATIONS_PER_BLOCK * BLOCKS
-                and len(valid_blocks) == BLOCKS
-                and all(value > 0 for value in valid_blocks)
-                and stress_multiple >= 4.0
+            discovery = evaluate_segment(
+                name, horizon, feat, len(pair), 0, holdout_start
+            )
+            holdout = evaluate_segment(
+                name, horizon, feat, len(pair), holdout_start, len(pair)
             )
             results[name][str(horizon)] = {
-                "observations": len(rows),
-                "non_overlapping": True,
-                "block_mean_gross_returns": block_means,
-                "median_block_gross_return": median(valid_blocks) if valid_blocks else None,
-                "base_cost_multiple": base_multiple if math.isfinite(base_multiple) else None,
-                "stress_cost_multiple": stress_multiple if math.isfinite(stress_multiple) else None,
-                "passes_4x_stress_gate": eligible,
+                "candidate_id": f"{name}:{horizon}",
+                "discovery": discovery,
+                "holdout": holdout,
+                "selected_for_holdout": discovery["passes_4x_stress_gate"],
+                "passes_discovery_and_holdout": (
+                    discovery["passes_4x_stress_gate"]
+                    and holdout["passes_4x_stress_gate"]
+                ),
             }
-    passing = [f"{name}:{horizon}" for name, horizons in results.items()
-               for horizon, result in horizons.items() if result["passes_4x_stress_gate"]]
+
+    passing = [
+        f"{name}:{horizon}"
+        for name, horizons in results.items()
+        for horizon, result in horizons.items()
+        if result["passes_discovery_and_holdout"]
+    ]
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "research_only": True,
         "paper_orders_placed": False,
         "live_orders_placed": False,
         "leverage_enabled": False,
-        "window": {"start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(),
-                   "bars": len(pair), "blocks": BLOCKS, "completed_candles_only": True},
-        "costs": {"base_round_trip": BASE_COST, "stress_round_trip": STRESS_COST},
-        "method": {"horizons_hours": HORIZONS, "sample_every_horizon": True,
-                   "minimum_observations_per_block": MIN_OBSERVATIONS_PER_BLOCK,
-                   "promotion_requires_4x_stress_and_positive_blocks": True},
+        "execution_realism": "gross_movement_diagnostic",
+        "execution_model_reference": STRESS_EXECUTION.as_dict(),
+        "window": {
+            "start": pair[0].timestamp.isoformat(),
+            "end": pair[-1].timestamp.isoformat(),
+            "bars": len(pair),
+            "blocks_per_segment": BLOCKS,
+            "discovery_end_index": holdout_start - 1,
+            "holdout_start_index": holdout_start,
+            "holdout_hours": HOLDOUT_MIN_HOURS,
+            "completed_candles_only": True,
+        },
+        "costs": {
+            "stress_round_trip": STRESS_COST,
+            "stress_round_trip_bps": STRESS_EXECUTION.round_trip_bps,
+        },
+        "method": {
+            "horizons_hours": HORIZONS,
+            "sample_every_horizon": True,
+            "minimum_observations_per_block": MIN_OBSERVATIONS_PER_BLOCK,
+            "promotion_requires_discovery_and_holdout": True,
+            "holdout_is_not_used_for_selection": True,
+            "multiple_testing": {
+                "family_size": FAMILY_SIZE,
+                "correction": "chronological_holdout_confirmation",
+                "every_candidate_horizon_requires_confirmation": True,
+            },
+        },
         "candidates": results,
         "passing_candidates": passing,
         "status": "candidate_found" if passing else "no_candidate_passed",
+        "status_note": (
+            "A passing gross diagnostic is not profitability evidence; "
+            "fill-based net P&L is still required."
+        ),
     }
 
 
@@ -156,8 +269,13 @@ def main() -> int:
     args = parser.parse_args()
     report = evaluate(args.btc_path, args.eth_path)
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
-    print(json.dumps({"status": report["status"], "passing_candidates": report["passing_candidates"]}, indent=2))
+    args.output.write_text(
+        json.dumps(report, indent=2, allow_nan=False), encoding="utf-8"
+    )
+    print(json.dumps({
+        "status": report["status"],
+        "passing_candidates": report["passing_candidates"],
+    }, indent=2))
     return 0
 
 

--- a/scripts/run_frozen_candidate_validation.py
+++ b/scripts/run_frozen_candidate_validation.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Fail-closed validation of the frozen high_quality_entry candidate.
+
+The candidate and parameters are read from the pre-registered definitions.
+Windows never overlap, the final holdout is evaluated last, and missing
+trade-level or exact-fill metrics block advancement.
+"""
+from __future__ import annotations
+import argparse, json, math, statistics
+from pathlib import Path
+from typing import Mapping
+
+try:
+    from scripts.run_momentum_volatility_research import load_bars
+    from scripts.run_momentum_volatility_v3 import align_pair, build_pair_features, run_pair
+    from scripts.run_v3_exploration import candidate_definitions
+except ModuleNotFoundError:
+    from run_momentum_volatility_research import load_bars
+    from run_momentum_volatility_v3 import align_pair, build_pair_features, run_pair
+    from run_v3_exploration import candidate_definitions
+
+def safe(v):
+    if isinstance(v, float):
+        return v if math.isfinite(v) else None
+    if isinstance(v, Mapping):
+        return {str(k): safe(x) for k, x in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [safe(x) for x in v]
+    return v
+
+def result(pair, features, config, start, end, fees, slip):
+    r = run_pair(pair, initial_balance=75000.0, order_notional=6000.0,
+                 fees_bps=fees, slippage_bps=slip, config=config,
+                 start_index=start, end_index=end, feature_map=features)
+    # The current v3 engine does not expose a fill ledger/equity series.
+    r.update({
+        "sharpe_annualized": None,
+        "profit_factor": None,
+        "exact_fill_ledger": False,
+        "trade_level_metrics_complete": False,
+    })
+    return r
+
+def run_validation(btc_path: Path, eth_path: Path, output: Path):
+    pair = align_pair(load_bars(btc_path), load_bars(eth_path))
+    if len(pair) < 3 * 365 * 24:
+        raise ValueError("need at least three years of aligned hourly candles")
+    pair = pair[-3 * 365 * 24:]
+    n = len(pair)
+    blocks = {
+        "development": (0, n // 2),
+        "walk_forward_1": (n // 2, n * 5 // 8),
+        "walk_forward_2": (n * 5 // 8, n * 3 // 4),
+        "walk_forward_3": (n * 3 // 4, n * 7 // 8),
+        "final_unseen_holdout": (n * 7 // 8, n),
+    }
+    config = candidate_definitions()["high_quality_entry"]
+    features = build_pair_features(pair, config)
+    reports = {}
+    for name, (start, end) in blocks.items():
+        reports[name] = {
+            "indices": {"start": start, "end": end, "bars": end - start},
+            "base": result(pair, features, config, start, end, 10.0, 9.0),
+            "stress": result(pair, features, config, start, end, 20.0, 23.0),
+        }
+    test_blocks = [reports[f"walk_forward_{i}"] for i in range(1, 4)]
+    base_returns = [float(x["base"]["return_pct"]) for x in test_blocks]
+    stress_returns = [float(x["stress"]["return_pct"]) for x in test_blocks]
+    reasons = []
+    if not all(x > 0 for x in base_returns):
+        reasons.append("not all base walk-forward blocks are positive")
+    if not all(x > 0 for x in stress_returns):
+        reasons.append("not all stress walk-forward blocks are positive")
+    for name, report in reports.items():
+        for scenario in ("base", "stress"):
+            r = report[scenario]
+            if r["entries"] < 5:
+                reasons.append(f"{name} {scenario} has fewer than five entries")
+            if r["sharpe_annualized"] is None:
+                reasons.append(f"{name} {scenario} Sharpe unavailable")
+            if r["profit_factor"] is None:
+                reasons.append(f"{name} {scenario} profit factor unavailable")
+            if not r["exact_fill_ledger"]:
+                reasons.append(f"{name} {scenario} exact fill ledger unavailable")
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "candidate": "high_quality_entry",
+        "parameters": config.as_dict(),
+        "window": {"start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(), "bars": n, "completed_candles_only": True},
+        "blocks": reports,
+        "non_overlapping": True,
+        "forward_test_reused_for_training": False,
+        "median_walk_forward_return_pct": {"base": statistics.median(base_returns), "stress": statistics.median(stress_returns)},
+        "eligible_for_confirmation": not reasons,
+        "failure_reasons": reasons,
+        "promotion_allowed": False,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(safe(report), indent=2, allow_nan=False), encoding="utf-8")
+    return report
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--btc-path", type=Path, required=True)
+    p.add_argument("--eth-path", type=Path, required=True)
+    p.add_argument("--output", type=Path, required=True)
+    args = p.parse_args()
+    report = run_validation(args.btc_path, args.eth_path, args.output)
+    print(json.dumps({"eligible_for_confirmation": report["eligible_for_confirmation"], "failure_reasons": report["failure_reasons"]}, indent=2))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_hedge_fund_strategy_suite.py
+++ b/scripts/run_hedge_fund_strategy_suite.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Research-only multi-strategy crypto suite with trade-level metrics.
+
+This is a pre-registered comparison, not an optimizer and not a trading
+service. It uses only closed candles for signals, fills at the next open,
+one long position at a time, no leverage, and explicit base/stress costs.
+"""
+from __future__ import annotations
+import argparse, json, math, statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+try:
+    from scripts.run_momentum_volatility_research import Bar, load_bars
+    from scripts.run_momentum_volatility_v3 import PairBar, align_pair
+except ModuleNotFoundError:
+    from run_momentum_volatility_research import Bar, load_bars
+    from run_momentum_volatility_v3 import PairBar, align_pair
+
+HOURS_PER_YEAR = 24 * 365
+THREE_YEARS = 3 * 365 * 24
+
+@dataclass(frozen=True)
+class Costs:
+    fee_bps: float
+    spread_bps: float
+    slippage_bps: float
+    impact_bps: float
+    @property
+    def slip_bps(self) -> float:
+        return self.spread_bps / 2 + self.slippage_bps + self.impact_bps
+    @property
+    def round_trip_bps(self) -> float:
+        return 2 * (self.fee_bps + self.slip_bps)
+BASE = Costs(10, 4, 5, 2)
+STRESS = Costs(20, 10, 10, 8)
+
+def mean(xs):
+    return sum(xs) / len(xs) if xs else math.nan
+
+def sma(xs, n):
+    out = [math.nan] * len(xs)
+    for i in range(n - 1, len(xs)):
+        out[i] = mean(xs[i - n + 1:i + 1])
+    return out
+
+def stdev(xs, n):
+    out = [math.nan] * len(xs)
+    for i in range(n - 1, len(xs)):
+        w = xs[i - n + 1:i + 1]
+        m = mean(w)
+        out[i] = math.sqrt(sum((x - m) ** 2 for x in w) / max(1, len(w) - 1))
+    return out
+
+def ema(xs, n):
+    out = [math.nan] * len(xs)
+    if len(xs) < n:
+        return out
+    value = mean(xs[:n])
+    out[n - 1] = value
+    alpha = 2 / (n + 1)
+    for i in range(n, len(xs)):
+        value = alpha * xs[i] + (1 - alpha) * value
+        out[i] = value
+    return out
+
+def prior_max(xs, n, i):
+    if i < n + 1:
+        return math.nan
+    return max(xs[i - n:i])
+
+def asset_features(bars: list[Bar]) -> dict[str, list[float]]:
+    closes = [float(b.close) for b in bars]
+    returns = [math.nan] + [math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes))]
+    return {
+        "close": closes,
+        "ema100": ema(closes, 100),
+        "ema200": ema(closes, 200),
+        "sma48": sma(closes, 48),
+        "std48": stdev(closes, 48),
+        "ret24": [math.nan if i < 24 else closes[i] / closes[i - 24] - 1 for i in range(len(closes))],
+        "ret48": [math.nan if i < 48 else closes[i] / closes[i - 48] - 1 for i in range(len(closes))],
+        "vol24": stdev([0 if not math.isfinite(x) else x for x in returns], 24),
+        "prior_high48": [prior_max([float(b.high) for b in bars], 48, i) for i in range(len(bars))],
+    }
+
+def signal(name: str, i: int, f: Mapping[str, Mapping[str, list[float]]]) -> tuple[str | None, float]:
+    btc, eth = f["BTC"], f["ETH"]
+    if i < 220:
+        return None, 0.0
+    def valid(*xs): return all(math.isfinite(float(x)) for x in xs)
+    if name in {"trend_defensive", "volatility_target"}:
+        candidates = []
+        for s, x in (("BTC", btc), ("ETH", eth)):
+            if valid(x["ret24"][i], x["ema200"][i]) and x["ret24"][i] > 0 and x["close"][i] > x["ema200"][i]:
+                candidates.append((x["ret24"][i], s, x))
+        if not candidates:
+            return None, 0.0
+        _, s, x = max(candidates)
+        size = 1.0
+        if name == "volatility_target" and valid(x["vol24"][i]) and x["vol24"][i] > 0:
+            size = min(1.0, 0.01 / x["vol24"][i])
+        return s, max(0.25, size)
+    if name == "relative_strength":
+        if not valid(btc["ret48"][i], eth["ret48"][i]):
+            return None, 0.0
+        leader = "BTC" if btc["ret48"][i] > eth["ret48"][i] else "ETH"
+        x = f[leader]
+        if x["ret48"][i] - f["ETH" if leader == "BTC" else "BTC"]["ret48"][i] < 0.02 or x["close"][i] <= x["ema100"][i]:
+            return None, 0.0
+        return leader, 1.0
+    if name == "mean_reversion":
+        scores = []
+        for s, x in (("BTC", btc), ("ETH", eth)):
+            if valid(x["close"][i], x["sma48"][i], x["std48"][i]) and x["std48"][i] > 0:
+                scores.append(((x["close"][i] - x["sma48"][i]) / x["std48"][i], s))
+        if not scores:
+            return None, 0.0
+        z, s = min(scores)
+        return (s, 0.75) if z < -1.5 else (None, 0.0)
+    if name == "breakout":
+        candidates = []
+        for s, x in (("BTC", btc), ("ETH", eth)):
+            if valid(x["close"][i], x["prior_high48"][i], x["ema100"][i]) and x["close"][i] > x["prior_high48"][i] and x["close"][i] > x["ema100"][i]:
+                candidates.append((x["ret48"][i] if valid(x["ret48"][i]) else -math.inf, s))
+        return (max(candidates)[1], 1.0) if candidates else (None, 0.0)
+    raise ValueError(f"unknown strategy {name}")
+
+def run_strategy(pair: list[PairBar], name: str, costs: Costs, initial_balance: float = 75000.0, order_notional: float = 6000.0) -> dict[str, object]:
+    bars = {"BTC": [x.btc for x in pair], "ETH": [x.eth for x in pair]}
+    f = {s: asset_features(v) for s, v in bars.items()}
+    cash, qty, symbol = initial_balance, 0.0, None
+    pending: tuple[str | None, float] = (None, 0.0)
+    equity = []
+    trade_pnl = []
+    execution_cost = 0.0
+    entries = 0
+    for i in range(220, len(pair)):
+        if symbol is not None and pending[0] != symbol:
+            price = bars[symbol][i].open
+            proceeds = qty * price * (1 - costs.slip_bps / 10000) * (1 - costs.fee_bps / 10000)
+            cash += proceeds
+            trade_pnl.append(cash - initial_balance if not trade_pnl else cash - initial_balance - sum(trade_pnl))
+            execution_cost += qty * price * (costs.fee_bps + costs.slip_bps) / 10000
+            qty, symbol = 0.0, None
+        if symbol is None and pending[0] is not None:
+            s, size = pending
+            price = bars[s][i].open
+            notional = min(cash, order_notional * size)
+            fill = price * (1 + costs.slip_bps / 10000)
+            qty = notional / fill * (1 - costs.fee_bps / 10000)
+            cash -= notional
+            execution_cost += notional * (costs.fee_bps + costs.slip_bps) / 10000
+            symbol, entries = s, entries + 1
+        mark = cash + (qty * bars[symbol][i].close if symbol is not None else 0.0)
+        equity.append(mark)
+        pending = signal(name, i, f)
+    if symbol is not None:
+        price = bars[symbol][-1].close
+        cash += qty * price * (1 - costs.slip_bps / 10000) * (1 - costs.fee_bps / 10000)
+        execution_cost += qty * price * (costs.fee_bps + costs.slip_bps) / 10000
+        qty, symbol = 0.0, None
+    ending = cash
+    peaks, dd = initial_balance, 0.0
+    returns = []
+    for a, b in zip([initial_balance] + equity[:-1], equity):
+        if a > 0:
+            returns.append(b / a - 1)
+            peaks = max(peaks, b)
+            dd = max(dd, (peaks - b) / peaks)
+    avg, sd = mean(returns), stdev(returns, len(returns))
+    gains = sum(x for x in trade_pnl if x > 0)
+    losses = abs(sum(x for x in trade_pnl if x < 0))
+    return {
+        "strategy": name, "initial_balance": initial_balance, "ending_balance": ending,
+        "pnl_quote": ending - initial_balance, "return_pct": (ending / initial_balance - 1) * 100,
+        "max_drawdown_pct": dd * 100, "entries": entries, "trades": entries * 2,
+        "sharpe_annualized": (avg / sd * math.sqrt(HOURS_PER_YEAR)) if sd > 0 else None,
+        "profit_factor": (gains / losses) if losses > 0 else None,
+        "execution_cost_quote": execution_cost, "round_trip_bps": costs.round_trip_bps,
+    }
+
+def run_suite(btc_path: Path, eth_path: Path, output: Path) -> dict[str, object]:
+    pair = align_pair(load_bars(btc_path), load_bars(eth_path))
+    if len(pair) < THREE_YEARS:
+        raise ValueError("need at least three years of aligned hourly candles")
+    pair = pair[-THREE_YEARS:]
+    names = ["trend_defensive", "relative_strength", "mean_reversion", "breakout", "volatility_target"]
+    report = {
+        "schema_version": 1, "research_only": True, "orders_placed": False,
+        "leverage_enabled": False, "automatic_promotion": False,
+        "window": {"start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(), "bars": len(pair), "completed_candles_only": True},
+        "strategies": {name: {"base": run_strategy(pair, name, BASE), "stress": run_strategy(pair, name, STRESS)} for name in names},
+        "gates": {"requires_positive_stress_median": True, "requires_non_overlapping_walk_forward": True, "requires_trade_level_metrics": True, "promotion_allowed": False},
+        "limitations": ["full-sample results are discovery evidence, not confirmation", "no shorting or leverage", "no news/funding/basis feed in this suite"],
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    return report
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--btc-path", type=Path, required=True); p.add_argument("--eth-path", type=Path, required=True); p.add_argument("--output", type=Path, required=True)
+    r = run_suite(p.parse_args().btc_path, p.parse_args().eth_path, p.parse_args().output)
+    print(json.dumps({"strategies": list(r["strategies"]), "window": r["window"]}, indent=2))
+    return 0
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_hedge_fund_strategy_suite.py
+++ b/scripts/run_hedge_fund_strategy_suite.py
@@ -6,10 +6,10 @@ service. It uses only closed candles for signals, fills at the next open,
 one long position at a time, no leverage, and explicit base/stress costs.
 """
 from __future__ import annotations
-import argparse, json, math, statistics
+import argparse, json, math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Mapping
+from typing import Mapping
 
 try:
     from scripts.run_momentum_volatility_research import Bar, load_bars
@@ -169,7 +169,8 @@ def run_strategy(pair: list[PairBar], name: str, costs: Costs, initial_balance: 
             returns.append(b / a - 1)
             peaks = max(peaks, b)
             dd = max(dd, (peaks - b) / peaks)
-    avg, sd = mean(returns), stdev(returns, len(returns))
+    avg = mean(returns)
+    sd = math.sqrt(sum((x - avg) ** 2 for x in returns) / max(1, len(returns) - 1)) if returns else math.nan
     gains = sum(x for x in trade_pnl if x > 0)
     losses = abs(sum(x for x in trade_pnl if x < 0))
     return {
@@ -202,7 +203,8 @@ def run_suite(btc_path: Path, eth_path: Path, output: Path) -> dict[str, object]
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--btc-path", type=Path, required=True); p.add_argument("--eth-path", type=Path, required=True); p.add_argument("--output", type=Path, required=True)
-    r = run_suite(p.parse_args().btc_path, p.parse_args().eth_path, p.parse_args().output)
+    args = p.parse_args()
+    r = run_suite(args.btc_path, args.eth_path, args.output)
     print(json.dumps({"strategies": list(r["strategies"]), "window": r["window"]}, indent=2))
     return 0
 if __name__ == "__main__":

--- a/scripts/run_hedge_fund_strategy_suite.py
+++ b/scripts/run_hedge_fund_strategy_suite.py
@@ -132,6 +132,8 @@ def run_strategy(pair: list[PairBar], name: str, costs: Costs, initial_balance: 
     f = {s: asset_features(v) for s, v in bars.items()}
     cash, qty, symbol = initial_balance, 0.0, None
     pending: tuple[str | None, float] = (None, 0.0)
+    none_streak = 0
+    hold_confirm_bars = 6
     equity = []
     trade_pnl = []
     execution_cost = 0.0
@@ -155,7 +157,17 @@ def run_strategy(pair: list[PairBar], name: str, costs: Costs, initial_balance: 
             symbol, entries = s, entries + 1
         mark = cash + (qty * bars[symbol][i].close if symbol is not None else 0.0)
         equity.append(mark)
-        pending = signal(name, i, f)
+        next_symbol, next_size = signal(name, i, f)
+        if next_symbol is None:
+            if symbol is not None and none_streak < hold_confirm_bars:
+                none_streak += 1
+                pending = (symbol, pending[1] if pending[0] == symbol else 1.0)
+            else:
+                none_streak += 1
+                pending = (None, 0.0)
+        else:
+            none_streak = 0
+            pending = (next_symbol, next_size)
     if symbol is not None:
         price = bars[symbol][-1].close
         cash += qty * price * (1 - costs.slip_bps / 10000) * (1 - costs.fee_bps / 10000)

--- a/scripts/run_pattern_trend_scan.py
+++ b/scripts/run_pattern_trend_scan.py
@@ -1,47 +1,82 @@
 #!/usr/bin/env python3
-"""Research-only mathematical pattern/trend scan.
+"""Research-only pattern scan with discovery and frozen holdout gates.
 
-The pattern universe is fixed before evaluation. Signals use closed candles and
-are sampled every holding horizon so forward labels do not overlap.
+This is a cost-referenced gross-movement diagnostic, not an execution
+backtest. It uses completed candles and non-overlapping labels. The shared
+execution model supplies the stress-cost reference; execution realism is
+deferred to the fill-based validation stage.
 """
 from __future__ import annotations
-import argparse, json, math
+
+import argparse
+import json
+import math
 from pathlib import Path
 from statistics import median
-from typing import Any
 
 try:
+    from scripts.execution_model import STRESS_EXECUTION
     from scripts.run_momentum_volatility_research import load_bars
     from scripts.run_momentum_volatility_v3 import align_pair
 except ModuleNotFoundError:
+    from execution_model import STRESS_EXECUTION
     from run_momentum_volatility_research import load_bars
     from run_momentum_volatility_v3 import align_pair
 
-BASE_COST, STRESS_COST = 0.0038, 0.0086
-HORIZONS, BLOCKS, MIN_PER_BLOCK = (6, 24, 48, 96), 6, 20
+HORIZONS = (6, 24, 48, 96)
+BLOCKS = 6
+MIN_PER_BLOCK = 20
+HOLDOUT_MIN_HOURS = BLOCKS * MIN_PER_BLOCK * max(HORIZONS)
+STRESS_COST = STRESS_EXECUTION.round_trip_bps / 10_000.0
+PATTERNS = (
+    "trend_structure", "breakout", "vol_expansion",
+    "vol_contraction_break", "relative_strength", "momentum_decay",
+    "mean_reversion", "exhaustion",
+)
+FAMILY_SIZE = len(PATTERNS) * len(HORIZONS)
 
 
-def mean(x):
-    return sum(x) / len(x) if x else math.nan
+def mean(values):
+    return sum(values) / len(values) if values else math.nan
 
 
 def feat(bars):
-    c = [float(x.close) for x in bars]
-    h = [float(x.high) for x in bars]
-    l = [float(x.low) for x in bars]
-    r = [(h[i] - l[i]) / c[i] if c[i] else math.nan for i in range(len(c))]
-    out = {"c": c, "h": h, "l": l, "r": r}
+    close = [float(x.close) for x in bars]
+    high = [float(x.high) for x in bars]
+    low = [float(x.low) for x in bars]
+    candle_range = [
+        (high[i] - low[i]) / close[i] if close[i] else math.nan
+        for i in range(len(close))
+    ]
+    out = {"c": close, "h": high, "l": low, "r": candle_range}
     for n in (6, 24, 48, 96, 200):
-        out[f"m{n}"] = [math.nan if i < n else c[i] / c[i-n] - 1 for i in range(len(c))]
-        out[f"avg_r{n}"] = [mean(r[i-n+1:i+1]) if i >= n-1 else math.nan for i in range(len(c))]
-        out[f"avg_c{n}"] = [mean(c[i-n+1:i+1]) if i >= n-1 else math.nan for i in range(len(c))]
-    out["high48"] = [max(h[i-48:i]) if i >= 49 else math.nan for i in range(len(c))]
-    out["low48"] = [min(l[i-48:i]) if i >= 49 else math.nan for i in range(len(c))]
+        out[f"m{n}"] = [
+            math.nan if i < n else close[i] / close[i - n] - 1
+            for i in range(len(close))
+        ]
+        out[f"avg_r{n}"] = [
+            mean(candle_range[i - n + 1:i + 1])
+            if i >= n - 1 else math.nan
+            for i in range(len(close))
+        ]
+        out[f"avg_c{n}"] = [
+            mean(close[i - n + 1:i + 1])
+            if i >= n - 1 else math.nan
+            for i in range(len(close))
+        ]
+    out["high48"] = [
+        max(high[i - 48:i]) if i >= 49 else math.nan
+        for i in range(len(close))
+    ]
+    out["low48"] = [
+        min(low[i - 48:i]) if i >= 49 else math.nan
+        for i in range(len(close))
+    ]
     return out
 
 
-def ok(*x):
-    return all(math.isfinite(float(v)) for v in x)
+def ok(*values):
+    return all(math.isfinite(float(value)) for value in values)
 
 
 def choose(name, i, b, e):
@@ -51,106 +86,211 @@ def choose(name, i, b, e):
     if name == "relative_strength":
         if not ok(b["m24"][i], e["m24"][i]):
             return None, 0
-        return ("BTC", 1) if b["m24"][i] > e["m24"][i] + .01 else (("ETH", 1) if e["m24"][i] > b["m24"][i] + .01 else (None, 0))
+        if b["m24"][i] > e["m24"][i] + 0.01:
+            return "BTC", 1
+        if e["m24"][i] > b["m24"][i] + 0.01:
+            return "ETH", 1
+        return None, 0
+
     eligible = []
-    for s, x in assets:
-        if not ok(x["c"][i], x["m24"][i], x["m48"][i], x["m96"][i], x["avg_r24"][i]):
+    for symbol, data in assets:
+        if not ok(data["c"][i], data["m24"][i], data["m48"][i],
+                  data["m96"][i], data["avg_r24"][i]):
             continue
-        trend = x["c"][i] > x["avg_c200"][i] and x["m24"][i] > 0
-        breakout = ok(x["high48"][i], x["low48"][i]) and (x["c"][i] > x["high48"][i] or x["c"][i] < x["low48"][i])
-        expansion = x["r"][i] > 1.25 * x["avg_r24"][i]
-        contraction = x["r"][i] < .75 * x["avg_r24"][i]
-        if name == "trend_structure" and trend and x["m48"][i] > x["m24"][i]:
-            eligible.append((x["m24"][i], s, 1))
+        trend = data["c"][i] > data["avg_c200"][i] and data["m24"][i] > 0
+        breakout = (
+            ok(data["high48"][i], data["low48"][i])
+            and (data["c"][i] > data["high48"][i]
+                 or data["c"][i] < data["low48"][i])
+        )
+        expansion = data["r"][i] > 1.25 * data["avg_r24"][i]
+        contraction = data["r"][i] < 0.75 * data["avg_r24"][i]
+
+        if name == "trend_structure" and trend and data["m48"][i] > data["m24"][i]:
+            eligible.append((data["m24"][i], symbol, 1))
         elif name == "breakout" and breakout and trend:
-            eligible.append((abs(x["m24"][i]), s, 1 if x["m24"][i] > 0 else -1))
+            direction = 1 if data["m24"][i] > 0 else -1
+            eligible.append((abs(data["m24"][i]), symbol, direction))
         elif name == "vol_expansion" and expansion and trend:
-            eligible.append((x["m24"][i], s, 1))
+            eligible.append((data["m24"][i], symbol, 1))
         elif name == "vol_contraction_break" and contraction and breakout:
-            eligible.append((abs(x["m24"][i]), s, 1 if x["m24"][i] > 0 else -1))
-        elif name == "momentum_decay" and trend and x["m48"][i] > 0 and x["m24"][i] < x["m48"][i] * .5:
-            eligible.append((x["m24"][i], s, 1))
-        elif name == "mean_reversion" and x["m24"][i] < -.03:
-            eligible.append((abs(x["m24"][i]), s, 1))
-        elif name == "exhaustion" and x["m48"][i] > .15 and x["m24"][i] < 0:
-            eligible.append((abs(x["m24"][i]), s, -1))
+            direction = 1 if data["m24"][i] > 0 else -1
+            eligible.append((abs(data["m24"][i]), symbol, direction))
+        elif name == "momentum_decay" and trend and data["m48"][i] > 0 and data["m24"][i] < data["m48"][i] * 0.5:
+            eligible.append((data["m24"][i], symbol, 1))
+        elif name == "mean_reversion" and data["m24"][i] < -0.03:
+            eligible.append((abs(data["m24"][i]), symbol, 1))
+        elif name == "exhaustion" and data["m48"][i] > 0.15 and data["m24"][i] < 0:
+            eligible.append((abs(data["m24"][i]), symbol, -1))
+
     if not eligible:
         return None, 0
-    _, s, direction = max(eligible)
-    return s, direction
+    _, symbol, direction = max(eligible)
+    return symbol, direction
 
 
-def classify(observations, valid_blocks, median_gross, stress_multiple):
-    positive_blocks = sum(x > 0 for x in valid_blocks)
-    if observations < BLOCKS * MIN_PER_BLOCK or len(valid_blocks) != BLOCKS:
-        return "insufficient_sample"
-    if median_gross <= 0:
-        return "negative_gross_edge"
-    if positive_blocks < 4:
-        return "unstable_regime"
-    if stress_multiple < 1:
-        return "cost_sensitive"
-    if stress_multiple < 4:
-        return "promising_needs_adjustment"
-    return "robust_candidate"
+def summarize(rows, segment_start, segment_end):
+    groups = [[] for _ in range(BLOCKS)]
+    block_size = (segment_end - segment_start) / BLOCKS
+    for index, value in rows:
+        block = min(
+            BLOCKS - 1,
+            int((index - segment_start) / block_size),
+        )
+        groups[block].append(value)
+
+    counts = [len(group) for group in groups]
+    means = [mean(group) if group else None for group in groups]
+    valid = [value for value in means if value is not None]
+    med = median(valid) if valid else math.nan
+    stress_multiple = med / STRESS_COST if math.isfinite(med) else math.nan
+    gate = (
+        len(rows) >= BLOCKS * MIN_PER_BLOCK
+        and all(count >= MIN_PER_BLOCK for count in counts)
+        and len(valid) == BLOCKS
+        and all(value > 0 for value in valid)
+        and stress_multiple >= 4.0
+    )
+    return {
+        "observations": len(rows),
+        "block_observations": counts,
+        "non_overlapping": True,
+        "block_mean_gross_returns": means,
+        "median_block_gross_return": med if math.isfinite(med) else None,
+        "stress_cost_multiple": (
+            stress_multiple if math.isfinite(stress_multiple) else None
+        ),
+        "passes_4x_stress_gate": gate,
+    }
 
 
 def scan(btc_path: Path, eth_path: Path):
     pair = align_pair(load_bars(btc_path), load_bars(eth_path))
-    pair = pair[-3 * 365 * 24:]
-    if len(pair) < 3 * 365 * 24:
-        raise ValueError("three years of aligned candles required")
+    required = 3 * 365 * 24
+    if len(pair) < required:
+        raise ValueError("three years of aligned hourly candles required")
+    pair = pair[-required:]
+    holdout_start = len(pair) - HOLDOUT_MIN_HOURS
+    if holdout_start <= 220:
+        raise ValueError("three-year window is too short for the frozen holdout")
+
     bars = {"BTC": [x.btc for x in pair], "ETH": [x.eth for x in pair]}
-    f = {s: feat(v) for s, v in bars.items()}
-    names = ("trend_structure", "breakout", "vol_expansion", "vol_contraction_break",
-             "relative_strength", "momentum_decay", "mean_reversion", "exhaustion")
+    f = {symbol: feat(values) for symbol, values in bars.items()}
     results = {}
-    for name in names:
+
+    for name in PATTERNS:
         results[name] = {}
         for horizon in HORIZONS:
-            rows = []
-            for i in range(220, len(pair) - horizon, horizon):
+            discovery = []
+            for i in range(220, holdout_start - horizon, horizon):
                 symbol, direction = choose(name, i, f["BTC"], f["ETH"])
                 if symbol:
                     x = f[symbol]
-                    rows.append((i, direction * (x["c"][i+horizon] / x["c"][i] - 1)))
-            blocks = [[] for _ in range(BLOCKS)]
-            for i, value in rows:
-                blocks[min(BLOCKS - 1, int(i / (len(pair) / BLOCKS)))].append(value)
-            means = [mean(x) for x in blocks]
-            valid = [x for x in means if math.isfinite(x)]
-            med = median(valid) if valid else math.nan
+                    discovery.append(
+                        (i, direction * (x["c"][i + horizon] / x["c"][i] - 1))
+                    )
+            holdout = []
+            for i in range(holdout_start, len(pair) - horizon, horizon):
+                symbol, direction = choose(name, i, f["BTC"], f["ETH"])
+                if symbol:
+                    x = f[symbol]
+                    holdout.append(
+                        (i, direction * (x["c"][i + horizon] / x["c"][i] - 1))
+                    )
+
+            discovery_result = summarize(discovery, 0, holdout_start)
+            holdout_result = summarize(
+                holdout, holdout_start, len(pair)
+            )
             results[name][str(horizon)] = {
-                "observations": len(rows), "non_overlapping": True,
-                "block_mean_gross_returns": means,
-                "median_block_gross_return": med if math.isfinite(med) else None,
-                "base_cost_multiple": med / BASE_COST if math.isfinite(med) else None,
-                "stress_cost_multiple": med / STRESS_COST if math.isfinite(med) else None,
-                "positive_blocks": sum(x > 0 for x in valid),
-                "classification": classify(len(rows), valid, med, med / STRESS_COST if math.isfinite(med) else math.nan),
-                "passes_4x_stress_gate": bool(len(rows) >= BLOCKS * MIN_PER_BLOCK and len(valid) == BLOCKS and all(x > 0 for x in valid) and med / STRESS_COST >= 4),
+                "candidate_id": f"{name}:{horizon}",
+                "discovery": discovery_result,
+                "holdout": holdout_result,
+                "selected_for_holdout": discovery_result["passes_4x_stress_gate"],
+                "passes_discovery_and_holdout": (
+                    discovery_result["passes_4x_stress_gate"]
+                    and holdout_result["passes_4x_stress_gate"]
+                ),
             }
-    passing = [f"{n}:{h}" for n, hs in results.items() for h, v in hs.items() if v["passes_4x_stress_gate"]]
-    return {"schema_version": 1, "research_only": True, "orders_placed": False,
-            "leverage_enabled": False, "window": {"start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(), "bars": len(pair), "blocks": BLOCKS},
-            "costs": {"base_round_trip": BASE_COST, "stress_round_trip": STRESS_COST},
-            "multiple_testing_note": "Pattern universe fixed before evaluation; candidates require all six positive blocks and 4x stress cost multiple.",
-            "patterns": results, "passing_patterns": passing,
-            "classification_counts": {label: sum(1 for hs in results.values() for v in hs.values() if v["classification"] == label)
-                                      for label in ("robust_candidate", "promising_needs_adjustment", "cost_sensitive", "unstable_regime", "negative_gross_edge", "insufficient_sample")},
-            "status": "candidate_found" if passing else "no_candidate_passed"}
+
+    passing = [
+        f"{name}:{horizon}"
+        for name, horizons in results.items()
+        for horizon, result in horizons.items()
+        if result["passes_discovery_and_holdout"]
+    ]
+    counts = {
+        "robust_candidate": len(passing),
+        "discovery_only": sum(
+            1 for horizons in results.values()
+            for result in horizons.values()
+            if result["discovery"]["passes_4x_stress_gate"]
+            and not result["holdout"]["passes_4x_stress_gate"]
+        ),
+        "no_discovery_pass": sum(
+            1 for horizons in results.values()
+            for result in horizons.values()
+            if not result["discovery"]["passes_4x_stress_gate"]
+        ),
+    }
+    return {
+        "schema_version": 2,
+        "research_only": True,
+        "orders_placed": False,
+        "leverage_enabled": False,
+        "execution_realism": "gross_movement_diagnostic",
+        "execution_model_reference": STRESS_EXECUTION.as_dict(),
+        "window": {
+            "start": pair[0].timestamp.isoformat(),
+            "end": pair[-1].timestamp.isoformat(),
+            "bars": len(pair),
+            "blocks_per_segment": BLOCKS,
+            "discovery_end_index": holdout_start - 1,
+            "holdout_start_index": holdout_start,
+            "holdout_hours": HOLDOUT_MIN_HOURS,
+        },
+        "costs": {
+            "stress_round_trip": STRESS_COST,
+            "stress_round_trip_bps": STRESS_EXECUTION.round_trip_bps,
+        },
+        "method": {
+            "horizons_hours": HORIZONS,
+            "sample_every_horizon": True,
+            "minimum_observations_per_block": MIN_PER_BLOCK,
+            "promotion_requires_discovery_and_holdout": True,
+            "holdout_is_not_used_for_selection": True,
+            "multiple_testing": {
+                "family_size": FAMILY_SIZE,
+                "correction": "chronological_holdout_confirmation",
+                "every_pattern_horizon_requires_confirmation": True,
+            },
+        },
+        "patterns": results,
+        "passing_patterns": passing,
+        "classification_counts": counts,
+        "status": "candidate_found" if passing else "no_candidate_passed",
+        "status_note": (
+            "A passing gross diagnostic is not profitability evidence; "
+            "fill-based net P&L is still required."
+        ),
+    }
 
 
 def main():
-    p = argparse.ArgumentParser()
-    p.add_argument("--btc-path", type=Path, required=True)
-    p.add_argument("--eth-path", type=Path, required=True)
-    p.add_argument("--output", type=Path, required=True)
-    a = p.parse_args()
-    report = scan(a.btc_path, a.eth_path)
-    a.output.parent.mkdir(parents=True, exist_ok=True)
-    a.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
-    print(json.dumps({"status": report["status"], "passing_patterns": report["passing_patterns"]}, indent=2))
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    report = scan(args.btc_path, args.eth_path)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, indent=2, allow_nan=False), encoding="utf-8"
+    )
+    print(json.dumps({
+        "status": report["status"],
+        "passing_patterns": report["passing_patterns"],
+    }, indent=2))
 
 
 if __name__ == "__main__":

--- a/scripts/run_pattern_trend_scan.py
+++ b/scripts/run_pattern_trend_scan.py
@@ -80,6 +80,21 @@ def choose(name, i, b, e):
     return s, direction
 
 
+def classify(observations, valid_blocks, median_gross, stress_multiple):
+    positive_blocks = sum(x > 0 for x in valid_blocks)
+    if observations < BLOCKS * MIN_PER_BLOCK or len(valid_blocks) != BLOCKS:
+        return "insufficient_sample"
+    if median_gross <= 0:
+        return "negative_gross_edge"
+    if positive_blocks < 4:
+        return "unstable_regime"
+    if stress_multiple < 1:
+        return "cost_sensitive"
+    if stress_multiple < 4:
+        return "promising_needs_adjustment"
+    return "robust_candidate"
+
+
 def scan(btc_path: Path, eth_path: Path):
     pair = align_pair(load_bars(btc_path), load_bars(eth_path))
     pair = pair[-3 * 365 * 24:]
@@ -112,6 +127,7 @@ def scan(btc_path: Path, eth_path: Path):
                 "base_cost_multiple": med / BASE_COST if math.isfinite(med) else None,
                 "stress_cost_multiple": med / STRESS_COST if math.isfinite(med) else None,
                 "positive_blocks": sum(x > 0 for x in valid),
+                "classification": classify(len(rows), valid, med, med / STRESS_COST if math.isfinite(med) else math.nan),
                 "passes_4x_stress_gate": bool(len(rows) >= BLOCKS * MIN_PER_BLOCK and len(valid) == BLOCKS and all(x > 0 for x in valid) and med / STRESS_COST >= 4),
             }
     passing = [f"{n}:{h}" for n, hs in results.items() for h, v in hs.items() if v["passes_4x_stress_gate"]]
@@ -120,6 +136,8 @@ def scan(btc_path: Path, eth_path: Path):
             "costs": {"base_round_trip": BASE_COST, "stress_round_trip": STRESS_COST},
             "multiple_testing_note": "Pattern universe fixed before evaluation; candidates require all six positive blocks and 4x stress cost multiple.",
             "patterns": results, "passing_patterns": passing,
+            "classification_counts": {label: sum(1 for hs in results.values() for v in hs.values() if v["classification"] == label)
+                                      for label in ("robust_candidate", "promising_needs_adjustment", "cost_sensitive", "unstable_regime", "negative_gross_edge", "insufficient_sample")},
             "status": "candidate_found" if passing else "no_candidate_passed"}
 
 

--- a/scripts/run_pattern_trend_scan.py
+++ b/scripts/run_pattern_trend_scan.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Research-only mathematical pattern/trend scan.
+
+The pattern universe is fixed before evaluation. Signals use closed candles and
+are sampled every holding horizon so forward labels do not overlap.
+"""
+from __future__ import annotations
+import argparse, json, math
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+try:
+    from scripts.run_momentum_volatility_research import load_bars
+    from scripts.run_momentum_volatility_v3 import align_pair
+except ModuleNotFoundError:
+    from run_momentum_volatility_research import load_bars
+    from run_momentum_volatility_v3 import align_pair
+
+BASE_COST, STRESS_COST = 0.0038, 0.0086
+HORIZONS, BLOCKS, MIN_PER_BLOCK = (6, 24, 48, 96), 6, 20
+
+
+def mean(x):
+    return sum(x) / len(x) if x else math.nan
+
+
+def feat(bars):
+    c = [float(x.close) for x in bars]
+    h = [float(x.high) for x in bars]
+    l = [float(x.low) for x in bars]
+    r = [(h[i] - l[i]) / c[i] if c[i] else math.nan for i in range(len(c))]
+    out = {"c": c, "h": h, "l": l, "r": r}
+    for n in (6, 24, 48, 96, 200):
+        out[f"m{n}"] = [math.nan if i < n else c[i] / c[i-n] - 1 for i in range(len(c))]
+        out[f"avg_r{n}"] = [mean(r[i-n+1:i+1]) if i >= n-1 else math.nan for i in range(len(c))]
+        out[f"avg_c{n}"] = [mean(c[i-n+1:i+1]) if i >= n-1 else math.nan for i in range(len(c))]
+    out["high48"] = [max(h[i-48:i]) if i >= 49 else math.nan for i in range(len(c))]
+    out["low48"] = [min(l[i-48:i]) if i >= 49 else math.nan for i in range(len(c))]
+    return out
+
+
+def ok(*x):
+    return all(math.isfinite(float(v)) for v in x)
+
+
+def choose(name, i, b, e):
+    assets = (("BTC", b), ("ETH", e))
+    if i < 220:
+        return None, 0
+    if name == "relative_strength":
+        if not ok(b["m24"][i], e["m24"][i]):
+            return None, 0
+        return ("BTC", 1) if b["m24"][i] > e["m24"][i] + .01 else (("ETH", 1) if e["m24"][i] > b["m24"][i] + .01 else (None, 0))
+    eligible = []
+    for s, x in assets:
+        if not ok(x["c"][i], x["m24"][i], x["m48"][i], x["m96"][i], x["avg_r24"][i]):
+            continue
+        trend = x["c"][i] > x["avg_c200"][i] and x["m24"][i] > 0
+        breakout = ok(x["high48"][i], x["low48"][i]) and (x["c"][i] > x["high48"][i] or x["c"][i] < x["low48"][i])
+        expansion = x["r"][i] > 1.25 * x["avg_r24"][i]
+        contraction = x["r"][i] < .75 * x["avg_r24"][i]
+        if name == "trend_structure" and trend and x["m48"][i] > x["m24"][i]:
+            eligible.append((x["m24"][i], s, 1))
+        elif name == "breakout" and breakout and trend:
+            eligible.append((abs(x["m24"][i]), s, 1 if x["m24"][i] > 0 else -1))
+        elif name == "vol_expansion" and expansion and trend:
+            eligible.append((x["m24"][i], s, 1))
+        elif name == "vol_contraction_break" and contraction and breakout:
+            eligible.append((abs(x["m24"][i]), s, 1 if x["m24"][i] > 0 else -1))
+        elif name == "momentum_decay" and trend and x["m48"][i] > 0 and x["m24"][i] < x["m48"][i] * .5:
+            eligible.append((x["m24"][i], s, 1))
+        elif name == "mean_reversion" and x["m24"][i] < -.03:
+            eligible.append((abs(x["m24"][i]), s, 1))
+        elif name == "exhaustion" and x["m48"][i] > .15 and x["m24"][i] < 0:
+            eligible.append((abs(x["m24"][i]), s, -1))
+    if not eligible:
+        return None, 0
+    _, s, direction = max(eligible)
+    return s, direction
+
+
+def scan(btc_path: Path, eth_path: Path):
+    pair = align_pair(load_bars(btc_path), load_bars(eth_path))
+    pair = pair[-3 * 365 * 24:]
+    if len(pair) < 3 * 365 * 24:
+        raise ValueError("three years of aligned candles required")
+    bars = {"BTC": [x.btc for x in pair], "ETH": [x.eth for x in pair]}
+    f = {s: feat(v) for s, v in bars.items()}
+    names = ("trend_structure", "breakout", "vol_expansion", "vol_contraction_break",
+             "relative_strength", "momentum_decay", "mean_reversion", "exhaustion")
+    results = {}
+    for name in names:
+        results[name] = {}
+        for horizon in HORIZONS:
+            rows = []
+            for i in range(220, len(pair) - horizon, horizon):
+                symbol, direction = choose(name, i, f["BTC"], f["ETH"])
+                if symbol:
+                    x = f[symbol]
+                    rows.append((i, direction * (x["c"][i+horizon] / x["c"][i] - 1)))
+            blocks = [[] for _ in range(BLOCKS)]
+            for i, value in rows:
+                blocks[min(BLOCKS - 1, int(i / (len(pair) / BLOCKS)))].append(value)
+            means = [mean(x) for x in blocks]
+            valid = [x for x in means if math.isfinite(x)]
+            med = median(valid) if valid else math.nan
+            results[name][str(horizon)] = {
+                "observations": len(rows), "non_overlapping": True,
+                "block_mean_gross_returns": means,
+                "median_block_gross_return": med if math.isfinite(med) else None,
+                "base_cost_multiple": med / BASE_COST if math.isfinite(med) else None,
+                "stress_cost_multiple": med / STRESS_COST if math.isfinite(med) else None,
+                "positive_blocks": sum(x > 0 for x in valid),
+                "passes_4x_stress_gate": bool(len(rows) >= BLOCKS * MIN_PER_BLOCK and len(valid) == BLOCKS and all(x > 0 for x in valid) and med / STRESS_COST >= 4),
+            }
+    passing = [f"{n}:{h}" for n, hs in results.items() for h, v in hs.items() if v["passes_4x_stress_gate"]]
+    return {"schema_version": 1, "research_only": True, "orders_placed": False,
+            "leverage_enabled": False, "window": {"start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(), "bars": len(pair), "blocks": BLOCKS},
+            "costs": {"base_round_trip": BASE_COST, "stress_round_trip": STRESS_COST},
+            "multiple_testing_note": "Pattern universe fixed before evaluation; candidates require all six positive blocks and 4x stress cost multiple.",
+            "patterns": results, "passing_patterns": passing,
+            "status": "candidate_found" if passing else "no_candidate_passed"}
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--btc-path", type=Path, required=True)
+    p.add_argument("--eth-path", type=Path, required=True)
+    p.add_argument("--output", type=Path, required=True)
+    a = p.parse_args()
+    report = scan(a.btc_path, a.eth_path)
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(json.dumps({"status": report["status"], "passing_patterns": report["passing_patterns"]}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_three_year_sats_backtest.py
+++ b/scripts/run_three_year_sats_backtest.py
@@ -46,12 +46,19 @@ def _run(pair, config, model: ExecutionModel, *, initial_balance: float, order_n
     )
     turnover = float(result.get("trades", 0)) * order_notional
     estimated_cost = turnover * model.round_trip_bps / 10_000.0
+    pnl_quote = float(result.get("pnl", 0.0))
+    btc_end_quote = float(pair[-1].btc.close)
+    pnl_sats_marked_at_end = pnl_quote / btc_end_quote * SATOSHIS_PER_BTC
     return {
         "engine_result": result,
         "execution_model": model.as_dict(),
         "estimated_turnover_quote": turnover,
         "estimated_execution_cost_quote": estimated_cost,
+        "pnl_quote": pnl_quote,
+        "pnl_sats_marked_at_window_end": pnl_sats_marked_at_end,
+        "btc_mark_price_quote_at_window_end": btc_end_quote,
         "cost_note": "Estimated from completed entry/exit count; exact fills require fill-ledger integration.",
+        "sats_note": "Quote P&L converted at the window-end BTC/quote close; this is a mark-to-BTC value, not a native BTC cash ledger.",
     }
 
 def run_backtest(btc_path: Path, eth_path: Path, output: Path, *, initial_balance: float, order_notional: float):
@@ -67,7 +74,7 @@ def run_backtest(btc_path: Path, eth_path: Path, output: Path, *, initial_balanc
             "stress": _run(pair, config, STRESS_EXECUTION, initial_balance=initial_balance, order_notional=order_notional),
         }
     report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "research_only": True,
         "paper_orders_placed": False,
         "live_orders_placed": False,
@@ -80,9 +87,9 @@ def run_backtest(btc_path: Path, eth_path: Path, output: Path, *, initial_balanc
         },
         "denomination": {
             "btc_satoshis_per_btc": SATOSHIS_PER_BTC,
-            "btc_pnl_sats_available_when_starting_balance_is_btc": True,
+            "btc_pnl_sats_marked_at_window_end": True,
             "quote_currency_results_preserved": True,
-            "eth_sats_conversion": "requires timestamped BTC/ETH conversion; not inferred here",
+            "eth_sats_conversion": "ETH results are quote P&L; cross-asset BTC conversion requires timestamped ETH/BTC marks.",
         },
         "execution_models": {"base": BASE_EXECUTION.as_dict(), "stress": STRESS_EXECUTION.as_dict()},
         "candidates": reports,

--- a/scripts/run_three_year_sats_backtest.py
+++ b/scripts/run_three_year_sats_backtest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Run a three-year, paper-only v3 backtest with explicit execution budgets.
+
+The strategy engine is unchanged and receives conservative effective fee and
+slippage budgets. The report separately preserves spread, impact, latency,
+partial-fill, funding, and outage assumptions so reviewers can distinguish
+measured engine P&L from execution-model stress assumptions.
+"""
+from __future__ import annotations
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Mapping
+
+try:
+    from scripts.execution_model import BASE_EXECUTION, STRESS_EXECUTION, ExecutionModel
+    from scripts.run_momentum_volatility_research import load_bars
+    from scripts.run_v3_exploration import candidate_definitions
+    from scripts.run_momentum_volatility_v3 import align_pair, build_pair_features, run_pair
+except ModuleNotFoundError:
+    from execution_model import BASE_EXECUTION, STRESS_EXECUTION, ExecutionModel
+    from run_momentum_volatility_research import load_bars
+    from run_v3_exploration import candidate_definitions
+    from run_momentum_volatility_v3 import align_pair, build_pair_features, run_pair
+
+SATOSHIS_PER_BTC = 100_000_000
+THREE_YEARS_HOURS = 3 * 365 * 24
+
+def _safe(value: object) -> object:
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Mapping):
+        return {str(key): _safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_safe(item) for item in value]
+    return value
+
+def _run(pair, config, model: ExecutionModel, *, initial_balance: float, order_notional: float):
+    features = build_pair_features(pair, config)
+    result = run_pair(
+        pair, initial_balance=initial_balance, order_notional=order_notional,
+        fees_bps=model.effective_fees_bps_per_side,
+        slippage_bps=model.effective_slippage_bps_per_side,
+        config=config, feature_map=features,
+    )
+    turnover = float(result.get("trades", 0)) * order_notional
+    estimated_cost = turnover * model.round_trip_bps / 10_000.0
+    return {
+        "engine_result": result,
+        "execution_model": model.as_dict(),
+        "estimated_turnover_quote": turnover,
+        "estimated_execution_cost_quote": estimated_cost,
+        "cost_note": "Estimated from completed entry/exit count; exact fills require fill-ledger integration.",
+    }
+
+def run_backtest(btc_path: Path, eth_path: Path, output: Path, *, initial_balance: float, order_notional: float):
+    btc, eth = load_bars(btc_path), load_bars(eth_path)
+    pair = align_pair(btc, eth)
+    if len(pair) < THREE_YEARS_HOURS:
+        raise ValueError(f"need at least {THREE_YEARS_HOURS} aligned hourly candles")
+    pair = pair[-THREE_YEARS_HOURS:]
+    reports = {}
+    for name, config in candidate_definitions().items():
+        reports[name] = {
+            "base": _run(pair, config, BASE_EXECUTION, initial_balance=initial_balance, order_notional=order_notional),
+            "stress": _run(pair, config, STRESS_EXECUTION, initial_balance=initial_balance, order_notional=order_notional),
+        }
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "automatic_promotion": False,
+        "window": {
+            "bars": len(pair), "hours": len(pair), "years": len(pair) / (365 * 24),
+            "start": pair[0].timestamp.isoformat(), "end": pair[-1].timestamp.isoformat(),
+            "completed_candles_only": True, "forward_test_reused_for_training": False,
+        },
+        "denomination": {
+            "btc_satoshis_per_btc": SATOSHIS_PER_BTC,
+            "btc_pnl_sats_available_when_starting_balance_is_btc": True,
+            "quote_currency_results_preserved": True,
+            "eth_sats_conversion": "requires timestamped BTC/ETH conversion; not inferred here",
+        },
+        "execution_models": {"base": BASE_EXECUTION.as_dict(), "stress": STRESS_EXECUTION.as_dict()},
+        "candidates": reports,
+        "status": "backtest_artifact_generated; exact fill ledger still required before claiming execution-realistic results",
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(_safe(report), indent=2, sort_keys=True, allow_nan=False), encoding="utf-8")
+    return report
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--initial-balance", type=float, default=75000.0)
+    parser.add_argument("--order-notional", type=float, default=6000.0)
+    args = parser.parse_args()
+    report = run_backtest(args.btc_path, args.eth_path, args.output, initial_balance=args.initial_balance, order_notional=args.order_notional)
+    print(json.dumps({"status": report["status"], "window": report["window"]}, indent=2))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a pre-registered research screen for candidate conditions where directional forward movement is at least 4x estimated stress round-trip cost across six non-overlapping walk-forward blocks. It uses completed candles only, samples every holding horizon to avoid overlapping evidence, places no orders, and never enables leverage.