### PR TITLE
Research cross-exchange volume shock

### DIFF
--- a/.github/workflows/book-liquidation-confirmation.yml
+++ b/.github/workflows/book-liquidation-confirmation.yml
@@ -25,7 +25,7 @@ permissions:
 
 concurrency:
   group: book-liquidation-confirmation
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   research:

--- a/.github/workflows/book-liquidation-confirmation.yml
+++ b/.github/workflows/book-liquidation-confirmation.yml
@@ -45,15 +45,15 @@ jobs:
           set -euo pipefail
           python scripts/fetch_binance_vision_klines.py \
             --symbols BTCUSDT ETHUSDT \
-            --since 2025-08 \
+            --since 2023-06 \
             --until 2024-11
       - name: Download completed COIN-M liquidation snapshots
         run: |
           set -euo pipefail
           python scripts/fetch_binance_coinm_liquidations.py \
             --symbols BTCUSD_PERP ETHUSD_PERP \
-            --since 2025-08-01 \
-            --until 2026-08-01 \
+            --since 2023-06-25 \
+            --until 2024-10-15 \
             --output-dir data/historical/binance/liquidations
       - name: Download completed USD-M book depth
         run: |

--- a/.github/workflows/book-liquidation-confirmation.yml
+++ b/.github/workflows/book-liquidation-confirmation.yml
@@ -46,7 +46,7 @@ jobs:
           python scripts/fetch_binance_vision_klines.py \
             --symbols BTCUSDT ETHUSDT \
             --since 2025-08 \
-            --until 2026-08
+            --until 2024-11
       - name: Download completed COIN-M liquidation snapshots
         run: |
           set -euo pipefail

--- a/.github/workflows/book-liquidation-confirmation.yml
+++ b/.github/workflows/book-liquidation-confirmation.yml
@@ -60,8 +60,8 @@ jobs:
           set -euo pipefail
           python scripts/fetch_binance_um_bookdepth.py \
             --symbols BTCUSDT ETHUSDT \
-            --since 2025-08-01 \
-            --until 2026-08-01
+            --since 2023-06-25 \
+            --until 2024-10-15
       - name: Run frozen candidates
         run: |
           set -euo pipefail

--- a/.github/workflows/book-liquidation-confirmation.yml
+++ b/.github/workflows/book-liquidation-confirmation.yml
@@ -1,0 +1,81 @@
+# Frozen order-book plus liquidation confirmation; research-only.
+name: Order-book + Liquidation Confirmation
+
+on:
+  push:
+    branches:
+      - research/book-liquidation-confirmation
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/book-liquidation-confirmation.yml"
+      - "scripts/fetch_binance_um_bookdepth.py"
+      - "scripts/fetch_binance_coinm_liquidations.py"
+      - "scripts/run_book_liquidation_confirmation.py"
+      - "scripts/run_liquidation_flow_reversal.py"
+      - "scripts/execution_model.py"
+      - "scripts/run_momentum_volatility_research.py"
+      - "scripts/fetch_binance_vision_klines.py"
+      - "tests/test_book_liquidation_confirmation.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: book-liquidation-confirmation
+  cancel-in-progress: false
+
+jobs:
+  research:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install research dependencies
+        run: python -m pip install --upgrade pip pytest
+      - name: Run regression tests
+        run: python -m pytest -q tests/test_book_liquidation_confirmation.py tests/test_liquidation_flow_reversal.py
+      - name: Download completed spot candles
+        run: |
+          set -euo pipefail
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2025-08 \
+            --until 2026-08
+      - name: Download completed COIN-M liquidation snapshots
+        run: |
+          set -euo pipefail
+          python scripts/fetch_binance_coinm_liquidations.py \
+            --symbols BTCUSD_PERP ETHUSD_PERP \
+            --since 2025-08-01 \
+            --until 2026-08-01 \
+            --output-dir data/historical/binance/liquidations
+      - name: Download completed USD-M book depth
+        run: |
+          set -euo pipefail
+          python scripts/fetch_binance_um_bookdepth.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2025-08-01 \
+            --until 2026-08-01
+      - name: Run frozen candidates
+        run: |
+          set -euo pipefail
+          python scripts/run_book_liquidation_confirmation.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --liquidations-dir data/historical/binance/liquidations \
+            --bookdepth-dir data/historical/binance/bookdepth \
+            --output artifacts/book-liquidation-confirmation/report.json
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-liquidation-confirmation
+          path: artifacts/book-liquidation-confirmation
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/cross-exchange-lead-lag.yml
+++ b/.github/workflows/cross-exchange-lead-lag.yml
@@ -1,0 +1,70 @@
+# Frozen cross-exchange lead/lag experiment; research-only.
+name: Cross-Exchange Lead-Lag Confirmation
+
+on:
+  push:
+    branches:
+      - research/cross-exchange-lead-lag
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/cross-exchange-lead-lag.yml"
+      - "scripts/fetch_coinbase_exchange_candles.py"
+      - "scripts/run_cross_exchange_lead_lag.py"
+      - "scripts/execution_model.py"
+      - "scripts/run_momentum_volatility_research.py"
+      - "scripts/fetch_binance_vision_klines.py"
+      - "tests/test_cross_exchange_lead_lag.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-exchange-lead-lag
+  cancel-in-progress: true
+
+jobs:
+  research:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install research dependencies
+        run: python -m pip install --upgrade pip pytest
+      - name: Run regression tests
+        run: python -m pytest -q tests/test_cross_exchange_lead_lag.py
+      - name: Download completed Binance execution candles
+        run: |
+          set -euo pipefail
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-06 \
+            --until 2024-11
+      - name: Download completed Coinbase lead candles
+        run: |
+          set -euo pipefail
+          python scripts/fetch_coinbase_exchange_candles.py \
+            --products BTC-USD ETH-USD \
+            --since 2023-06-25T00:00:00Z \
+            --until 2024-10-15T00:00:00Z
+      - name: Run frozen lead/lag candidate
+        run: |
+          set -euo pipefail
+          python scripts/run_cross_exchange_lead_lag.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --coinbase-dir data/historical/coinbase/normalized \
+            --output artifacts/cross-exchange-lead-lag/report.json
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cross-exchange-lead-lag
+          path: artifacts/cross-exchange-lead-lag
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/cross-exchange-volume-shock.yml
+++ b/.github/workflows/cross-exchange-volume-shock.yml
@@ -1,0 +1,71 @@
+# Frozen cross-exchange volume-shock experiment; research-only.
+name: Cross-Exchange Volume Shock Confirmation
+
+on:
+  push:
+    branches:
+      - research/cross-exchange-volume-shock
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/cross-exchange-volume-shock.yml"
+      - "scripts/run_cross_exchange_volume_shock.py"
+      - "scripts/run_cross_exchange_lead_lag.py"
+      - "scripts/fetch_coinbase_exchange_candles.py"
+      - "scripts/execution_model.py"
+      - "scripts/run_momentum_volatility_research.py"
+      - "scripts/fetch_binance_vision_klines.py"
+      - "tests/test_cross_exchange_volume_shock.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-exchange-volume-shock
+  cancel-in-progress: true
+
+jobs:
+  research:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install research dependencies
+        run: python -m pip install --upgrade pip pytest
+      - name: Run regression tests
+        run: python -m pytest -q tests/test_cross_exchange_volume_shock.py
+      - name: Download completed Binance execution candles
+        run: |
+          set -euo pipefail
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-06 \
+            --until 2024-11
+      - name: Download completed Coinbase lead candles
+        run: |
+          set -euo pipefail
+          python scripts/fetch_coinbase_exchange_candles.py \
+            --products BTC-USD ETH-USD \
+            --since 2023-06-25T00:00:00Z \
+            --until 2024-10-15T00:00:00Z
+      - name: Run frozen volume-shock candidate
+        run: |
+          set -euo pipefail
+          python scripts/run_cross_exchange_volume_shock.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --coinbase-dir data/historical/coinbase/normalized \
+            --output artifacts/cross-exchange-volume-shock/report.json
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cross-exchange-volume-shock
+          path: artifacts/cross-exchange-volume-shock
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/liquidation-flow-reversal.yml
+++ b/.github/workflows/liquidation-flow-reversal.yml
@@ -1,0 +1,70 @@
+# Single frozen liquidation-flow reversal hypothesis; research-only.
+name: Liquidation Flow Reversal
+
+on:
+  push:
+    branches:
+      - research/liquidation-flow-reversal
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/liquidation-flow-reversal.yml"
+      - "scripts/fetch_binance_coinm_liquidations.py"
+      - "scripts/run_liquidation_flow_reversal.py"
+      - "scripts/execution_model.py"
+      - "scripts/run_momentum_volatility_research.py"
+      - "scripts/fetch_binance_vision_klines.py"
+      - "tests/test_liquidation_flow_reversal.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: liquidation-flow-reversal
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install research dependencies
+        run: python -m pip install --upgrade pip pytest
+      - name: Run regression tests
+        run: python -m pytest -q tests/test_liquidation_flow_reversal.py
+      - name: Download completed spot candles
+        run: |
+          set -euo pipefail
+          python scripts/fetch_binance_vision_klines.py \
+            --symbols BTCUSDT ETHUSDT \
+            --since 2023-06 \
+            --until 2024-11
+      - name: Download completed COIN-M liquidation snapshots
+        run: |
+          set -euo pipefail
+          python scripts/fetch_binance_coinm_liquidations.py \
+            --symbols BTCUSD_PERP ETHUSD_PERP \
+            --since 2023-06-25 \
+            --until 2024-10-15
+      - name: Run frozen liquidation hypothesis
+        run: |
+          set -euo pipefail
+          python scripts/run_liquidation_flow_reversal.py \
+            --btc-path data/historical/binance/normalized/BTCUSDT_1h.csv \
+            --eth-path data/historical/binance/normalized/ETHUSDT_1h.csv \
+            --liquidations-dir data/historical/binance/liquidations \
+            --output artifacts/liquidation-flow-reversal/report.json
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: liquidation-flow-reversal
+          path: artifacts/liquidation-flow-reversal
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/fetch_binance_coinm_liquidations.py
+++ b/scripts/fetch_binance_coinm_liquidations.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Download and normalize Binance COIN-M liquidation snapshots.
+
+The source is Binance Vision's daily COIN-M liquidationSnapshot archive. The
+archive coverage is intentionally bounded by the frozen experiment window;
+missing daily archives are errors, never zero-liquidation observations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+BASE_URL = "https://data.binance.vision"
+CONTRACT_SIZE_USD = {"BTCUSD_PERP": 100.0, "ETHUSD_PERP": 10.0}
+FIELDNAMES = ("timestamp", "side", "liquidation_usd")
+
+
+def day_iter(since: str, until: str) -> list[datetime]:
+    start = datetime.strptime(since, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    end = datetime.strptime(until, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    if start >= end:
+        raise ValueError("--since must be earlier than exclusive --until")
+    return [start + timedelta(days=offset) for offset in range((end - start).days)]
+
+
+def _download(url: str) -> bytes:
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "trading-bot-liquidation-research/1.0"}
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read()
+
+
+def _checksum(zip_bytes: bytes, checksum_text: str) -> str:
+    expected = checksum_text.strip().split()[0].lower()
+    if len(expected) != 64 or any(char not in "0123456789abcdef" for char in expected):
+        raise ValueError(f"unrecognized checksum format: {checksum_text!r}")
+    actual = hashlib.sha256(zip_bytes).hexdigest()
+    if actual != expected:
+        raise ValueError(f"checksum mismatch: expected {expected}, got {actual}")
+    return actual
+
+
+def _timestamp(raw: str) -> datetime:
+    value = int(float(raw))
+    if value >= 10**14:
+        value //= 1000
+    return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+
+
+def _read_archive(zip_bytes: bytes, contract_size: float) -> list[dict[str, object]]:
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as archive:
+        names = [name for name in archive.namelist() if name.lower().endswith(".csv")]
+        if len(names) != 1:
+            raise ValueError(f"expected one CSV in archive, found {names}")
+        rows: list[dict[str, object]] = []
+        with archive.open(names[0], "r") as raw:
+            reader = csv.DictReader(io.TextIOWrapper(raw, encoding="utf-8", newline=""))
+            required = {
+                "time",
+                "side",
+                "original_quantity",
+                "last_fill_quantity",
+                "accumulated_fill_quantity",
+                "order_status",
+            }
+            if not required.issubset(reader.fieldnames or set()):
+                raise ValueError(
+                    f"liquidation CSV missing columns: {sorted(required - set(reader.fieldnames or []))}"
+                )
+            for row in reader:
+                if row["order_status"].upper() != "FILLED":
+                    continue
+                side = row["side"].upper()
+                if side not in {"BUY", "SELL"}:
+                    raise ValueError(f"unexpected liquidation side: {side}")
+                quantity = float(row["accumulated_fill_quantity"])
+                if quantity <= 0:
+                    raise ValueError("filled liquidation quantity must be positive")
+                rows.append(
+                    {
+                        "timestamp": _timestamp(row["time"]).isoformat().replace("+00:00", "Z"),
+                        "side": side,
+                        "liquidation_usd": quantity * contract_size,
+                    }
+                )
+        return rows
+
+
+def fetch_symbol(
+    symbol: str,
+    since: str,
+    until: str,
+    output_dir: Path,
+) -> dict[str, object]:
+    if symbol not in CONTRACT_SIZE_USD:
+        raise ValueError(f"unsupported COIN-M liquidation symbol: {symbol}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, object]] = []
+    archives: list[dict[str, object]] = []
+    for day in day_iter(since, until):
+        date = day.strftime("%Y-%m-%d")
+        stem = f"{symbol}-liquidationSnapshot-{date}"
+        url = (
+            f"{BASE_URL}/data/futures/cm/daily/liquidationSnapshot/"
+            f"{symbol}/{stem}.zip"
+        )
+        checksum_url = f"{url}.CHECKSUM"
+        try:
+            zip_bytes = _download(url)
+            checksum_text = _download(checksum_url).decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"required liquidation archive unavailable for {symbol} {date}: HTTP {exc.code}"
+            ) from exc
+        digest = _checksum(zip_bytes, checksum_text)
+        day_rows = _read_archive(zip_bytes, CONTRACT_SIZE_USD[symbol])
+        rows.extend(day_rows)
+        archives.append({"url": url, "sha256": digest, "rows": len(day_rows)})
+    rows.sort(key=lambda row: (str(row["timestamp"]), str(row["side"])))
+    path = output_dir / f"{symbol}_liquidations.csv"
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+    manifest = {
+        "source": BASE_URL,
+        "market": "COIN-M futures",
+        "symbol": symbol,
+        "contract_size_usd": CONTRACT_SIZE_USD[symbol],
+        "since": since,
+        "until_exclusive": until,
+        "archive_count": len(archives),
+        "row_count": len(rows),
+        "archives": archives,
+    }
+    (output_dir / f"{symbol}_liquidations.manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return {"path": str(path), **{key: value for key, value in manifest.items() if key != "archives"}}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbols", nargs="+", default=list(CONTRACT_SIZE_USD))
+    parser.add_argument("--since", required=True, help="inclusive UTC date, YYYY-MM-DD")
+    parser.add_argument("--until", required=True, help="exclusive UTC date, YYYY-MM-DD")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/historical/binance/liquidations"),
+    )
+    args = parser.parse_args()
+    result = {
+        symbol: fetch_symbol(symbol, args.since, args.until, args.output_dir)
+        for symbol in args.symbols
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_binance_coinm_liquidations.py
+++ b/scripts/fetch_binance_coinm_liquidations.py
@@ -3,7 +3,7 @@
 
 The source is Binance Vision's daily COIN-M liquidationSnapshot archive. The
 archive coverage is intentionally bounded by the frozen experiment window;
-missing daily archives are errors, never zero-liquidation observations.
+missing daily archives are recorded and excluded, never treated as zero flow.
 """
 
 from __future__ import annotations
@@ -107,6 +107,7 @@ def fetch_symbol(
     output_dir.mkdir(parents=True, exist_ok=True)
     rows: list[dict[str, object]] = []
     archives: list[dict[str, object]] = []
+    missing_dates: list[str] = []
     for day in day_iter(since, until):
         date = day.strftime("%Y-%m-%d")
         stem = f"{symbol}-liquidationSnapshot-{date}"
@@ -119,8 +120,11 @@ def fetch_symbol(
             zip_bytes = _download(url)
             checksum_text = _download(checksum_url).decode("utf-8")
         except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                missing_dates.append(date)
+                continue
             raise RuntimeError(
-                f"required liquidation archive unavailable for {symbol} {date}: HTTP {exc.code}"
+                f"liquidation archive request failed for {symbol} {date}: HTTP {exc.code}"
             ) from exc
         digest = _checksum(zip_bytes, checksum_text)
         day_rows = _read_archive(zip_bytes, CONTRACT_SIZE_USD[symbol])
@@ -140,6 +144,8 @@ def fetch_symbol(
         "since": since,
         "until_exclusive": until,
         "archive_count": len(archives),
+        "missing_dates": missing_dates,
+        "missing_day_count": len(missing_dates),
         "row_count": len(rows),
         "archives": archives,
     }

--- a/scripts/fetch_binance_um_bookdepth.py
+++ b/scripts/fetch_binance_um_bookdepth.py
@@ -134,6 +134,46 @@ def fetch_symbol(symbol: str, since: str, until: str, raw_dir: Path, out_dir: Pa
             hour = timestamp.replace(minute=0, second=0, microsecond=0)
             rows_by_hour[hour].append(row)
 
+    rows: list[dict[str, object]] = []
+    for hour in sorted(rows_by_hour):
+        group = rows_by_hour[hour]
+        rows.append(
+            {
+                "timestamp": hour.isoformat().replace("+00:00", "Z"),
+                "imbalance": sum(float(row["imbalance"]) for row in group) / len(group),
+                "snapshot_count": len(group),
+                "bid_notional": sum(float(row["bid_notional"]) for row in group) / len(group),
+                "ask_notional": sum(float(row["ask_notional"]) for row in group) / len(group),
+            }
+        )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output_path = out_dir / f"{symbol}_bookdepth_1h.csv"
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    manifest = {
+        "source": BASE_URL,
+        "market": "USD-M futures daily bookDepth archives",
+        "symbol": symbol,
+        "since": since,
+        "until_exclusive": until,
+        "band_percentage": 1,
+        "aggregation": "mean of complete +/-1 percent snapshots within each UTC hour",
+        "archive_count": len(archives),
+        "missing_dates": missing_dates,
+        "missing_day_count": len(missing_dates),
+        "hour_count": len(rows),
+        "snapshot_count": sum(int(row["snapshot_count"]) for row in rows),
+        "archives": archives,
+    }
+    (out_dir / f"{symbol}_bookdepth_1h.manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return {key: value for key, value in manifest.items() if key != "archives"}
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)

--- a/scripts/fetch_binance_um_bookdepth.py
+++ b/scripts/fetch_binance_um_bookdepth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import io
 import json
@@ -92,6 +93,25 @@ def _read_archive(zip_bytes: bytes) -> list[dict[str, object]]:
     ]
 
 
+def _fetch_day(symbol: str, day: datetime) -> tuple[str, dict[str, object] | None, list[dict[str, object]]]:
+    date = day.strftime("%Y-%m-%d")
+    stem = f"{symbol}-bookDepth-{date}"
+    url = f"{BASE_URL}/data/futures/um/daily/bookDepth/{symbol}/{stem}.zip"
+    checksum_url = f"{url}.CHECKSUM"
+    try:
+        zip_bytes = _download(url)
+        checksum_text = _download(checksum_url).decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return date, None, []
+        raise RuntimeError(
+            f"book-depth archive request failed for {symbol} {date}: HTTP {exc.code}"
+        ) from exc
+    digest = _checksum(zip_bytes, checksum_text)
+    day_rows = _read_archive(zip_bytes)
+    return date, {"url": url, "sha256": digest, "snapshots": len(day_rows)}, day_rows
+
+
 def fetch_symbol(symbol: str, since: str, until: str, raw_dir: Path, out_dir: Path) -> dict[str, object]:
     rows_by_hour: dict[datetime, list[dict[str, object]]] = defaultdict(list)
     archives: list[dict[str, object]] = []
@@ -99,69 +119,20 @@ def fetch_symbol(symbol: str, since: str, until: str, raw_dir: Path, out_dir: Pa
     raw_symbol_dir = raw_dir / symbol
     raw_symbol_dir.mkdir(parents=True, exist_ok=True)
 
-    for day in day_iter(since, until):
-        date = day.strftime("%Y-%m-%d")
-        stem = f"{symbol}-bookDepth-{date}"
-        url = f"{BASE_URL}/data/futures/um/daily/bookDepth/{symbol}/{stem}.zip"
-        checksum_url = f"{url}.CHECKSUM"
-        try:
-            zip_bytes = _download(url)
-            checksum_text = _download(checksum_url).decode("utf-8")
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404:
-                missing_dates.append(date)
-                continue
-            raise RuntimeError(
-                f"book-depth archive request failed for {symbol} {date}: HTTP {exc.code}"
-            ) from exc
-
-        digest = _checksum(zip_bytes, checksum_text)
-        day_rows = _read_archive(zip_bytes)
+    # Bounded parallelism avoids a multi-hour sequential scan while preserving
+    # deterministic day ordering in the normalized output and manifest.
+    days = day_iter(since, until)
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda day: _fetch_day(symbol, day), days))
+    for date, archive_info, day_rows in results:
+        if archive_info is None:
+            missing_dates.append(date)
+            continue
+        archives.append(archive_info)
         for row in day_rows:
             timestamp = row["timestamp"]
             hour = timestamp.replace(minute=0, second=0, microsecond=0)
             rows_by_hour[hour].append(row)
-        archives.append({"url": url, "sha256": digest, "snapshots": len(day_rows)})
-
-    rows: list[dict[str, object]] = []
-    for hour in sorted(rows_by_hour):
-        group = rows_by_hour[hour]
-        rows.append(
-            {
-                "timestamp": hour.isoformat().replace("+00:00", "Z"),
-                "imbalance": sum(float(row["imbalance"]) for row in group) / len(group),
-                "snapshot_count": len(group),
-                "bid_notional": sum(float(row["bid_notional"]) for row in group) / len(group),
-                "ask_notional": sum(float(row["ask_notional"]) for row in group) / len(group),
-            }
-        )
-
-    out_dir.mkdir(parents=True, exist_ok=True)
-    output_path = out_dir / f"{symbol}_bookdepth_1h.csv"
-    with output_path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
-        writer.writeheader()
-        writer.writerows(rows)
-
-    manifest = {
-        "source": BASE_URL,
-        "market": "USD-M futures daily bookDepth archives",
-        "symbol": symbol,
-        "since": since,
-        "until_exclusive": until,
-        "band_percentage": 1,
-        "aggregation": "mean of complete +/-1 percent snapshots within each UTC hour",
-        "archive_count": len(archives),
-        "missing_dates": missing_dates,
-        "missing_day_count": len(missing_dates),
-        "hour_count": len(rows),
-        "snapshot_count": sum(int(row["snapshot_count"]) for row in rows),
-        "archives": archives,
-    }
-    (out_dir / f"{symbol}_bookdepth_1h.manifest.json").write_text(
-        json.dumps(manifest, indent=2), encoding="utf-8"
-    )
-    return {key: value for key, value in manifest.items() if key != "archives"}
 
 
 def main() -> None:

--- a/scripts/fetch_binance_um_bookdepth.py
+++ b/scripts/fetch_binance_um_bookdepth.py
@@ -72,7 +72,7 @@ def _read_archive(zip_bytes: bytes) -> list[dict[str, object]]:
                     f"book-depth CSV missing columns: {sorted(required - set(reader.fieldnames or []))}"
                 )
             for row in reader:
-                percentage = int(row["percentage"])
+                percentage = int(float(row["percentage"]))
                 if percentage not in {-1, 1}:
                     continue
                 notional = float(row["notional"])

--- a/scripts/fetch_binance_um_bookdepth.py
+++ b/scripts/fetch_binance_um_bookdepth.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Download Binance USD-M daily book-depth archives and normalize top-1% imbalance.
+
+The downloader is research-only. Missing archives remain missing in the manifest;
+they are never converted into zero order-book pressure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import urllib.error
+import urllib.request
+import zipfile
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+BASE_URL = "https://data.binance.vision"
+FIELDNAMES = ("timestamp", "imbalance", "snapshot_count", "bid_notional", "ask_notional")
+
+
+def day_iter(since: str, until: str) -> list[datetime]:
+    start = datetime.strptime(since, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    end = datetime.strptime(until, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    if start >= end:
+        raise ValueError("--since must be earlier than exclusive --until")
+    return [start + timedelta(days=offset) for offset in range((end - start).days)]
+
+
+def _download(url: str) -> bytes:
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "trading-bot-book-depth-research/1.0"}
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read()
+
+
+def _checksum(zip_bytes: bytes, checksum_text: str) -> str:
+    expected = checksum_text.strip().split()[0].lower()
+    if len(expected) != 64 or any(char not in "0123456789abcdef" for char in expected):
+        raise ValueError(f"unrecognized checksum format: {checksum_text!r}")
+    actual = hashlib.sha256(zip_bytes).hexdigest()
+    if actual != expected:
+        raise ValueError(f"checksum mismatch: expected {expected}, got {actual}")
+    return actual
+
+
+def _timestamp(raw: str) -> datetime:
+    value = raw.strip().replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _read_archive(zip_bytes: bytes) -> list[dict[str, object]]:
+    snapshots: dict[datetime, dict[int, float]] = defaultdict(dict)
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as archive:
+        names = [name for name in archive.namelist() if name.lower().endswith(".csv")]
+        if len(names) != 1:
+            raise ValueError(f"expected one CSV in archive, found {names}")
+        with archive.open(names[0], "r") as raw:
+            reader = csv.DictReader(io.TextIOWrapper(raw, encoding="utf-8", newline=""))
+            required = {"timestamp", "percentage", "notional"}
+            if not required.issubset(reader.fieldnames or set()):
+                raise ValueError(
+                    f"book-depth CSV missing columns: {sorted(required - set(reader.fieldnames or []))}"
+                )
+            for row in reader:
+                percentage = int(row["percentage"])
+                if percentage not in {-1, 1}:
+                    continue
+                notional = float(row["notional"])
+                if not math.isfinite(notional) or notional < 0:
+                    raise ValueError("book-depth notional must be finite and non-negative")
+                snapshots[_timestamp(row["timestamp"])][percentage] = notional
+
+    return [
+        {
+            "timestamp": timestamp,
+            "imbalance": (levels[-1] - levels[1]) / (levels[-1] + levels[1]),
+            "bid_notional": levels[-1],
+            "ask_notional": levels[1],
+        }
+        for timestamp, levels in snapshots.items()
+        if -1 in levels and 1 in levels and levels[-1] + levels[1] > 0
+    ]
+
+
+def fetch_symbol(symbol: str, since: str, until: str, raw_dir: Path, out_dir: Path) -> dict[str, object]:
+    rows_by_hour: dict[datetime, list[dict[str, object]]] = defaultdict(list)
+    archives: list[dict[str, object]] = []
+    missing_dates: list[str] = []
+    raw_symbol_dir = raw_dir / symbol
+    raw_symbol_dir.mkdir(parents=True, exist_ok=True)
+
+    for day in day_iter(since, until):
+        date = day.strftime("%Y-%m-%d")
+        stem = f"{symbol}-bookDepth-{date}"
+        url = f"{BASE_URL}/data/futures/um/daily/bookDepth/{symbol}/{stem}.zip"
+        checksum_url = f"{url}.CHECKSUM"
+        try:
+            zip_bytes = _download(url)
+            checksum_text = _download(checksum_url).decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                missing_dates.append(date)
+                continue
+            raise RuntimeError(
+                f"book-depth archive request failed for {symbol} {date}: HTTP {exc.code}"
+            ) from exc
+
+        digest = _checksum(zip_bytes, checksum_text)
+        day_rows = _read_archive(zip_bytes)
+        for row in day_rows:
+            timestamp = row["timestamp"]
+            hour = timestamp.replace(minute=0, second=0, microsecond=0)
+            rows_by_hour[hour].append(row)
+        archives.append({"url": url, "sha256": digest, "snapshots": len(day_rows)})
+
+    rows: list[dict[str, object]] = []
+    for hour in sorted(rows_by_hour):
+        group = rows_by_hour[hour]
+        rows.append(
+            {
+                "timestamp": hour.isoformat().replace("+00:00", "Z"),
+                "imbalance": sum(float(row["imbalance"]) for row in group) / len(group),
+                "snapshot_count": len(group),
+                "bid_notional": sum(float(row["bid_notional"]) for row in group) / len(group),
+                "ask_notional": sum(float(row["ask_notional"]) for row in group) / len(group),
+            }
+        )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output_path = out_dir / f"{symbol}_bookdepth_1h.csv"
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    manifest = {
+        "source": BASE_URL,
+        "market": "USD-M futures daily bookDepth archives",
+        "symbol": symbol,
+        "since": since,
+        "until_exclusive": until,
+        "band_percentage": 1,
+        "aggregation": "mean of complete +/-1 percent snapshots within each UTC hour",
+        "archive_count": len(archives),
+        "missing_dates": missing_dates,
+        "missing_day_count": len(missing_dates),
+        "hour_count": len(rows),
+        "snapshot_count": sum(int(row["snapshot_count"]) for row in rows),
+        "archives": archives,
+    }
+    (out_dir / f"{symbol}_bookdepth_1h.manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return {key: value for key, value in manifest.items() if key != "archives"}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbols", nargs="+", default=["BTCUSDT", "ETHUSDT"])
+    parser.add_argument("--since", required=True, help="inclusive UTC date, YYYY-MM-DD")
+    parser.add_argument("--until", required=True, help="exclusive UTC date, YYYY-MM-DD")
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/historical/binance/raw_bookdepth"))
+    parser.add_argument("--out-dir", type=Path, default=Path("data/historical/binance/bookdepth"))
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            {
+                symbol: fetch_symbol(symbol, args.since, args.until, args.raw_dir, args.out_dir)
+                for symbol in args.symbols
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_coinbase_exchange_candles.py
+++ b/scripts/fetch_coinbase_exchange_candles.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Download completed Coinbase Exchange hourly candles for research.
+
+Coinbase's public candles endpoint returns at most 300 candles per request.
+This downloader paginates fixed completed-hour windows, preserves gaps in the
+manifest, and never fills missing candles with synthetic values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+BASE_URL = "https://api.exchange.coinbase.com"
+GRANULARITY_SECONDS = 3600
+MAX_CANDLES_PER_REQUEST = 250
+FIELDNAMES = ("timestamp", "open", "high", "low", "close", "volume")
+
+
+def _utc_date(raw: str) -> datetime:
+    value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _download_json(url: str) -> list[list[object]]:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "trading-bot-cross-exchange-research/1.0"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"Coinbase candle request failed: HTTP {exc.code}: {url}") from exc
+    if not isinstance(payload, list):
+        raise ValueError(f"Coinbase candle response was not a list: {payload!r}")
+    return payload
+
+
+def _iso(timestamp: int) -> str:
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_rows(payload: list[list[object]], product: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for values in payload:
+        if len(values) < 6:
+            raise ValueError(f"{product} candle row has fewer than six fields")
+        timestamp = int(values[0])
+        low, high, open_price, close, volume = (float(value) for value in values[1:6])
+        if (
+            timestamp <= 0
+            or not all(math.isfinite(value) for value in (low, high, open_price, close, volume))
+            or min(low, high, open_price, close) <= 0
+            or high < max(open_price, close)
+            or low > min(open_price, close)
+            or volume < 0
+        ):
+            raise ValueError(f"invalid Coinbase candle for {product}: {values!r}")
+        rows.append(
+            {
+                "timestamp": _iso(timestamp),
+                "open": str(open_price),
+                "high": str(high),
+                "low": str(low),
+                "close": str(close),
+                "volume": str(volume),
+            }
+        )
+    return rows
+
+
+def fetch_product(product: str, since: str, until: str, output_dir: Path) -> dict[str, object]:
+    start = _utc_date(since).replace(minute=0, second=0, microsecond=0)
+    end = _utc_date(until).replace(minute=0, second=0, microsecond=0)
+    if start >= end:
+        raise ValueError("--since must be earlier than exclusive --until")
+
+    rows_by_timestamp: dict[str, dict[str, str]] = {}
+    chunks: list[dict[str, object]] = []
+    current = start
+    while current < end:
+        chunk_end = min(
+            end,
+            current + timedelta(hours=MAX_CANDLES_PER_REQUEST),
+        )
+        query = urllib.parse.urlencode(
+            {
+                "start": current.isoformat().replace("+00:00", "Z"),
+                "end": chunk_end.isoformat().replace("+00:00", "Z"),
+                "granularity": GRANULARITY_SECONDS,
+            }
+        )
+        url = f"{BASE_URL}/products/{product}/candles?{query}"
+        parsed = _parse_rows(_download_json(url), product)
+        for row in parsed:
+            timestamp = row["timestamp"]
+            existing = rows_by_timestamp.get(timestamp)
+            if existing is not None and existing != row:
+                raise ValueError(f"conflicting duplicate Coinbase candle at {product} {timestamp}")
+            rows_by_timestamp[timestamp] = row
+        chunks.append({"start": current.isoformat(), "end_exclusive": chunk_end.isoformat(), "rows": len(parsed)})
+        current = chunk_end
+        time.sleep(0.12)
+
+    rows = [
+        row for timestamp, row in sorted(rows_by_timestamp.items())
+        if start <= _utc_date(timestamp) < end
+    ]
+    if not rows:
+        raise ValueError(f"Coinbase returned no candles for {product}")
+
+    timestamps = [_utc_date(row["timestamp"]) for row in rows]
+    gaps = [
+        {
+            "from": previous.isoformat(),
+            "to": current_timestamp.isoformat(),
+            "missing_hours": int((current_timestamp - previous).total_seconds() / 3600) - 1,
+        }
+        for previous, current_timestamp in zip(timestamps, timestamps[1:])
+        if (current_timestamp - previous).total_seconds() > 5400
+    ]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / f"{product.replace('-', '')}_1h.csv"
+    with output.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    manifest = {
+        "source": BASE_URL,
+        "product": product,
+        "granularity_seconds": GRANULARITY_SECONDS,
+        "since": since,
+        "until_exclusive": until,
+        "request_count": len(chunks),
+        "row_count": len(rows),
+        "start": rows[0]["timestamp"],
+        "end": rows[-1]["timestamp"],
+        "gaps_over_90_minutes": gaps,
+        "chunks": chunks,
+    }
+    manifest_path = output_dir / f"{product.replace('-', '')}_1h.manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return {"output": str(output), **manifest}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--products", nargs="+", default=["BTC-USD", "ETH-USD"])
+    parser.add_argument("--since", required=True, help="inclusive UTC timestamp")
+    parser.add_argument("--until", required=True, help="exclusive UTC timestamp")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/historical/coinbase/normalized"),
+    )
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            {
+                product: fetch_product(product, args.since, args.until, args.output_dir)
+                for product in args.products
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_book_liquidation_confirmation.py
+++ b/scripts/run_book_liquidation_confirmation.py
@@ -55,9 +55,9 @@ except ModuleNotFoundError:
     )
     from run_momentum_volatility_research import Bar, load_bars
 
-START = datetime(2025, 8, 1, tzinfo=timezone.utc)
-DISCOVERY_END = datetime(2026, 2, 1, tzinfo=timezone.utc)
-END = datetime(2026, 8, 1, tzinfo=timezone.utc)
+START = datetime(2023, 6, 25, tzinfo=timezone.utc)
+DISCOVERY_END = datetime(2024, 2, 25, tzinfo=timezone.utc)
+END = datetime(2024, 10, 15, tzinfo=timezone.utc)
 BOOK_IMBALANCE_THRESHOLD = 0.20
 BOOK_PERSISTENCE_HOURS = 3
 BLOCKS = 6
@@ -364,6 +364,8 @@ def main() -> int:
             "holdout_selection_used": False,
             "overlapping_trade_windows_excluded_by_cooldown": True,
             "newest_unseen_data_used": False,
+            "window_is_independent_replication": False,
+            "window_note": "Historical overlap with the prior liquidation experiment; the combined rule is new, but this is not an independent time-period replication of liquidation flow.",
         },
         "source": {
             "provider": "Binance Vision",

--- a/scripts/run_book_liquidation_confirmation.py
+++ b/scripts/run_book_liquidation_confirmation.py
@@ -371,7 +371,7 @@ def main() -> int:
             "liquidation_archives": "COIN-M daily liquidationSnapshot",
             "bookdepth_missing_archive_days": book_missing,
             "liquidation_missing_archive_days": {
-                asset: sorted(value) for asset, value in liquidation_missing.items()
+                asset: sorted(item.isoformat() for item in value) for asset, value in liquidation_missing.items()
             },
         },
         "candidates": results,

--- a/scripts/run_book_liquidation_confirmation.py
+++ b/scripts/run_book_liquidation_confirmation.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Evaluate one frozen book-imbalance plus liquidation confirmation experiment."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.execution_model import STRESS_EXECUTION
+    from scripts.run_liquidation_flow_reversal import (
+        ASSETS,
+        BASELINE_HOURS,
+        COOLDOWN_HOURS,
+        DOMINANCE_THRESHOLD,
+        END as LIQ_END,
+        EXTREME_MULTIPLIER,
+        HOLD_HOURS,
+        LIQUIDATION_FILES,
+        MIN_BASELINE_EVENTS,
+        NOTIONAL,
+        START as LIQ_START,
+        DISCOVERY_END as LIQ_DISCOVERY_END,
+        _signal as liquidation_signal,
+        aggregate_hourly,
+        load_liquidations,
+        trade,
+    )
+    from scripts.run_momentum_volatility_research import Bar, load_bars
+except ModuleNotFoundError:
+    from execution_model import STRESS_EXECUTION
+    from run_liquidation_flow_reversal import (
+        ASSETS,
+        BASELINE_HOURS,
+        COOLDOWN_HOURS,
+        DOMINANCE_THRESHOLD,
+        END as LIQ_END,
+        EXTREME_MULTIPLIER,
+        HOLD_HOURS,
+        LIQUIDATION_FILES,
+        MIN_BASELINE_EVENTS,
+        NOTIONAL,
+        START as LIQ_START,
+        DISCOVERY_END as LIQ_DISCOVERY_END,
+        _signal as liquidation_signal,
+        aggregate_hourly,
+        load_liquidations,
+        trade,
+    )
+    from run_momentum_volatility_research import Bar, load_bars
+
+START = datetime(2025, 8, 1, tzinfo=timezone.utc)
+DISCOVERY_END = datetime(2026, 2, 1, tzinfo=timezone.utc)
+END = datetime(2026, 8, 1, tzinfo=timezone.utc)
+BOOK_IMBALANCE_THRESHOLD = 0.20
+BOOK_PERSISTENCE_HOURS = 3
+BLOCKS = 6
+MIN_TRADES_PER_BLOCK = 20
+BOOK_FILES = {
+    "BTC": "BTCUSDT_bookdepth_1h.csv",
+    "ETH": "ETHUSDT_bookdepth_1h.csv",
+}
+
+
+def _utc(raw: str) -> datetime:
+    value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def load_bookdepth(path: Path) -> dict[datetime, float]:
+    result: dict[datetime, float] = {}
+    with path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            timestamp = _utc(row["timestamp"])
+            imbalance = float(row["imbalance"])
+            snapshots = int(row["snapshot_count"])
+            if not math.isfinite(imbalance) or not -1 <= imbalance <= 1:
+                raise ValueError("book imbalance must be finite and within [-1, 1]")
+            if snapshots <= 0:
+                raise ValueError("book snapshot_count must be positive")
+            result[timestamp] = imbalance
+    return result
+
+
+def book_side(book: dict[datetime, float], timestamps: list[datetime], index: int) -> int:
+    start = max(0, index - BOOK_PERSISTENCE_HOURS + 1)
+    values = [book.get(timestamp) for timestamp in timestamps[start : index + 1]]
+    if len(values) != BOOK_PERSISTENCE_HOURS or any(value is None for value in values):
+        return 0
+    numeric = [float(value) for value in values if value is not None]
+    if all(value >= BOOK_IMBALANCE_THRESHOLD for value in numeric):
+        return 1
+    if all(value <= -BOOK_IMBALANCE_THRESHOLD for value in numeric):
+        return -1
+    return 0
+
+
+def candidate_side(
+    candidate: str,
+    flow: dict[datetime, dict[str, float]],
+    book: dict[datetime, float],
+    timestamps: list[datetime],
+    index: int,
+    missing_dates: set[date],
+) -> int:
+    pressure = book_side(book, timestamps, index)
+    if candidate == "orderbook_only":
+        return pressure
+    if candidate != "combined":
+        raise ValueError(f"unknown candidate: {candidate}")
+    forced_flow = liquidation_signal(flow, timestamps, index, missing_dates)
+    return forced_flow if forced_flow and forced_flow == pressure else 0
+
+
+def evaluate_asset(
+    bars: list[Bar],
+    flow: dict[datetime, dict[str, float]],
+    book: dict[datetime, float],
+    *,
+    start: int,
+    end: int,
+    symbol: str,
+    missing_dates: set[date],
+    candidate: str,
+) -> list[dict[str, Any]]:
+    timestamps = [bar.timestamp for bar in bars]
+    last_signal = -10**9
+    rows: list[dict[str, Any]] = []
+    signal_stop = min(len(bars), end - 1 - STRESS_EXECUTION.latency_bars - HOLD_HOURS)
+    for index in range(start, max(start, signal_stop)):
+        side = candidate_side(candidate, flow, book, timestamps, index, missing_dates)
+        if not side or index - last_signal < COOLDOWN_HOURS:
+            continue
+        result = trade(bars, index, side, symbol)
+        if result is not None:
+            result["signal_index"] = index
+            result["candidate"] = candidate
+            result["book_imbalance"] = book.get(timestamps[index])
+            rows.append(result)
+            last_signal = index
+    return rows
+
+
+def _summary_by_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    groups = [[] for _ in range(BLOCKS)]
+    for row in rows:
+        groups[int(row["block_index"])].append(row)
+    pnls = [float(row["net_pnl"]) for row in rows]
+    returns = [float(row["net_return"]) for row in rows]
+    gains = sum(value for value in pnls if value > 0)
+    losses = abs(sum(value for value in pnls if value < 0))
+    equity = peak = 0.0
+    max_drawdown = 0.0
+    for value in pnls:
+        equity += value
+        peak = max(peak, equity)
+        max_drawdown = max(max_drawdown, peak - equity)
+    block_means = [
+        statistics.mean(float(row["net_return"]) for row in group) if group else None
+        for group in groups
+    ]
+    valid_means = [value for value in block_means if value is not None]
+    median_block = statistics.median(valid_means) if valid_means else None
+    mean_return = statistics.mean(returns) if returns else None
+    volatility = statistics.pstdev(returns) if len(returns) > 1 else None
+    sharpe_proxy = (
+        mean_return / volatility * math.sqrt(len(returns))
+        if mean_return is not None and volatility and volatility > 0
+        else None
+    )
+    return {
+        "trade_count": len(rows),
+        "block_trade_counts": [len(group) for group in groups],
+        "block_mean_net_returns": block_means,
+        "net_pnl": sum(pnls),
+        "net_return_pct": sum(returns) * 100.0,
+        "max_drawdown_pct_of_notional": max_drawdown / NOTIONAL * 100.0,
+        "sharpe_proxy": sharpe_proxy,
+        "profit_factor": gains / losses if losses else None,
+        "execution_cost": sum(float(row["execution_cost"]) for row in rows),
+        "median_block_return_to_stress_cost": (
+            median_block / (STRESS_EXECUTION.round_trip_bps / 10_000.0)
+            if median_block is not None
+            else None
+        ),
+        "passes_sample_gate": all(len(group) >= MIN_TRADES_PER_BLOCK for group in groups),
+        "passes_positive_block_gate": (
+            len(valid_means) == BLOCKS and all(value > 0 for value in valid_means)
+        ),
+    }
+
+
+def _gate(summary: dict[str, Any]) -> bool:
+    ratio = summary["median_block_return_to_stress_cost"]
+    return bool(
+        summary["passes_sample_gate"]
+        and summary["passes_positive_block_gate"]
+        and ratio is not None
+        and ratio >= 1.0
+    )
+
+
+def _load_bars(path: Path) -> list[Bar]:
+    bars = load_bars(path)
+    if bars[0].timestamp > START or bars[-1].timestamp < END - timedelta(hours=1):
+        raise ValueError(f"{path} does not fully cover the frozen window")
+    selected = [bar for bar in bars if START <= bar.timestamp < END]
+    if not selected:
+        raise ValueError(f"{path} has no bars in the frozen window")
+    return selected
+
+
+def evaluate_split(
+    bars_by_asset: dict[str, list[Bar]],
+    flows_by_asset: dict[str, dict[datetime, dict[str, float]]],
+    books_by_asset: dict[str, dict[datetime, float]],
+    missing_dates_by_asset: dict[str, set[date]],
+    start: datetime,
+    end: datetime,
+    candidate: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for asset, bars in bars_by_asset.items():
+        start_index = next((i for i, bar in enumerate(bars) if bar.timestamp >= start), None)
+        end_index = next((i for i, bar in enumerate(bars) if bar.timestamp >= end), len(bars))
+        if start_index is None:
+            raise ValueError(f"{asset} bars do not cover {start.isoformat()}")
+        rows.extend(
+            evaluate_asset(
+                bars,
+                flows_by_asset[asset],
+                books_by_asset[asset],
+                start=start_index,
+                end=end_index,
+                symbol=asset,
+                missing_dates=missing_dates_by_asset[asset],
+                candidate=candidate,
+            )
+        )
+    rows.sort(key=lambda row: (_utc(row["signal_timestamp"]), row["symbol"]))
+    start_epoch = int(start.timestamp() // 3600)
+    end_epoch = int(end.timestamp() // 3600)
+    width = (end_epoch - start_epoch) / BLOCKS
+    for row in rows:
+        signal_epoch = int(_utc(row["signal_timestamp"]).timestamp() // 3600)
+        row["block_index"] = min(BLOCKS - 1, int((signal_epoch - start_epoch) / width))
+    return rows, _summary_by_block(rows)
+
+
+def _load_liquidation_files(liquidations_dir: Path) -> tuple[
+    dict[str, dict[datetime, dict[str, float]]], dict[str, set[date]]
+]:
+    flows: dict[str, dict[datetime, dict[str, float]]] = {}
+    missing_dates: dict[str, set[date]] = {}
+    for asset in ASSETS:
+        path = liquidations_dir / LIQUIDATION_FILES[asset]
+        flows[asset] = aggregate_hourly(load_liquidations(path))
+        manifest = json.loads(path.with_suffix(".manifest.json").read_text(encoding="utf-8"))
+        missing_dates[asset] = {
+            date.fromisoformat(value) for value in manifest.get("missing_dates", [])
+        }
+    return flows, missing_dates
+
+
+def _load_book_files(bookdepth_dir: Path) -> tuple[dict[str, dict[datetime, float]], dict[str, list[str]]]:
+    books: dict[str, dict[datetime, float]] = {}
+    missing_dates: dict[str, list[str]] = {}
+    for asset in ASSETS:
+        path = bookdepth_dir / BOOK_FILES[asset]
+        books[asset] = load_bookdepth(path)
+        manifest = json.loads(path.with_suffix(".manifest.json").read_text(encoding="utf-8"))
+        missing_dates[asset] = list(manifest.get("missing_dates", []))
+    return books, missing_dates
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--liquidations-dir", type=Path, required=True)
+    parser.add_argument("--bookdepth-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    bars_by_asset = {"BTC": _load_bars(args.btc_path), "ETH": _load_bars(args.eth_path)}
+    flows_by_asset, liquidation_missing = _load_liquidation_files(args.liquidations_dir)
+    books_by_asset, book_missing = _load_book_files(args.bookdepth_dir)
+    results: dict[str, Any] = {}
+    for candidate in ("orderbook_only", "combined"):
+        discovery_rows, discovery = evaluate_split(
+            bars_by_asset,
+            flows_by_asset,
+            books_by_asset,
+            liquidation_missing,
+            START,
+            DISCOVERY_END,
+            candidate,
+        )
+        holdout_rows, holdout = evaluate_split(
+            bars_by_asset,
+            flows_by_asset,
+            books_by_asset,
+            liquidation_missing,
+            DISCOVERY_END,
+            END,
+            candidate,
+        )
+        results[candidate] = {
+            "discovery": discovery,
+            "holdout": holdout,
+            "passes_discovery": _gate(discovery),
+            "passes_confirmation": bool(_gate(discovery) and _gate(holdout)),
+            "status": "confirmed" if _gate(discovery) and _gate(holdout) else "not_confirmed",
+            "discovery_trade_rows": discovery_rows,
+            "holdout_trade_rows": holdout_rows,
+        }
+
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "active_profile_changed": False,
+        "promotion_allowed": False,
+        "hypothesis": (
+            "A persistent one-sided order-book imbalance identifies near-term "
+            "direction, and liquidation-flow reversal is valid only when the "
+            "order book confirms the same direction."
+        ),
+        "frozen_parameters": {
+            "assets": ["BTCUSDT", "ETHUSDT"],
+            "book_depth_source": "Binance Vision USD-M daily bookDepth",
+            "book_band_percentage": 1,
+            "book_imbalance": "(bid_notional_at_-1pct - ask_notional_at_+1pct) / sum",
+            "book_imbalance_threshold": BOOK_IMBALANCE_THRESHOLD,
+            "book_persistence_hours": BOOK_PERSISTENCE_HOURS,
+            "combined_rule": "liquidation reversal side must equal persistent book-pressure side",
+            "liquidation_baseline_hours": BASELINE_HOURS,
+            "liquidation_minimum_baseline_events": MIN_BASELINE_EVENTS,
+            "liquidation_extreme_multiplier": EXTREME_MULTIPLIER,
+            "liquidation_dominance_threshold": DOMINANCE_THRESHOLD,
+            "hold_hours": HOLD_HOURS,
+            "cooldown_hours": COOLDOWN_HOURS,
+            "entry": "signal-hour close, next-bar open plus one latency bar",
+            "notional": NOTIONAL,
+        },
+        "execution_model": STRESS_EXECUTION.as_dict(),
+        "window": {
+            "start": START.isoformat(),
+            "discovery_end_exclusive": DISCOVERY_END.isoformat(),
+            "end_exclusive": END.isoformat(),
+            "holdout_untouched": True,
+            "completed_candles_only": True,
+            "six_chronological_blocks_per_split": True,
+            "holdout_selection_used": False,
+            "overlapping_trade_windows_excluded_by_cooldown": True,
+            "newest_unseen_data_used": False,
+        },
+        "source": {
+            "provider": "Binance Vision",
+            "bookdepth_archives": "USD-M daily bookDepth",
+            "liquidation_archives": "COIN-M daily liquidationSnapshot",
+            "bookdepth_missing_archive_days": book_missing,
+            "liquidation_missing_archive_days": {
+                asset: sorted(value) for asset, value in liquidation_missing.items()
+            },
+        },
+        "candidates": results,
+        "status": "confirmed"
+        if any(value["passes_confirmation"] for value in results.values())
+        else "not_confirmed",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                candidate: {
+                    "status": value["status"],
+                    "discovery_trades": value["discovery"]["trade_count"],
+                    "holdout_trades": value["holdout"]["trade_count"],
+                }
+                for candidate, value in results.items()
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_cross_exchange_lead_lag.py
+++ b/scripts/run_cross_exchange_lead_lag.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Evaluate one frozen Coinbase-leads-Binance hourly lead/lag hypothesis."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.execution_model import STRESS_EXECUTION
+    from scripts.run_momentum_volatility_research import Bar, load_bars
+except ModuleNotFoundError:
+    from execution_model import STRESS_EXECUTION
+    from run_momentum_volatility_research import Bar, load_bars
+
+START = datetime(2023, 6, 25, tzinfo=timezone.utc)
+DISCOVERY_END = datetime(2024, 2, 25, tzinfo=timezone.utc)
+END = datetime(2024, 10, 15, tzinfo=timezone.utc)
+ASSETS = {"BTC": ("BTCUSDT", "BTCUSD"), "ETH": ("ETHUSDT", "ETHUSD")}
+LEAD_HOURS = 3
+LEAD_MOVE_THRESHOLD = 0.010
+MINIMUM_LEAD_LAG_GAP = 0.005
+HOLD_HOURS = 8
+COOLDOWN_HOURS = 8
+NOTIONAL = 3_000.0
+BLOCKS = 6
+MIN_TRADES_PER_BLOCK = 20
+COINBASE_FILES = {"BTC": "BTCUSD_1h.csv", "ETH": "ETHUSD_1h.csv"}
+
+
+def _utc(raw: str) -> datetime:
+    value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def load_coinbase(path: Path) -> dict[datetime, float]:
+    result: dict[datetime, float] = {}
+    with path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            timestamp = _utc(row["timestamp"])
+            close = float(row["close"])
+            if not math.isfinite(close) or close <= 0:
+                raise ValueError("Coinbase close must be finite and positive")
+            result[timestamp] = close
+    return result
+
+
+def _signal(
+    coinbase: dict[datetime, float],
+    binance: dict[datetime, float],
+    timestamp: datetime,
+) -> tuple[int, float, float, float] | None:
+    prior_timestamp = timestamp.fromtimestamp(
+        timestamp.timestamp() - LEAD_HOURS * 3600,
+        tz=timezone.utc,
+    )
+    lead_start = coinbase.get(prior_timestamp)
+    lead_end = coinbase.get(timestamp)
+    execution_start = binance.get(prior_timestamp)
+    execution_end = binance.get(timestamp)
+    if None in {lead_start, lead_end, execution_start, execution_end}:
+        return None
+    lead_move = lead_end / lead_start - 1.0
+    execution_move = execution_end / execution_start - 1.0
+    gap = lead_move - execution_move
+    if lead_move >= LEAD_MOVE_THRESHOLD and gap >= MINIMUM_LEAD_LAG_GAP:
+        return 1, lead_move, execution_move, gap
+    if lead_move <= -LEAD_MOVE_THRESHOLD and gap <= -MINIMUM_LEAD_LAG_GAP:
+        return -1, lead_move, execution_move, gap
+    return 0, lead_move, execution_move, gap
+
+
+def _trade(bars: list[Bar], signal_index: int, side: int, symbol: str) -> dict[str, Any] | None:
+    entry_index = signal_index + 1 + STRESS_EXECUTION.latency_bars
+    exit_index = entry_index + HOLD_HOURS
+    if exit_index >= len(bars):
+        return None
+    entry = bars[entry_index].open
+    exit_price = bars[exit_index].close
+    if entry <= 0 or not math.isfinite(entry) or not math.isfinite(exit_price):
+        return None
+    gross_return = side * (exit_price / entry - 1.0)
+    filled_notional = (
+        NOTIONAL
+        * STRESS_EXECUTION.fill_fraction
+        * (1.0 - STRESS_EXECUTION.outage_rejection_rate)
+    )
+    trading_cost = filled_notional * STRESS_EXECUTION.round_trip_bps / 10_000.0
+    funding_cost = (
+        filled_notional
+        * STRESS_EXECUTION.funding_bps_per_bar
+        * HOLD_HOURS
+        / 10_000.0
+    )
+    net_pnl = filled_notional * gross_return - trading_cost - funding_cost
+    return {
+        "signal_timestamp": bars[signal_index].timestamp.isoformat(),
+        "entry_timestamp": bars[entry_index].timestamp.isoformat(),
+        "exit_timestamp": bars[exit_index].timestamp.isoformat(),
+        "symbol": symbol,
+        "side": "long" if side > 0 else "short",
+        "gross_return": gross_return,
+        "net_return": net_pnl / NOTIONAL,
+        "net_pnl": net_pnl,
+        "execution_cost": trading_cost + funding_cost,
+    }
+
+
+def _summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    groups = [[] for _ in range(BLOCKS)]
+    for row in rows:
+        groups[int(row["block_index"])].append(row)
+    pnls = [float(row["net_pnl"]) for row in rows]
+    returns = [float(row["net_return"]) for row in rows]
+    gains = sum(value for value in pnls if value > 0)
+    losses = abs(sum(value for value in pnls if value < 0))
+    equity = peak = 0.0
+    max_drawdown = 0.0
+    for value in pnls:
+        equity += value
+        peak = max(peak, equity)
+        max_drawdown = max(max_drawdown, peak - equity)
+    block_means = [
+        statistics.mean(float(row["net_return"]) for row in group) if group else None
+        for group in groups
+    ]
+    valid_means = [value for value in block_means if value is not None]
+    mean_return = statistics.mean(returns) if returns else None
+    volatility = statistics.pstdev(returns) if len(returns) > 1 else None
+    return {
+        "trade_count": len(rows),
+        "block_trade_counts": [len(group) for group in groups],
+        "block_mean_net_returns": block_means,
+        "net_pnl": sum(pnls),
+        "net_return_pct": sum(returns) * 100.0,
+        "max_drawdown_pct_of_notional": max_drawdown / NOTIONAL * 100.0,
+        "sharpe_proxy": (
+            mean_return / volatility * math.sqrt(len(returns))
+            if mean_return is not None and volatility and volatility > 0
+            else None
+        ),
+        "profit_factor": gains / losses if losses else None,
+        "execution_cost": sum(float(row["execution_cost"]) for row in rows),
+        "median_block_return_to_stress_cost": (
+            statistics.median(valid_means)
+            / (STRESS_EXECUTION.round_trip_bps / 10_000.0)
+            if valid_means
+            else None
+        ),
+        "passes_sample_gate": all(len(group) >= MIN_TRADES_PER_BLOCK for group in groups),
+        "passes_positive_block_gate": (
+            len(valid_means) == BLOCKS and all(value > 0 for value in valid_means)
+        ),
+    }
+
+
+def _gate(summary: dict[str, Any]) -> bool:
+    ratio = summary["median_block_return_to_stress_cost"]
+    return bool(
+        summary["passes_sample_gate"]
+        and summary["passes_positive_block_gate"]
+        and ratio is not None
+        and ratio >= 1.0
+    )
+
+
+def _load_binance(path: Path) -> list[Bar]:
+    bars = load_bars(path)
+    if not bars or bars[0].timestamp > START or bars[-1].timestamp < END:
+        raise ValueError(f"{path} does not cover the frozen window")
+    return [bar for bar in bars if START <= bar.timestamp < END]
+
+
+def _evaluate_split(
+    bars: list[Bar],
+    coinbase: dict[datetime, float],
+    start: datetime,
+    end: datetime,
+    symbol: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    bar_by_timestamp = {bar.timestamp: bar.close for bar in bars}
+    start_index = next((i for i, bar in enumerate(bars) if bar.timestamp >= start), None)
+    end_index = next((i for i, bar in enumerate(bars) if bar.timestamp >= end), len(bars))
+    if start_index is None:
+        raise ValueError(f"{symbol} bars do not cover {start.isoformat()}")
+    rows: list[dict[str, Any]] = []
+    last_signal_index = -10**9
+    for index in range(start_index, max(start_index, end_index - HOLD_HOURS - 2)):
+        timestamp = bars[index].timestamp
+        signal = _signal(coinbase, bar_by_timestamp, timestamp)
+        if signal is None:
+            continue
+        side, lead_move, execution_move, gap = signal
+        if not side or index - last_signal_index < COOLDOWN_HOURS:
+            continue
+        result = _trade(bars, index, side, symbol)
+        if result is not None:
+            result.update(
+                {
+                    "lead_move": lead_move,
+                    "execution_move": execution_move,
+                    "lead_lag_gap": gap,
+                }
+            )
+            rows.append(result)
+            last_signal_index = index
+    rows.sort(key=lambda row: (_utc(row["signal_timestamp"]), row["symbol"]))
+    start_epoch = int(start.timestamp() // 3600)
+    end_epoch = int(end.timestamp() // 3600)
+    width = (end_epoch - start_epoch) / BLOCKS
+    for row in rows:
+        signal_epoch = int(_utc(row["signal_timestamp"]).timestamp() // 3600)
+        row["block_index"] = min(BLOCKS - 1, int((signal_epoch - start_epoch) / width))
+    return rows, _summary(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--coinbase-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    bars_by_asset = {
+        "BTC": _load_binance(args.btc_path),
+        "ETH": _load_binance(args.eth_path),
+    }
+    coinbase_by_asset = {
+        asset: load_coinbase(args.coinbase_dir / COINBASE_FILES[asset])
+        for asset in ASSETS
+    }
+    results: dict[str, Any] = {}
+    for asset, bars in bars_by_asset.items():
+        discovery_rows, discovery = _evaluate_split(
+            bars, coinbase_by_asset[asset], START, DISCOVERY_END, asset
+        )
+        holdout_rows, holdout = _evaluate_split(
+            bars, coinbase_by_asset[asset], DISCOVERY_END, END, asset
+        )
+        results[asset] = {
+            "discovery": discovery,
+            "holdout": holdout,
+            "passes_discovery": _gate(discovery),
+            "passes_confirmation": bool(_gate(discovery) and _gate(holdout)),
+            "status": "confirmed" if _gate(discovery) and _gate(holdout) else "not_confirmed",
+            "discovery_trade_rows": discovery_rows,
+            "holdout_trade_rows": holdout_rows,
+        }
+
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "active_profile_changed": False,
+        "promotion_allowed": False,
+        "hypothesis": (
+            "A large completed Coinbase move leads an under-reacting Binance "
+            "market, which catches up in the next eight hours."
+        ),
+        "frozen_parameters": {
+            "lead_source": "Coinbase Exchange hourly candles",
+            "execution_source": "Binance spot hourly candles",
+            "assets": ["BTCUSDT", "ETHUSDT"],
+            "lead_window_hours": LEAD_HOURS,
+            "lead_move_threshold": LEAD_MOVE_THRESHOLD,
+            "minimum_lead_lag_gap": MINIMUM_LEAD_LAG_GAP,
+            "hold_hours": HOLD_HOURS,
+            "cooldown_hours": COOLDOWN_HOURS,
+            "entry": "signal-hour close, next-bar open plus one latency bar",
+            "direction": "positive Coinbase lead and positive gap -> long Binance; negative -> short",
+            "notional": NOTIONAL,
+        },
+        "execution_model": STRESS_EXECUTION.as_dict(),
+        "window": {
+            "start": START.isoformat(),
+            "discovery_end_exclusive": DISCOVERY_END.isoformat(),
+            "end_exclusive": END.isoformat(),
+            "holdout_untouched": True,
+            "completed_candles_only": True,
+            "six_chronological_blocks_per_split": True,
+            "holdout_selection_used": False,
+            "overlapping_trade_windows_excluded_by_cooldown": True,
+            "newest_unseen_data_used": False,
+            "window_is_independent_replication": False,
+            "window_note": "New cross-exchange data source tested on the same frozen historical window; this is not an independent time-period replication of earlier hypotheses.",
+        },
+        "source": {
+            "lead_provider": "Coinbase Exchange public candles",
+            "execution_provider": "Binance Vision spot klines",
+            "coinbase_products": ["BTC-USD", "ETH-USD"],
+            "binance_symbols": ["BTCUSDT", "ETHUSDT"],
+        },
+        "candidates": results,
+        "status": "confirmed"
+        if any(value["passes_confirmation"] for value in results.values())
+        else "not_confirmed",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                asset: {
+                    "status": value["status"],
+                    "discovery_trades": value["discovery"]["trade_count"],
+                    "holdout_trades": value["holdout"]["trade_count"],
+                }
+                for asset, value in results.items()
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_cross_exchange_volume_shock.py
+++ b/scripts/run_cross_exchange_volume_shock.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Evaluate one frozen Coinbase-volume-shock to Binance continuation hypothesis."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import statistics
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.run_cross_exchange_lead_lag import (
+        ASSETS,
+        BLOCKS,
+        COOLDOWN_HOURS,
+        DISCOVERY_END,
+        END,
+        HOLD_HOURS,
+        MIN_TRADES_PER_BLOCK,
+        NOTIONAL,
+        START,
+        _gate,
+        _summary,
+        _trade,
+        _load_binance,
+        _utc,
+    )
+except ModuleNotFoundError:
+    from run_cross_exchange_lead_lag import (
+        ASSETS,
+        BLOCKS,
+        COOLDOWN_HOURS,
+        DISCOVERY_END,
+        END,
+        HOLD_HOURS,
+        MIN_TRADES_PER_BLOCK,
+        NOTIONAL,
+        START,
+        _gate,
+        _summary,
+        _trade,
+        _load_binance,
+        _utc,
+    )
+
+VOLUME_LOOKBACK_HOURS = 720
+VOLUME_SHOCK_MULTIPLIER = 2.0
+MOVE_THRESHOLD = 0.005
+SIGNAL_WINDOW_HOURS = 3
+COINBASE_FILES = {"BTC": "BTCUSD_1h.csv", "ETH": "ETHUSD_1h.csv"}
+
+
+def load_coinbase(path: Path) -> dict[datetime, dict[str, float]]:
+    result: dict[datetime, dict[str, float]] = {}
+    with path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            timestamp = _utc(row["timestamp"])
+            close = float(row["close"])
+            volume = float(row["volume"])
+            if (
+                not math.isfinite(close)
+                or close <= 0
+                or not math.isfinite(volume)
+                or volume < 0
+            ):
+                raise ValueError("Coinbase close and volume must be finite and valid")
+            result[timestamp] = {"close": close, "volume": volume}
+    return result
+
+
+def _hour_range(end: datetime, count: int) -> list[datetime]:
+    return [
+        end - timedelta(hours=offset)
+        for offset in range(count - 1, -1, -1)
+    ]
+
+
+def _signal(
+    coinbase: dict[datetime, dict[str, float]],
+    timestamp: datetime,
+) -> tuple[int, float, float, float] | None:
+    current_hours = _hour_range(timestamp, SIGNAL_WINDOW_HOURS)
+    prior_hours = _hour_range(timestamp - timedelta(hours=SIGNAL_WINDOW_HOURS), VOLUME_LOOKBACK_HOURS)
+    required = current_hours + prior_hours
+    if any(hour not in coinbase for hour in required):
+        return None
+    start = coinbase[current_hours[0]]["close"]
+    end = coinbase[current_hours[-1]]["close"]
+    move = end / start - 1.0
+    current_volume = sum(coinbase[hour]["volume"] for hour in current_hours)
+    prior_windows = []
+    for offset in range(0, VOLUME_LOOKBACK_HOURS - SIGNAL_WINDOW_HOURS + 1):
+        window = _hour_range(
+            timestamp - timedelta(hours=SIGNAL_WINDOW_HOURS + offset),
+            SIGNAL_WINDOW_HOURS,
+        )
+        prior_windows.append(sum(coinbase[hour]["volume"] for hour in window))
+    baseline = statistics.median(prior_windows)
+    if baseline <= 0 or current_volume < VOLUME_SHOCK_MULTIPLIER * baseline:
+        return 0, move, current_volume, baseline
+    if move >= MOVE_THRESHOLD:
+        return 1, move, current_volume, baseline
+    if move <= -MOVE_THRESHOLD:
+        return -1, move, current_volume, baseline
+    return 0, move, current_volume, baseline
+
+
+def _evaluate_asset(
+    bars: list[Any],
+    coinbase: dict[datetime, dict[str, float]],
+    start: datetime,
+    end: datetime,
+    symbol: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    start_index = next((i for i, bar in enumerate(bars) if bar.timestamp >= start), None)
+    end_index = next((i for i, bar in enumerate(bars) if bar.timestamp >= end), len(bars))
+    if start_index is None:
+        raise ValueError(f"{symbol} bars do not cover {start.isoformat()}")
+    rows: list[dict[str, Any]] = []
+    last_signal_index = -10**9
+    signal_stop = max(start_index, end_index - HOLD_HOURS - 2)
+    for index in range(start_index, signal_stop):
+        signal = _signal(coinbase, bars[index].timestamp)
+        if signal is None:
+            continue
+        side, move, current_volume, baseline_volume = signal
+        if not side or index - last_signal_index < COOLDOWN_HOURS:
+            continue
+        result = _trade(bars, index, side, symbol)
+        if result is None:
+            continue
+        result.update(
+            {
+                "coinbase_move": move,
+                "coinbase_volume_3h": current_volume,
+                "coinbase_volume_baseline_3h": baseline_volume,
+                "coinbase_volume_multiple": (
+                    current_volume / baseline_volume if baseline_volume else None
+                ),
+            }
+        )
+        rows.append(result)
+        last_signal_index = index
+    rows.sort(key=lambda row: (_utc(row["signal_timestamp"]), row["symbol"]))
+    start_epoch = int(start.timestamp() // 3600)
+    end_epoch = int(end.timestamp() // 3600)
+    width = (end_epoch - start_epoch) / BLOCKS
+    for row in rows:
+        signal_epoch = int(_utc(row["signal_timestamp"]).timestamp() // 3600)
+        row["block_index"] = min(BLOCKS - 1, int((signal_epoch - start_epoch) / width))
+    return rows, _summary(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--coinbase-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    bars_by_asset = {
+        "BTC": _load_binance(args.btc_path),
+        "ETH": _load_binance(args.eth_path),
+    }
+    coinbase_by_asset = {
+        asset: load_coinbase(args.coinbase_dir / COINBASE_FILES[asset])
+        for asset in ASSETS
+    }
+    results: dict[str, Any] = {}
+    for asset, bars in bars_by_asset.items():
+        discovery_rows, discovery = _evaluate_asset(
+            bars, coinbase_by_asset[asset], START, DISCOVERY_END, asset
+        )
+        holdout_rows, holdout = _evaluate_asset(
+            bars, coinbase_by_asset[asset], DISCOVERY_END, END, asset
+        )
+        results[asset] = {
+            "discovery": discovery,
+            "holdout": holdout,
+            "passes_discovery": _gate(discovery),
+            "passes_confirmation": bool(_gate(discovery) and _gate(holdout)),
+            "status": "confirmed" if _gate(discovery) and _gate(holdout) else "not_confirmed",
+            "discovery_trade_rows": discovery_rows,
+            "holdout_trade_rows": holdout_rows,
+        }
+
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "active_profile_changed": False,
+        "promotion_allowed": False,
+        "hypothesis": (
+            "A large completed Coinbase volume shock with directional movement "
+            "leads to continuation on Binance during the next eight hours."
+        ),
+        "frozen_parameters": {
+            "lead_source": "Coinbase Exchange hourly candles and quote volume",
+            "execution_source": "Binance spot hourly candles",
+            "assets": ["BTCUSDT", "ETHUSDT"],
+            "signal_window_hours": SIGNAL_WINDOW_HOURS,
+            "volume_lookback_hours": VOLUME_LOOKBACK_HOURS,
+            "volume_shock_multiplier": VOLUME_SHOCK_MULTIPLIER,
+            "directional_move_threshold": MOVE_THRESHOLD,
+            "hold_hours": HOLD_HOURS,
+            "cooldown_hours": COOLDOWN_HOURS,
+            "entry": "signal-hour close, next-bar open plus one latency bar",
+            "direction": "positive Coinbase shock -> long Binance; negative -> short",
+            "notional": NOTIONAL,
+        },
+        "execution_model": __import__(
+            "scripts.execution_model", fromlist=["STRESS_EXECUTION"]
+        ).STRESS_EXECUTION.as_dict(),
+        "window": {
+            "start": START.isoformat(),
+            "discovery_end_exclusive": DISCOVERY_END.isoformat(),
+            "end_exclusive": END.isoformat(),
+            "holdout_untouched": True,
+            "completed_candles_only": True,
+            "six_chronological_blocks_per_split": True,
+            "holdout_selection_used": False,
+            "overlapping_trade_windows_excluded_by_cooldown": True,
+            "newest_unseen_data_used": False,
+            "window_is_independent_replication": False,
+            "window_note": "New pre-specified volume-shock rule; no thresholds were changed after evaluation.",
+        },
+        "source": {
+            "lead_provider": "Coinbase Exchange public candles",
+            "execution_provider": "Binance Vision spot klines",
+            "coinbase_products": ["BTC-USD", "ETH-USD"],
+            "binance_symbols": ["BTCUSDT", "ETHUSDT"],
+        },
+        "candidates": results,
+        "status": "confirmed"
+        if any(value["passes_confirmation"] for value in results.values())
+        else "not_confirmed",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                asset: {
+                    "status": value["status"],
+                    "discovery_trades": value["discovery"]["trade_count"],
+                    "holdout_trades": value["holdout"]["trade_count"],
+                }
+                for asset, value in results.items()
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_cross_exchange_volume_shock.py
+++ b/scripts/run_cross_exchange_volume_shock.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from scripts.execution_model import STRESS_EXECUTION
     from scripts.run_cross_exchange_lead_lag import (
         ASSETS,
         BLOCKS,
@@ -30,6 +31,7 @@ try:
         _utc,
     )
 except ModuleNotFoundError:
+    from execution_model import STRESS_EXECUTION
     from run_cross_exchange_lead_lag import (
         ASSETS,
         BLOCKS,
@@ -215,9 +217,7 @@ def main() -> int:
             "direction": "positive Coinbase shock -> long Binance; negative -> short",
             "notional": NOTIONAL,
         },
-        "execution_model": __import__(
-            "scripts.execution_model", fromlist=["STRESS_EXECUTION"]
-        ).STRESS_EXECUTION.as_dict(),
+        "execution_model": STRESS_EXECUTION.as_dict(),
         "window": {
             "start": START.isoformat(),
             "discovery_end_exclusive": DISCOVERY_END.isoformat(),

--- a/scripts/run_liquidation_flow_reversal.py
+++ b/scripts/run_liquidation_flow_reversal.py
@@ -12,7 +12,7 @@ import csv
 import json
 import math
 import statistics
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -82,7 +82,14 @@ def _signal(
     flow: dict[datetime, dict[str, float]],
     timestamps: list[datetime],
     index: int,
+    missing_dates: set[date] | None = None,
 ) -> int:
+    missing_dates = missing_dates or set()
+    prior_timestamps = timestamps[max(0, index - BASELINE_HOURS):index]
+    if timestamps[index].date() in missing_dates or any(
+        timestamp.date() in missing_dates for timestamp in prior_timestamps
+    ):
+        return 0
     current = flow.get(
         timestamps[index],
         {"buy_usd": 0.0, "sell_usd": 0.0, "total_usd": 0.0},
@@ -153,6 +160,7 @@ def evaluate_asset(
     start: int,
     end: int,
     symbol: str,
+    missing_dates: set[date],
 ) -> list[dict[str, Any]]:
     timestamps = [bar.timestamp for bar in bars]
     last_signal = -10**9
@@ -163,7 +171,7 @@ def evaluate_asset(
         end - 1 - STRESS_EXECUTION.latency_bars - HOLD_HOURS,
     )
     for index in range(start, max(start, signal_stop)):
-        side = _signal(flow, timestamps, index)
+        side = _signal(flow, timestamps, index, missing_dates)
         if not side or index - last_signal < COOLDOWN_HOURS:
             continue
         result = trade(bars, index, side, symbol)
@@ -238,6 +246,7 @@ def _load_bars(path: Path) -> list[Bar]:
 def evaluate_split(
     bars_by_asset: dict[str, list[Bar]],
     flows_by_asset: dict[str, dict[datetime, dict[str, float]]],
+    missing_dates_by_asset: dict[str, set[date]],
     start: datetime,
     end: datetime,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -254,6 +263,7 @@ def evaluate_split(
                 start=start_index,
                 end=end_index,
                 symbol=asset,
+                missing_dates=missing_dates_by_asset[asset],
             )
         )
     rows.sort(key=lambda row: (_utc(row["signal_timestamp"]), row["symbol"]))
@@ -266,13 +276,20 @@ def evaluate_split(
     return rows, _summary_by_block(rows)
 
 
-def _load_liquidation_files(liquidations_dir: Path) -> dict[str, dict[datetime, dict[str, float]]]:
-    return {
-        asset: aggregate_hourly(
-            load_liquidations(liquidations_dir / LIQUIDATION_FILES[asset])
-        )
-        for asset in ASSETS
-    }
+def _load_liquidation_files(
+    liquidations_dir: Path,
+) -> tuple[dict[str, dict[datetime, dict[str, float]]], dict[str, set[date]]]:
+    flows: dict[str, dict[datetime, dict[str, float]]] = {}
+    missing_dates: dict[str, set[date]] = {}
+    for asset in ASSETS:
+        path = liquidations_dir / LIQUIDATION_FILES[asset]
+        flows[asset] = aggregate_hourly(load_liquidations(path))
+        manifest_path = path.with_suffix(".manifest.json")
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        missing_dates[asset] = {
+            date.fromisoformat(value) for value in manifest.get("missing_dates", [])
+        }
+    return flows, missing_dates
 
 
 def main() -> int:
@@ -287,16 +304,18 @@ def main() -> int:
         "BTC": _load_bars(args.btc_path),
         "ETH": _load_bars(args.eth_path),
     }
-    flows_by_asset = _load_liquidation_files(args.liquidations_dir)
+    flows_by_asset, missing_dates_by_asset = _load_liquidation_files(args.liquidations_dir)
     discovery_rows, discovery = evaluate_split(
         bars_by_asset,
         flows_by_asset,
+        missing_dates_by_asset,
         START,
         DISCOVERY_END,
     )
     holdout_rows, holdout = evaluate_split(
         bars_by_asset,
         flows_by_asset,
+        missing_dates_by_asset,
         DISCOVERY_END,
         END,
     )
@@ -343,6 +362,10 @@ def main() -> int:
             "market": "COIN-M perpetual liquidationSnapshot archives",
             "coverage_constraint": "2023-06-25 through 2024-10-14 inclusive",
             "contract_sizes_usd": {"BTCUSD_PERP": 100.0, "ETHUSD_PERP": 10.0},
+            "missing_archive_days_excluded": {
+                asset: sorted(value.isoformat() for value in dates)
+                for asset, dates in missing_dates_by_asset.items()
+            },
         },
         "discovery": discovery,
         "holdout": holdout,

--- a/scripts/run_liquidation_flow_reversal.py
+++ b/scripts/run_liquidation_flow_reversal.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Evaluate one frozen liquidation-flow reversal hypothesis.
+
+This is a research-only diagnostic. It never places orders, enables leverage,
+changes the active profile, or uses the confirmation slice for selection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.execution_model import STRESS_EXECUTION
+    from scripts.run_momentum_volatility_research import Bar, load_bars
+except ModuleNotFoundError:
+    from execution_model import STRESS_EXECUTION
+    from run_momentum_volatility_research import Bar, load_bars
+
+START = datetime(2023, 6, 25, tzinfo=timezone.utc)
+DISCOVERY_END = datetime(2024, 2, 25, tzinfo=timezone.utc)
+END = datetime(2024, 10, 15, tzinfo=timezone.utc)
+ASSETS = {"BTC": "BTCUSDT", "ETH": "ETHUSDT"}
+LIQUIDATION_FILES = {
+    "BTC": "BTCUSD_PERP_liquidations.csv",
+    "ETH": "ETHUSD_PERP_liquidations.csv",
+}
+BASELINE_HOURS = 720
+MIN_BASELINE_EVENTS = 30
+EXTREME_MULTIPLIER = 3.0
+DOMINANCE_THRESHOLD = 0.60
+HOLD_HOURS = 8
+COOLDOWN_HOURS = 8
+NOTIONAL = 3_000.0
+BLOCKS = 6
+MIN_TRADES_PER_BLOCK = 20
+
+
+def _utc(raw: str) -> datetime:
+    value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def load_liquidations(path: Path) -> list[dict[str, Any]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows: list[dict[str, Any]] = []
+        for row in csv.DictReader(handle):
+            side = row["side"].upper()
+            if side not in {"BUY", "SELL"}:
+                raise ValueError(f"unexpected liquidation side: {side}")
+            amount = float(row["liquidation_usd"])
+            if not math.isfinite(amount) or amount <= 0:
+                raise ValueError("liquidation_usd must be finite and positive")
+            timestamp = _utc(row["timestamp"]).replace(minute=0, second=0, microsecond=0)
+            rows.append({"timestamp": timestamp, "side": side, "liquidation_usd": amount})
+    return rows
+
+
+def aggregate_hourly(rows: list[dict[str, Any]]) -> dict[datetime, dict[str, float]]:
+    result: dict[datetime, dict[str, float]] = {}
+    for row in rows:
+        bucket = result.setdefault(
+            row["timestamp"],
+            {"buy_usd": 0.0, "sell_usd": 0.0},
+        )
+        bucket["buy_usd" if row["side"] == "BUY" else "sell_usd"] += row["liquidation_usd"]
+    for bucket in result.values():
+        bucket["total_usd"] = bucket["buy_usd"] + bucket["sell_usd"]
+    return result
+
+
+def _signal(
+    flow: dict[datetime, dict[str, float]],
+    timestamps: list[datetime],
+    index: int,
+) -> int:
+    current = flow.get(
+        timestamps[index],
+        {"buy_usd": 0.0, "sell_usd": 0.0, "total_usd": 0.0},
+    )
+    prior = [
+        flow.get(timestamp, {"total_usd": 0.0})["total_usd"]
+        for timestamp in timestamps[max(0, index - BASELINE_HOURS):index]
+    ]
+    nonzero = [value for value in prior if value > 0]
+    if len(nonzero) < MIN_BASELINE_EVENTS or not current["total_usd"]:
+        return 0
+    baseline = statistics.median(nonzero)
+    if current["total_usd"] < EXTREME_MULTIPLIER * baseline:
+        return 0
+    dominant = max(current["buy_usd"], current["sell_usd"]) / current["total_usd"]
+    if dominant < DOMINANCE_THRESHOLD:
+        return 0
+    # BUY liquidations close shorts; SELL liquidations close longs. The
+    # reversal trades against the forced-flow direction after the flush.
+    return 1 if current["sell_usd"] > current["buy_usd"] else -1
+
+
+def trade(
+    bars: list[Bar],
+    signal_index: int,
+    side: int,
+    symbol: str,
+) -> dict[str, Any] | None:
+    entry_index = signal_index + 1 + STRESS_EXECUTION.latency_bars
+    exit_index = entry_index + HOLD_HOURS
+    if exit_index >= len(bars):
+        return None
+    entry = bars[entry_index].open
+    exit_price = bars[exit_index].close
+    if entry <= 0 or not math.isfinite(entry) or not math.isfinite(exit_price):
+        return None
+    gross_return = side * (exit_price / entry - 1.0)
+    filled_notional = (
+        NOTIONAL
+        * STRESS_EXECUTION.fill_fraction
+        * (1.0 - STRESS_EXECUTION.outage_rejection_rate)
+    )
+    trading_cost = filled_notional * STRESS_EXECUTION.round_trip_bps / 10_000.0
+    funding_cost = (
+        filled_notional
+        * STRESS_EXECUTION.funding_bps_per_bar
+        * HOLD_HOURS
+        / 10_000.0
+    )
+    net_pnl = filled_notional * gross_return - trading_cost - funding_cost
+    return {
+        "signal_timestamp": bars[signal_index].timestamp.isoformat(),
+        "entry_timestamp": bars[entry_index].timestamp.isoformat(),
+        "exit_timestamp": bars[exit_index].timestamp.isoformat(),
+        "symbol": symbol,
+        "side": "long" if side > 0 else "short",
+        "gross_return": gross_return,
+        "net_return": net_pnl / NOTIONAL,
+        "net_pnl": net_pnl,
+        "execution_cost": trading_cost + funding_cost,
+    }
+
+
+def evaluate_asset(
+    bars: list[Bar],
+    flow: dict[datetime, dict[str, float]],
+    *,
+    start: int,
+    end: int,
+    symbol: str,
+) -> list[dict[str, Any]]:
+    timestamps = [bar.timestamp for bar in bars]
+    last_signal = -10**9
+    rows: list[dict[str, Any]] = []
+    # Do not score a signal unless its complete trade closes inside this split.
+    signal_stop = min(
+        len(bars),
+        end - 1 - STRESS_EXECUTION.latency_bars - HOLD_HOURS,
+    )
+    for index in range(start, max(start, signal_stop)):
+        side = _signal(flow, timestamps, index)
+        if not side or index - last_signal < COOLDOWN_HOURS:
+            continue
+        result = trade(bars, index, side, symbol)
+        if result is not None:
+            result["signal_index"] = index
+            rows.append(result)
+            last_signal = index
+    return rows
+
+
+def _summary_by_block(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    groups = [[] for _ in range(BLOCKS)]
+    for row in rows:
+        groups[int(row["block_index"])].append(row)
+    pnls = [float(row["net_pnl"]) for row in rows]
+    returns = [float(row["net_return"]) for row in rows]
+    gains = sum(value for value in pnls if value > 0)
+    losses = abs(sum(value for value in pnls if value < 0))
+    equity = peak = 0.0
+    max_drawdown = 0.0
+    for value in pnls:
+        equity += value
+        peak = max(peak, equity)
+        max_drawdown = max(max_drawdown, peak - equity)
+    block_means = [
+        statistics.mean(float(row["net_return"]) for row in group) if group else None
+        for group in groups
+    ]
+    valid_means = [value for value in block_means if value is not None]
+    median_block = statistics.median(valid_means) if valid_means else None
+    return {
+        "trade_count": len(rows),
+        "block_trade_counts": [len(group) for group in groups],
+        "block_mean_net_returns": block_means,
+        "net_pnl": sum(pnls),
+        "net_return_pct": sum(returns) * 100.0,
+        "max_drawdown_pct_of_notional": max_drawdown / NOTIONAL * 100.0,
+        "profit_factor": gains / losses if losses else None,
+        "execution_cost": sum(float(row["execution_cost"]) for row in rows),
+        "median_block_return_to_stress_cost": (
+            median_block / (STRESS_EXECUTION.round_trip_bps / 10_000.0)
+            if median_block is not None
+            else None
+        ),
+        "passes_sample_gate": all(len(group) >= MIN_TRADES_PER_BLOCK for group in groups),
+        "passes_positive_block_gate": (
+            len(valid_means) == BLOCKS and all(value > 0 for value in valid_means)
+        ),
+    }
+
+
+def _gate(summary: dict[str, Any]) -> bool:
+    ratio = summary["median_block_return_to_stress_cost"]
+    return bool(
+        summary["passes_sample_gate"]
+        and summary["passes_positive_block_gate"]
+        and ratio is not None
+        and ratio >= 1.0
+    )
+
+
+def _load_bars(path: Path) -> list[Bar]:
+    bars = load_bars(path)
+    if bars[0].timestamp > START or bars[-1].timestamp < END - timedelta(hours=1):
+        raise ValueError(f"{path} does not fully cover the frozen window")
+    selected = [bar for bar in bars if START <= bar.timestamp < END]
+    if not selected:
+        raise ValueError(f"{path} has no bars in the frozen window")
+    return selected
+
+
+def evaluate_split(
+    bars_by_asset: dict[str, list[Bar]],
+    flows_by_asset: dict[str, dict[datetime, dict[str, float]]],
+    start: datetime,
+    end: datetime,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for asset, bars in bars_by_asset.items():
+        start_index = next((i for i, bar in enumerate(bars) if bar.timestamp >= start), None)
+        end_index = next((i for i, bar in enumerate(bars) if bar.timestamp >= end), len(bars))
+        if start_index is None:
+            raise ValueError(f"{asset} bars do not cover {start.isoformat()}")
+        rows.extend(
+            evaluate_asset(
+                bars,
+                flows_by_asset[asset],
+                start=start_index,
+                end=end_index,
+                symbol=asset,
+            )
+        )
+    start_epoch = int(start.timestamp() // 3600)
+    end_epoch = int(end.timestamp() // 3600)
+    width = (end_epoch - start_epoch) / BLOCKS
+    for row in rows:
+        signal_epoch = int(_utc(row["signal_timestamp"]).timestamp() // 3600)
+        row["block_index"] = min(BLOCKS - 1, int((signal_epoch - start_epoch) / width))
+    return rows, _summary_by_block(rows)
+
+
+def _load_liquidation_files(liquidations_dir: Path) -> dict[str, dict[datetime, dict[str, float]]]:
+    return {
+        asset: aggregate_hourly(
+            load_liquidations(liquidations_dir / LIQUIDATION_FILES[asset])
+        )
+        for asset in ASSETS
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--btc-path", type=Path, required=True)
+    parser.add_argument("--eth-path", type=Path, required=True)
+    parser.add_argument("--liquidations-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    bars_by_asset = {
+        "BTC": _load_bars(args.btc_path),
+        "ETH": _load_bars(args.eth_path),
+    }
+    flows_by_asset = _load_liquidation_files(args.liquidations_dir)
+    discovery_rows, discovery = evaluate_split(
+        bars_by_asset,
+        flows_by_asset,
+        START,
+        DISCOVERY_END,
+    )
+    holdout_rows, holdout = evaluate_split(
+        bars_by_asset,
+        flows_by_asset,
+        DISCOVERY_END,
+        END,
+    )
+    passes_discovery = _gate(discovery)
+    passes_confirmation = bool(passes_discovery and _gate(holdout))
+    report = {
+        "schema_version": 1,
+        "research_only": True,
+        "paper_orders_placed": False,
+        "live_orders_placed": False,
+        "leverage_enabled": False,
+        "active_profile_changed": False,
+        "promotion_allowed": False,
+        "hypothesis": (
+            "After an extreme one-hour liquidation flush, forced-flow exhaustion "
+            "is followed by an eight-hour reversal."
+        ),
+        "frozen_parameters": {
+            "assets": ["BTCUSDT", "ETHUSDT"],
+            "liquidation_source_symbols": ["BTCUSD_PERP", "ETHUSD_PERP"],
+            "baseline_hours": BASELINE_HOURS,
+            "minimum_baseline_events": MIN_BASELINE_EVENTS,
+            "extreme_multiplier": EXTREME_MULTIPLIER,
+            "dominance_threshold": DOMINANCE_THRESHOLD,
+            "hold_hours": HOLD_HOURS,
+            "cooldown_hours": COOLDOWN_HOURS,
+            "entry": "signal-hour close, next-bar open plus one latency bar",
+            "direction": "SELL liquidation flow -> long; BUY liquidation flow -> short",
+            "position_selection": "BTC and ETH evaluated independently",
+        },
+        "execution_model": STRESS_EXECUTION.as_dict(),
+        "window": {
+            "start": START.isoformat(),
+            "discovery_end_exclusive": DISCOVERY_END.isoformat(),
+            "end_exclusive": END.isoformat(),
+            "holdout_untouched": True,
+            "completed_candles_only": True,
+            "six_chronological_blocks_per_split": True,
+            "holdout_selection_used": False,
+            "discovery_trades_cannot_exit_in_holdout": True,
+        },
+        "source": {
+            "provider": "Binance Vision",
+            "market": "COIN-M perpetual liquidationSnapshot archives",
+            "coverage_constraint": "2023-06-25 through 2024-10-14 inclusive",
+            "contract_sizes_usd": {"BTCUSD_PERP": 100.0, "ETHUSD_PERP": 10.0},
+        },
+        "discovery": discovery,
+        "holdout": holdout,
+        "passes_discovery": passes_discovery,
+        "passes_confirmation": passes_confirmation,
+        "status": "confirmed" if passes_confirmation else "not_confirmed",
+        "discovery_trade_rows": discovery_rows,
+        "holdout_trade_rows": holdout_rows,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False), encoding="utf-8")
+    print(
+        json.dumps(
+            {key: report[key] for key in ("status", "passes_discovery", "passes_confirmation")},
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_liquidation_flow_reversal.py
+++ b/scripts/run_liquidation_flow_reversal.py
@@ -67,8 +67,9 @@ def load_liquidations(path: Path) -> list[dict[str, Any]]:
 def aggregate_hourly(rows: list[dict[str, Any]]) -> dict[datetime, dict[str, float]]:
     result: dict[datetime, dict[str, float]] = {}
     for row in rows:
+        timestamp = row["timestamp"].replace(minute=0, second=0, microsecond=0)
         bucket = result.setdefault(
-            row["timestamp"],
+            timestamp,
             {"buy_usd": 0.0, "sell_usd": 0.0},
         )
         bucket["buy_usd" if row["side"] == "BUY" else "sell_usd"] += row["liquidation_usd"]

--- a/scripts/run_liquidation_flow_reversal.py
+++ b/scripts/run_liquidation_flow_reversal.py
@@ -256,6 +256,7 @@ def evaluate_split(
                 symbol=asset,
             )
         )
+    rows.sort(key=lambda row: (_utc(row["signal_timestamp"]), row["symbol"]))
     start_epoch = int(start.timestamp() // 3600)
     end_epoch = int(end.timestamp() // 3600)
     width = (end_epoch - start_epoch) / BLOCKS

--- a/tests/test_book_liquidation_confirmation.py
+++ b/tests/test_book_liquidation_confirmation.py
@@ -1,0 +1,38 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from scripts.execution_model import STRESS_EXECUTION
+from scripts.run_book_liquidation_confirmation import (
+    BOOK_IMBALANCE_THRESHOLD,
+    BOOK_PERSISTENCE_HOURS,
+    book_side,
+)
+
+
+class BookLiquidationConfirmationTests(unittest.TestCase):
+    def test_persistent_bid_pressure_is_long(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        timestamps = [start + timedelta(hours=index) for index in range(5)]
+        book = {timestamp: 0.25 for timestamp in timestamps}
+        self.assertEqual(book_side(book, timestamps, 2), 1)
+
+    def test_persistent_ask_pressure_is_short(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        timestamps = [start + timedelta(hours=index) for index in range(5)]
+        book = {timestamp: -0.25 for timestamp in timestamps}
+        self.assertEqual(book_side(book, timestamps, 2), -1)
+
+    def test_missing_hour_does_not_become_pressure(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        timestamps = [start + timedelta(hours=index) for index in range(5)]
+        book = {timestamps[1]: 0.25, timestamps[2]: 0.25}
+        self.assertEqual(book_side(book, timestamps, 2), 0)
+
+    def test_parameters_and_costs_are_frozen(self) -> None:
+        self.assertEqual(BOOK_IMBALANCE_THRESHOLD, 0.20)
+        self.assertEqual(BOOK_PERSISTENCE_HOURS, 3)
+        self.assertEqual(STRESS_EXECUTION.round_trip_bps, 86.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cross_exchange_lead_lag.py
+++ b/tests/test_cross_exchange_lead_lag.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timezone
+
+from scripts.run_cross_exchange_lead_lag import _signal
+
+UTC = timezone.utc
+
+
+def test_positive_coinbase_lead_emits_long():
+    timestamp = datetime(2024, 1, 1, 3, tzinfo=UTC)
+    coinbase = {
+        datetime(2024, 1, 1, 0, tzinfo=UTC): 100.0,
+        timestamp: 101.5,
+    }
+    binance = {
+        datetime(2024, 1, 1, 0, tzinfo=UTC): 100.0,
+        timestamp: 100.5,
+    }
+    side, lead_move, execution_move, gap = _signal(coinbase, binance, timestamp)
+    assert side == 1
+    assert lead_move == 0.015
+    assert execution_move == 0.005
+    assert gap == 0.01
+
+
+def test_negative_coinbase_lead_emits_short():
+    timestamp = datetime(2024, 1, 1, 3, tzinfo=UTC)
+    coinbase = {
+        datetime(2024, 1, 1, 0, tzinfo=UTC): 100.0,
+        timestamp: 98.0,
+    }
+    binance = {
+        datetime(2024, 1, 1, 0, tzinfo=UTC): 100.0,
+        timestamp: 99.5,
+    }
+    side, *_ = _signal(coinbase, binance, timestamp)
+    assert side == -1
+
+
+def test_incomplete_cross_exchange_window_is_not_signal():
+    timestamp = datetime(2024, 1, 1, 3, tzinfo=UTC)
+    side = _signal(
+        {timestamp: 101.0},
+        {timestamp: 100.0},
+        timestamp,
+    )
+    assert side is None

--- a/tests/test_cross_exchange_lead_lag.py
+++ b/tests/test_cross_exchange_lead_lag.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from scripts.run_cross_exchange_lead_lag import _signal
 
 UTC = timezone.utc
@@ -17,9 +19,9 @@ def test_positive_coinbase_lead_emits_long():
     }
     side, lead_move, execution_move, gap = _signal(coinbase, binance, timestamp)
     assert side == 1
-    assert lead_move == 0.015
-    assert execution_move == 0.005
-    assert gap == 0.01
+    assert lead_move == pytest.approx(0.015)
+    assert execution_move == pytest.approx(0.005)
+    assert gap == pytest.approx(0.01)
 
 
 def test_negative_coinbase_lead_emits_short():

--- a/tests/test_cross_exchange_volume_shock.py
+++ b/tests/test_cross_exchange_volume_shock.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.run_cross_exchange_volume_shock import _signal
+
+UTC = timezone.utc
+
+
+def _series():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    data = {}
+    for offset in range(-2, 721):
+        timestamp = start + timedelta(hours=offset)
+        data[timestamp] = {"close": 100.0, "volume": 10.0}
+    signal_timestamp = start + timedelta(hours=720)
+    for offset in range(3):
+        timestamp = signal_timestamp - timedelta(hours=2 - offset)
+        data[timestamp] = {"close": 100.0 + offset * 0.6, "volume": 30.0}
+    return data, signal_timestamp
+
+
+def test_volume_shock_emits_long():
+    data, timestamp = _series()
+    side, move, current_volume, baseline = _signal(data, timestamp)
+    assert side == 1
+    assert move == pytest.approx(0.012)
+    assert current_volume == pytest.approx(90.0)
+    assert baseline == pytest.approx(30.0)
+
+
+def test_missing_hour_is_not_signal():
+    data, timestamp = _series()
+    data.pop(timestamp)
+    assert _signal(data, timestamp) is None

--- a/tests/test_liquidation_flow_reversal.py
+++ b/tests/test_liquidation_flow_reversal.py
@@ -1,0 +1,53 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from scripts.execution_model import STRESS_EXECUTION
+from scripts.run_liquidation_flow_reversal import (
+    BASELINE_HOURS,
+    DOMINANCE_THRESHOLD,
+    EXTREME_MULTIPLIER,
+    _signal,
+    aggregate_hourly,
+)
+
+
+class LiquidationFlowReversalTests(unittest.TestCase):
+    def test_hourly_aggregation_preserves_sides_and_notional(self) -> None:
+        rows = [
+            {
+                "timestamp": datetime(2024, 1, 1, 0, 10, tzinfo=timezone.utc),
+                "side": "SELL",
+                "liquidation_usd": 100.0,
+            },
+            {
+                "timestamp": datetime(2024, 1, 1, 0, 50, tzinfo=timezone.utc),
+                "side": "BUY",
+                "liquidation_usd": 25.0,
+            },
+        ]
+        result = aggregate_hourly(rows)
+        bucket = result[datetime(2024, 1, 1, 0, tzinfo=timezone.utc)]
+        self.assertEqual(bucket["sell_usd"], 100.0)
+        self.assertEqual(bucket["buy_usd"], 25.0)
+        self.assertEqual(bucket["total_usd"], 125.0)
+
+    def test_signal_is_causal_and_reverses_forced_flow(self) -> None:
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        timestamps = [start + timedelta(hours=index) for index in range(BASELINE_HOURS + 2)]
+        flow = {
+            timestamp: {"buy_usd": 10.0, "sell_usd": 0.0, "total_usd": 10.0}
+            for timestamp in timestamps[:BASELINE_HOURS]
+        }
+        signal_timestamp = timestamps[BASELINE_HOURS]
+        flow[signal_timestamp] = {"buy_usd": 0.0, "sell_usd": 40.0, "total_usd": 40.0}
+        self.assertEqual(_signal(flow, timestamps, BASELINE_HOURS), 1)
+        self.assertEqual(_signal(flow, timestamps, BASELINE_HOURS + 1), 0)
+        self.assertEqual(EXTREME_MULTIPLIER, 3.0)
+        self.assertEqual(DOMINANCE_THRESHOLD, 0.60)
+
+    def test_shared_stress_execution_model_is_86_bps(self) -> None:
+        self.assertEqual(STRESS_EXECUTION.round_trip_bps, 86.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_liquidation_flow_reversal.py
+++ b/tests/test_liquidation_flow_reversal.py
@@ -42,6 +42,7 @@ class LiquidationFlowReversalTests(unittest.TestCase):
         flow[signal_timestamp] = {"buy_usd": 0.0, "sell_usd": 40.0, "total_usd": 40.0}
         self.assertEqual(_signal(flow, timestamps, BASELINE_HOURS), 1)
         self.assertEqual(_signal(flow, timestamps, BASELINE_HOURS + 1), 0)
+        self.assertEqual(_signal(flow, timestamps, BASELINE_HOURS, {signal_timestamp.date()}), 0)
         self.assertEqual(EXTREME_MULTIPLIER, 3.0)
         self.assertEqual(DOMINANCE_THRESHOLD, 0.60)
 


### PR DESCRIPTION
## Research-only frozen hypothesis

This draft follows the zero-trade cross-exchange price lead/lag screen with a separate volume-shock rule. It is not a threshold adjustment to the prior candidate.

### Frozen rule

- Coinbase Exchange BTC-USD and ETH-USD hourly candles provide the lead movement and volume.
- A signal requires a completed three-hour Coinbase move of at least 0.5% in either direction.
- The same three-hour Coinbase quote volume must be at least 2.0 times the median three-hour volume over the prior 720 completed hours.
- Positive shock -> long Binance; negative shock -> short Binance.
- Enter on the next completed Binance bar plus one latency bar.
- Hold eight hours with an eight-hour cooldown.
- Fixed $3,000 notional and shared 86-bps round-trip stress execution.
- Discovery: 2023-06-25 through 2024-02-24 UTC.
- Untouched confirmation: 2024-02-25 through 2024-10-14 UTC.
- Six chronological blocks per split; minimum 20 trades per block.
- No threshold grid, holdout tuning, overlapping-window proof, leverage, orders, risk changes, or promotion.

A positive discovery result advances only if the untouched holdout also clears every gate.