### PR TITLE
Research: one-year 8-bps funding reproduction

### DIFF
--- a/.github/workflows/funding-8bps-new-data-repro.yml
+++ b/.github/workflows/funding-8bps-new-data-repro.yml
@@ -1,0 +1,56 @@
+name: Funding 8bps New-Data Reproducibility
+
+on:
+  push:
+    branches:
+      - research/funding-8bps-repro-new-data
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/funding-8bps-new-data-repro.yml"
+      - "scripts/fetch_current_binance_data.py"
+      - "scripts/run_funding_8bps_repro.py"
+      - "scripts/run_funding_positioning_reversal.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: funding-8bps-new-data-repro
+  cancel-in-progress: false
+
+jobs:
+  reproducibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed historical monthly data
+        run: |
+          set -euo pipefail
+          UNTIL="$(date -u +%Y-%m)"
+          python scripts/fetch_binance_vision_klines.py --symbols BTCUSDT ETHUSDT --since 2023-01 --until "$UNTIL"
+          python scripts/fetch_binance_funding_rates.py --symbols BTCUSDT ETHUSDT --since 2023-01 --until "$UNTIL"
+      - name: Append completed current-month data
+        run: |
+          set -euo pipefail
+          CUTOFF="$(date -u -d '1 hour ago' +%Y-%m-%dT%H:00:00Z)"
+          python scripts/fetch_current_binance_data.py --cutoff "$CUTOFF"
+          echo "CUTOFF=$CUTOFF" >> "$GITHUB_ENV"
+      - name: Run unchanged 8-bps rule on new cutoff
+        run: |
+          set -euo pipefail
+          python scripts/run_funding_8bps_repro.py             --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv             --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv             --btc-funding-path data/historical/binance/funding/BTCUSDT_funding.csv             --eth-funding-path data/historical/binance/funding/ETHUSDT_funding.csv             --cutoff "$CUTOFF"             --output artifacts/funding-8bps-new-data-repro/report.json
+      - name: Upload reproducibility artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: funding-8bps-new-data-repro-${{ github.run_number }}
+          path: artifacts/funding-8bps-new-data-repro
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/funding-8bps-one-year.yml
+++ b/.github/workflows/funding-8bps-one-year.yml
@@ -1,0 +1,83 @@
+name: Funding 8bps One-Year Reproduction
+
+on:
+  push:
+    branches:
+      - research/funding-8bps-one-year
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/funding-8bps-one-year.yml"
+      - "scripts/fetch_binance_vision_klines.py"
+      - "scripts/fetch_binance_funding_rates.py"
+      - "scripts/fetch_current_binance_data.py"
+      - "scripts/run_funding_8bps_one_year.py"
+      - "scripts/run_funding_positioning_reversal.py"
+      - "scripts/execution_model.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: funding-8bps-one-year
+  cancel-in-progress: false
+
+jobs:
+  backtest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed historical monthly data
+        run: |
+          set -euo pipefail
+          UNTIL="$(date -u +%Y-%m)"
+          for attempt in 1 2 3; do
+            if python scripts/fetch_binance_vision_klines.py --symbols BTCUSDT ETHUSDT --since 2023-01 --until "$UNTIL"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 15
+          done
+          for attempt in 1 2 3; do
+            if python scripts/fetch_binance_funding_rates.py --symbols BTCUSDT ETHUSDT --since 2023-01 --until "$UNTIL"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 15
+          done
+      - name: Append completed current-month data
+        run: |
+          set -euo pipefail
+          CUTOFF="$(date -u -d '1 hour ago' +%Y-%m-%dT%H:00:00Z)"
+          for attempt in 1 2 3; do
+            if python scripts/fetch_current_binance_data.py --cutoff "$CUTOFF"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "CUTOFF=$CUTOFF" >> "$GITHUB_ENV"
+      - name: Run one-year backtest and exact reproduction
+        run: |
+          set -euo pipefail
+          python scripts/run_funding_8bps_one_year.py             --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv             --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv             --btc-funding-path data/historical/binance/funding/BTCUSDT_funding.csv             --eth-funding-path data/historical/binance/funding/ETHUSDT_funding.csv             --output artifacts/funding-8bps-one-year/report.json
+      - name: Upload one-year artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: funding-8bps-one-year-${{ github.run_number }}
+          path: artifacts/funding-8bps-one-year
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/funding-positioning-reversal.yml
+++ b/.github/workflows/funding-positioning-reversal.yml
@@ -1,0 +1,58 @@
+# Single frozen funding-positioning hypothesis; paper-only.
+name: Funding Positioning Reversal
+
+on:
+  push:
+    branches:
+      - research/funding-positioning-reversal
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/funding-positioning-reversal.yml"
+      - "scripts/fetch_binance_funding_rates.py"
+      - "scripts/run_funding_positioning_reversal.py"
+      - "scripts/execution_model.py"
+      - "scripts/run_momentum_volatility_research.py"
+      - "scripts/run_momentum_volatility_v3.py"
+      - "scripts/fetch_binance_vision_klines.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: funding-positioning-reversal
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download completed spot candles
+        run: |
+          set -euo pipefail
+          UNTIL="$(date -u +%Y-%m)"
+          python scripts/fetch_binance_vision_klines.py --symbols BTCUSDT ETHUSDT --since 2023-01 --until "$UNTIL"
+      - name: Download completed funding rates
+        run: |
+          set -euo pipefail
+          UNTIL="$(date -u +%Y-%m)"
+          python scripts/fetch_binance_funding_rates.py --symbols BTCUSDT ETHUSDT --since 2023-01 --until "$UNTIL"
+      - name: Run frozen funding hypothesis
+        run: |
+          set -euo pipefail
+          python scripts/run_funding_positioning_reversal.py             --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv             --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv             --btc-funding-path data/historical/binance/funding/BTCUSDT_funding.csv             --eth-funding-path data/historical/binance/funding/ETHUSDT_funding.csv             --output artifacts/funding-positioning-reversal/report.json
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: funding-positioning-reversal-${{ github.run_number }}
+          path: artifacts/funding-positioning-reversal
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/fetch_binance_funding_rates.py
+++ b/scripts/fetch_binance_funding_rates.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Download completed Binance USD-M funding-rate archives."""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASE = "https://data.binance.vision"
+
+
+def months(since: str, until: str) -> list[tuple[int, int]]:
+    start = datetime.strptime(since, "%Y-%m")
+    end = datetime.strptime(until, "%Y-%m")
+    out = []
+    year, month = start.year, start.month
+    while (year, month) < (end.year, end.month):
+        out.append((year, month))
+        month += 1
+        if month == 13:
+            year, month = year + 1, 1
+    return out
+
+
+def fetch(symbol: str, since: str, until: str, output: Path) -> dict:
+    rows = {}
+    archives = []
+    for year, month in months(since, until):
+        stem = f"{symbol}-fundingRate-{year:04d}-{month:02d}"
+        url = f"{BASE}/data/futures/um/monthly/fundingRate/{symbol}/{stem}.zip"
+        with urllib.request.urlopen(url, timeout=60) as response:
+            payload = response.read()
+        digest = hashlib.sha256(payload).hexdigest()
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            names = [name for name in archive.namelist() if name.endswith(".csv")]
+            if len(names) != 1:
+                raise ValueError(f"expected one funding CSV for {symbol} {year}-{month}")
+            for row in csv.DictReader(io.TextIOWrapper(archive.open(names[0]), encoding="utf-8")):
+                timestamp = datetime.fromtimestamp(
+                    int(float(row["calc_time"])) / 1000, tz=timezone.utc
+                ).isoformat()
+                rows[timestamp] = {
+                    "timestamp": timestamp,
+                    "funding_rate": float(row["last_funding_rate"]),
+                    "interval_hours": int(row["funding_interval_hours"]),
+                }
+        archives.append({"url": url, "sha256": digest, "rows": len(rows)})
+    output.parent.mkdir(parents=True, exist_ok=True)
+    ordered = [rows[key] for key in sorted(rows)]
+    with output.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["timestamp", "funding_rate", "interval_hours"])
+        writer.writeheader()
+        writer.writerows(ordered)
+    return {
+        "symbol": symbol,
+        "rows": len(ordered),
+        "start": ordered[0]["timestamp"] if ordered else None,
+        "end": ordered[-1]["timestamp"] if ordered else None,
+        "archives": archives,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--symbols", nargs="+", default=["BTCUSDT", "ETHUSDT"])
+    parser.add_argument("--since", required=True)
+    parser.add_argument("--until", required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path("data/historical/binance/funding"))
+    args = parser.parse_args()
+    result = {
+        symbol: fetch(symbol, args.since, args.until, args.output_dir / f"{symbol}_funding.csv")
+        for symbol in args.symbols
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_current_binance_data.py
+++ b/scripts/fetch_current_binance_data.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Append completed current-month Binance Vision spot candles and funding observations.
+
+This is a research-only forward-data collector. Historical monthly archives remain
+untouched; only current-month rows are appended after duplicate/conflict checks.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import urllib.parse
+import urllib.request
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+VISION = "https://data.binance.vision"
+FAPI = "https://fapi.binance.com"
+FIELDS = ["timestamp", "open", "high", "low", "close", "volume"]
+
+
+def get(url: str) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": "funding-8bps-repro/1.0"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read()
+
+
+def iso_ms(raw: str) -> str:
+    value = int(float(raw))
+    if value >= 10**14:
+        value //= 1000
+    return datetime.fromtimestamp(value / 1000, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def read_spot_archive(payload: bytes) -> list[dict[str, str]]:
+    rows = []
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        names = [n for n in archive.namelist() if n.endswith(".csv")]
+        if len(names) != 1:
+            raise ValueError(f"expected one spot CSV, found {names}")
+        with archive.open(names[0], "r") as raw:
+            for values in csv.reader(io.TextIOWrapper(raw, encoding="utf-8", newline="")):
+                if not values or values[0].lower() in {"open time", "open_time"}:
+                    continue
+                if len(values) < 6:
+                    raise ValueError("spot row has fewer than six columns")
+                rows.append({
+                    "timestamp": iso_ms(values[0]),
+                    "open": values[1],
+                    "high": values[2],
+                    "low": values[3],
+                    "close": values[4],
+                    "volume": values[5],
+                })
+    return rows
+
+
+def merge_csv(path: Path, rows: list[dict[str, str]], fields: list[str]) -> None:
+    existing = {}
+    if path.exists():
+        with path.open(encoding="utf-8", newline="") as handle:
+            existing = {row["timestamp"]: row for row in csv.DictReader(handle)}
+    for row in rows:
+        prior = existing.get(row["timestamp"])
+        if prior is not None and any(prior.get(key) != row.get(key) for key in fields[1:]):
+            raise ValueError(f"conflicting duplicate at {path} {row['timestamp']}")
+        existing[row["timestamp"]] = row
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(existing[key] for key in sorted(existing))
+
+
+def update_spot(symbol: str, cutoff: datetime, out_dir: Path) -> dict:
+    first = cutoff.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    day = first
+    rows = []
+    # A daily archive is used only after its UTC day is complete.
+    last_day = cutoff.date() - timedelta(days=1)
+    while day.date() <= last_day:
+        stem = f"{symbol}-1h-{day:%Y-%m-%d}"
+        url = f"{VISION}/data/spot/daily/klines/{symbol}/1h/{stem}.zip"
+        try:
+            rows.extend(read_spot_archive(get(url)))
+        except urllib.error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+        day += timedelta(days=1)
+    path = out_dir / f"{symbol}_1h.csv"
+    merge_csv(path, rows, FIELDS)
+    return {"symbol": symbol, "new_rows_seen": len(rows), "path": str(path)}
+
+
+def update_funding(symbol: str, cutoff: datetime, out_dir: Path) -> dict:
+    path = out_dir / f"{symbol}_funding.csv"
+    rows = []
+    start_ms = int(cutoff.replace(day=1, hour=0, minute=0, second=0, microsecond=0).timestamp() * 1000)
+    end_ms = int(cutoff.timestamp() * 1000)
+    url = f"{FAPI}/fapi/v1/fundingRate?{urllib.parse.urlencode({'symbol': symbol, 'startTime': start_ms, 'endTime': end_ms, 'limit': 1000})}"
+    payload = json.loads(get(url))
+    if isinstance(payload, dict) and payload.get("code"):
+        raise RuntimeError(f"funding endpoint error: {payload}")
+    for item in payload:
+        rate_time = datetime.fromtimestamp(int(item["fundingTime"]) / 1000, timezone.utc)
+        rows.append({
+            "timestamp": rate_time.isoformat().replace("+00:00", "Z"),
+            "funding_rate": str(item["fundingRate"]),
+            "interval_hours": "8",
+        })
+    merge_csv(path, rows, ["timestamp", "funding_rate", "interval_hours"])
+    return {"symbol": symbol, "new_rows_seen": len(rows), "path": str(path)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cutoff", required=True, help="exclusive UTC cutoff, ISO-8601")
+    parser.add_argument("--spot-dir", type=Path, default=Path("data/historical/binance/normalized"))
+    parser.add_argument("--funding-dir", type=Path, default=Path("data/historical/binance/funding"))
+    args = parser.parse_args()
+    cutoff = datetime.fromisoformat(args.cutoff.replace("Z", "+00:00"))
+    result = {
+        "cutoff": cutoff.isoformat(),
+        "spot": [update_spot(symbol, cutoff, args.spot_dir) for symbol in ("BTCUSDT", "ETHUSDT")],
+        "funding": [update_funding(symbol, cutoff, args.funding_dir) for symbol in ("BTCUSDT", "ETHUSDT")],
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_current_binance_data.py
+++ b/scripts/fetch_current_binance_data.py
@@ -10,6 +10,7 @@ import argparse
 import csv
 import io
 import json
+import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
@@ -17,7 +18,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 VISION = "https://data.binance.vision"
-FAPI = "https://fapi.binance.com"
+FAPI = "https://www.binance.com"
 FIELDS = ["timestamp", "open", "high", "low", "close", "volume"]
 
 

--- a/scripts/run_funding_8bps_one_year.py
+++ b/scripts/run_funding_8bps_one_year.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 try:
@@ -40,7 +40,7 @@ def main() -> int:
     ]
     if not pair:
         raise ValueError("one-year window contains no completed aligned candles")
-    if pair[-1].btc.timestamp < ONE_YEAR_END - impl.timedelta(hours=1):
+    if pair[-1].btc.timestamp < ONE_YEAR_END - timedelta(hours=1):
         raise ValueError("one-year window is missing its final completed candle")
 
     funding = {

--- a/scripts/run_funding_8bps_one_year.py
+++ b/scripts/run_funding_8bps_one_year.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Backtest and exact-reproduce the frozen 8-bps funding rule over one fixed year."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from scripts import run_funding_positioning_reversal as impl
+except ModuleNotFoundError:
+    import run_funding_positioning_reversal as impl
+
+
+ONE_YEAR_START = datetime(2025, 8, 27, tzinfo=timezone.utc)
+ONE_YEAR_END = datetime(2026, 8, 27, tzinfo=timezone.utc)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--btc-funding-path", type=Path, required=True)
+    parser.add_argument("--eth-funding-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    # Use the existing frozen implementation; only the fixed evaluation window
+    # changes. No parameter, execution-model, or signal-rule tuning is performed.
+    impl.START = ONE_YEAR_START
+    impl.END = ONE_YEAR_END
+    aligned = impl.align_pair(
+        impl.load_bars(args.btc_path),
+        impl.load_bars(args.eth_path),
+    )
+    pair = [
+        item for item in aligned
+        if ONE_YEAR_START <= item.btc.timestamp < ONE_YEAR_END
+    ]
+    if not pair:
+        raise ValueError("one-year window contains no completed aligned candles")
+    if pair[-1].btc.timestamp < ONE_YEAR_END - impl.timedelta(hours=1):
+        raise ValueError("one-year window is missing its final completed candle")
+
+    funding = {
+        "BTC": impl.load_funding(args.btc_funding_path),
+        "ETH": impl.load_funding(args.eth_funding_path),
+    }
+
+    first_rows = impl.evaluate(pair, funding, 0, len(pair))
+    repeat_rows = impl.evaluate(pair, funding, 0, len(pair))
+    first = impl.summary(first_rows, 0, len(pair))
+    repeat = impl.summary(repeat_rows, 0, len(pair))
+
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "hypothesis": "extreme funding indicates crowded positioning that reverses over the next eight hours",
+        "frozen_parameters": {
+            "assets": ["BTCUSDT", "ETHUSDT"],
+            "funding_threshold_bps": impl.FUNDING_THRESHOLD * 10_000,
+            "hold_hours": impl.HOLD_HOURS,
+            "cooldown_hours": impl.COOLDOWN_HOURS,
+            "direction": "positive funding short; negative funding long",
+            "position_selection": "both assets independently; no leader selection",
+            "notional": impl.NOTIONAL,
+        },
+        "execution_model": impl.STRESS_EXECUTION.as_dict(),
+        "window": {
+            "start": ONE_YEAR_START.isoformat(),
+            "end_exclusive": ONE_YEAR_END.isoformat(),
+            "last_completed_candle": pair[-1].btc.timestamp.isoformat(),
+            "completed_candles_only": True,
+            "non_overlapping_per_asset": True,
+        },
+        "funding_data": {
+            "source": "Binance USD-M funding-rate archives plus completed current-month observations",
+            "btc_rows": len(funding["BTC"]),
+            "eth_rows": len(funding["ETH"]),
+        },
+        "one_year": first,
+        "repeat": repeat,
+        "trades": first_rows,
+        "reproduction": {
+            "identical_trade_rows": first_rows == repeat_rows,
+            "identical_summary": first == repeat,
+            "counts_as_new_evidence": False,
+        },
+        "status": "reproduced" if first_rows == repeat_rows and first == repeat else "mismatch",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({
+        "status": report["status"],
+        "one_year_trades": first["trade_count"],
+        "one_year_net_return_pct": first["net_return_pct"],
+        "repeat_identical": report["reproduction"]["identical_trade_rows"]
+        and report["reproduction"]["identical_summary"],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_funding_8bps_repro.py
+++ b/scripts/run_funding_8bps_repro.py
@@ -7,7 +7,12 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from scripts import run_funding_positioning_reversal as impl
+try:
+    from scripts import run_funding_positioning_reversal as impl
+except ModuleNotFoundError:
+    # GitHub Actions invokes this file as a script, so the repository root is
+    # not necessarily importable as the "scripts" package.
+    import run_funding_positioning_reversal as impl
 
 
 def main() -> None:

--- a/scripts/run_funding_8bps_repro.py
+++ b/scripts/run_funding_8bps_repro.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Run the unchanged 8-bps hypothesis through a newer completed-data cutoff."""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts import run_funding_positioning_reversal as impl
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--btc-funding-path", type=Path, required=True)
+    parser.add_argument("--eth-funding-path", type=Path, required=True)
+    parser.add_argument("--cutoff", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    cutoff = datetime.fromisoformat(args.cutoff.replace("Z", "+00:00")).astimezone(timezone.utc)
+    if cutoff <= impl.DISCOVERY_END:
+        raise ValueError("reproducibility cutoff must be after discovery")
+    impl.END = cutoff
+    sys.argv = [
+        "run_funding_positioning_reversal.py",
+        "--btc-path", str(args.btc_path),
+        "--eth-path", str(args.eth_path),
+        "--btc-funding-path", str(args.btc_funding_path),
+        "--eth-funding-path", str(args.eth_funding_path),
+        "--output", str(args.output),
+    ]
+    impl.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_funding_positioning_reversal.py
+++ b/scripts/run_funding_positioning_reversal.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Frozen funding-positioning reversal experiment; research-only."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean, median, pstdev
+
+try:
+    from scripts.execution_model import STRESS_EXECUTION
+    from scripts.run_momentum_volatility_research import load_bars
+    from scripts.run_momentum_volatility_v3 import align_pair
+except ModuleNotFoundError:
+    from execution_model import STRESS_EXECUTION
+    from run_momentum_volatility_research import load_bars
+    from run_momentum_volatility_v3 import align_pair
+
+START = datetime(2023, 1, 1, tzinfo=timezone.utc)
+END = datetime(2026, 8, 1, tzinfo=timezone.utc)
+DISCOVERY_END = datetime(2025, 4, 1, tzinfo=timezone.utc)
+FUNDING_THRESHOLD = 0.0008
+HOLD_HOURS = 8
+COOLDOWN_HOURS = 8
+NOTIONAL = 3_000.0
+BLOCKS = 6
+MIN_TRADES_PER_BLOCK = 20
+
+
+def finite(*values: float) -> bool:
+    return all(math.isfinite(float(value)) for value in values)
+
+
+def load_funding(path: Path) -> dict[datetime, float]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return {
+            datetime.fromisoformat(row["timestamp"]): float(row["funding_rate"])
+            for row in csv.DictReader(handle)
+        }
+
+
+def summary(rows: list[dict], start: int, end: int) -> dict:
+    width = (end - start) / BLOCKS
+    groups = [[] for _ in range(BLOCKS)]
+    for row in rows:
+        block = min(BLOCKS - 1, int((row["index"] - start) / width))
+        groups[block].append(row)
+    pnl = [row["net_pnl"] for row in rows]
+    returns = [row["net_return"] for row in rows]
+    block_means = [
+        mean([row["net_return"] for row in group]) if group else None
+        for group in groups
+    ]
+    gains = sum(value for value in pnl if value > 0)
+    losses = abs(sum(value for value in pnl if value < 0))
+    equity = peak = max_drawdown = 0.0
+    for value in pnl:
+        equity += value
+        peak = max(peak, equity)
+        max_drawdown = max(max_drawdown, peak - equity)
+    sharpe = None
+    if len(returns) > 1 and pstdev(returns) > 0:
+        sharpe = mean(returns) / pstdev(returns) * math.sqrt(365 * 24 / HOLD_HOURS)
+    valid = [value for value in block_means if value is not None]
+    median_block = median(valid) if valid else None
+    stress_cost = STRESS_EXECUTION.round_trip_bps / 10_000.0
+    return {
+        "trade_count": len(rows),
+        "block_trade_counts": [len(group) for group in groups],
+        "block_mean_net_returns": block_means,
+        "net_pnl": sum(pnl),
+        "net_return_pct": sum(returns) * 100.0,
+        "max_drawdown_pct_of_notional": max_drawdown / NOTIONAL * 100.0,
+        "sharpe_annualized_trade_proxy": sharpe,
+        "profit_factor": gains / losses if losses else None,
+        "execution_cost": sum(row["execution_cost"] for row in rows),
+        "median_block_return_to_stress_cost": (
+            median_block / stress_cost if median_block is not None else None
+        ),
+        "passes_sample_gate": all(len(group) >= MIN_TRADES_PER_BLOCK for group in groups),
+        "passes_positive_block_gate": (
+            len(valid) == BLOCKS and all(value > 0 for value in valid)
+        ),
+    }
+
+
+def trade(pair: list, symbol: str, side: int, index: int) -> dict | None:
+    entry_index = index + 1 + STRESS_EXECUTION.latency_bars
+    exit_index = entry_index + HOLD_HOURS
+    if exit_index >= len(pair):
+        return None
+    entry_bar = pair[entry_index].btc if symbol == "BTC" else pair[entry_index].eth
+    exit_bar = pair[exit_index].btc if symbol == "BTC" else pair[exit_index].eth
+    entry = float(entry_bar.open)
+    exit_price = float(exit_bar.close)
+    if entry <= 0:
+        return None
+    gross = side * (exit_price / entry - 1.0)
+    filled = NOTIONAL * STRESS_EXECUTION.fill_fraction * (
+        1.0 - STRESS_EXECUTION.outage_rejection_rate
+    )
+    trading_cost = filled * STRESS_EXECUTION.round_trip_bps / 10_000.0
+    funding_cost = filled * STRESS_EXECUTION.funding_bps_per_bar * HOLD_HOURS / 10_000.0
+    net_pnl = filled * gross - trading_cost - funding_cost
+    return {
+        "index": index,
+        "symbol": symbol,
+        "side": "long" if side > 0 else "short",
+        "funding_rate": None,
+        "gross_return": gross,
+        "net_return": net_pnl / NOTIONAL,
+        "net_pnl": net_pnl,
+        "execution_cost": trading_cost + funding_cost,
+    }
+
+
+def evaluate(
+    pair: list,
+    funding: dict[str, dict[datetime, float]],
+    start: int,
+    end: int,
+) -> list[dict]:
+    index_by_time = {item.btc.timestamp: index for index, item in enumerate(pair)}
+    events = []
+    for symbol, rates in funding.items():
+        for timestamp, rate in rates.items():
+            if timestamp in index_by_time and START <= timestamp < END:
+                events.append((index_by_time[timestamp], symbol, rate))
+    events.sort()
+    last_signal = {"BTC": -10**9, "ETH": -10**9}
+    rows = []
+    for index, symbol, rate in events:
+        if index < start or index >= end or index - last_signal[symbol] < COOLDOWN_HOURS:
+            continue
+        side = -1 if rate >= FUNDING_THRESHOLD else 1 if rate <= -FUNDING_THRESHOLD else 0
+        if side == 0:
+            continue
+        row = trade(pair, symbol, side, index)
+        if row is not None:
+            row["funding_rate"] = rate
+            rows.append(row)
+            last_signal[symbol] = index
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--btc-funding-path", type=Path, required=True)
+    parser.add_argument("--eth-funding-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    aligned = align_pair(load_bars(args.btc_path), load_bars(args.eth_path))
+    pair = [item for item in aligned if START <= item.btc.timestamp < END]
+    if not pair or pair[-1].btc.timestamp < DISCOVERY_END:
+        raise ValueError("fixed evaluation window is incomplete")
+    discovery_end = next(
+        index for index, item in enumerate(pair) if item.btc.timestamp >= DISCOVERY_END
+    )
+    funding = {
+        "BTC": load_funding(args.btc_funding_path),
+        "ETH": load_funding(args.eth_funding_path),
+    }
+    discovery_rows = evaluate(pair, funding, 0, discovery_end)
+    holdout_rows = evaluate(pair, funding, discovery_end, len(pair))
+    discovery = summary(discovery_rows, 0, discovery_end)
+    holdout = summary(holdout_rows, discovery_end, len(pair))
+    passes_discovery = (
+        discovery["passes_sample_gate"]
+        and discovery["passes_positive_block_gate"]
+        and (discovery["median_block_return_to_stress_cost"] or 0.0) >= 1.0
+    )
+    passes_confirmation = (
+        passes_discovery
+        and holdout["passes_sample_gate"]
+        and holdout["passes_positive_block_gate"]
+        and (holdout["median_block_return_to_stress_cost"] or 0.0) >= 1.0
+    )
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "hypothesis": "extreme funding indicates crowded positioning that reverses over the next eight hours",
+        "frozen_parameters": {
+            "assets": ["BTCUSDT", "ETHUSDT"],
+            "funding_threshold": FUNDING_THRESHOLD,
+            "funding_threshold_bps": FUNDING_THRESHOLD * 10_000,
+            "hold_hours": HOLD_HOURS,
+            "cooldown_hours": COOLDOWN_HOURS,
+            "direction": "positive funding short; negative funding long",
+            "position_selection": "both assets independently; no leader selection",
+        },
+        "execution_model": STRESS_EXECUTION.as_dict(),
+        "window": {
+            "start": pair[0].btc.timestamp.isoformat(),
+            "end": pair[-1].btc.timestamp.isoformat(),
+            "discovery_end_exclusive": DISCOVERY_END.isoformat(),
+            "holdout_untouched": True,
+            "completed_candles_only": True,
+            "non_overlapping_per_asset": True,
+        },
+        "funding_data": {
+            "source": "Binance USD-M monthly funding-rate archives",
+            "btc_rows": len(funding["BTC"]),
+            "eth_rows": len(funding["ETH"]),
+        },
+        "discovery": discovery,
+        "holdout": holdout,
+        "passes_discovery": passes_discovery,
+        "passes_confirmation": passes_confirmation,
+        "status": "confirmed" if passes_confirmation else "not_confirmed",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({
+        "status": report["status"],
+        "discovery_trades": discovery["trade_count"],
+        "holdout_trades": holdout["trade_count"],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Research-only one-year backtest

This PR evaluates the existing frozen 8-bps funding-positioning reversal rule over the fixed latest completed one-year window:

- 2025-08-27 through 2026-08-26 UTC
- Positive funding -> short; negative funding -> long
- BTCUSDT and ETHUSDT independently
- Eight-hour hold and cooldown
- Same 86-bps stress execution model
- Completed candles only
- Exact same-dataset reproduction in the same run
- No threshold tuning, holdout reuse, leverage, orders, risk changes, or promotion

The repeated output is explicitly not counted as new evidence; it verifies deterministic reproduction of the one-year result.